### PR TITLE
SAKIII-808 Create "/tags" folder under which any logged-in user can add new tag nodes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -27,6 +27,9 @@
         <property name="SRC_DIR_APPS" value="apps" description="Source folder for content under /apps that needs to be stored in JCR" />
         <property name="TARGET_DIR_APPS" value="${TARGET_RESOURCES}/apps" description="Target folder for content under /apps that needs to be stored in JCR" />
 
+        <property name="SRC_DIR_ROOT" value="root" description="Source folder for content under / that needs to be stored in JCR" />
+        <property name="TARGET_DIR_ROOT" value="${TARGET_RESOURCES}/root" description="Target folder for content under / that needs to be stored in JCR" />
+
         <!-- SETUP - Processed output file names -->
         <property name="TARGET_JAR_FILE" value="${TARGET_COMPRESSED_DIR}/sakai3-ux.jar" description="Target JAR file" />
         <property name="TARGET_ZIP_FILE" value="${TARGET_COMPRESSED_DIR}/sakai3-ux.zip" description="Target ZIP file" />
@@ -72,6 +75,7 @@
         <mkdir dir="${TARGET_DIR_W}"/>
         <mkdir dir="${TARGET_DIR_VAR}"/>
         <mkdir dir="${TARGET_DIR_APPS}"/>
+        <mkdir dir="${TARGET_DIR_ROOT}"/>
         <mkdir dir="${TARGET_COMPRESSED_DIR}"/>
         <mkdir dir="${TARGET_DOCUMENTATION_DIR}"/>
         <mkdir dir="${TARGET_REPORTS_DIR}"/>
@@ -102,6 +106,11 @@
         <echo message="Making a copy of apps content files..." />
         <copy todir="${TARGET_DIR_APPS}">
             <fileset dir="${SRC_DIR_APPS}" />
+        </copy>
+
+        <echo message="Making a copy of root content files..." />
+        <copy todir="${TARGET_DIR_ROOT}">
+            <fileset dir="${SRC_DIR_ROOT}" />
         </copy>
 
     </target>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,8 @@
                 SLING-INF/content/dev;path:=/dev;ignoreImportProviders:="xml,json,html,jar,zip";overwrite:=true,
                 SLING-INF/content/devwidgets;path:=/devwidgets;ignoreImportProviders:="xml,json,html,jar,zip";overwrite:=true,
                 SLING-INF/content/var;path:=/var,
-                SLING-INF/content/apps;path:=/apps;overwrite:=true
+                SLING-INF/content/apps;path:=/apps;overwrite:=true,
+                SLING-INF/content/root;path:=/
             </Sling-Initial-Content>
           </instructions>
         </configuration>

--- a/root/tags.json
+++ b/root/tags.json
@@ -1,0 +1,20 @@
+{
+  "jcr:primaryType":"sling:Folder",
+  "sakai:description":"Holder for shared tags",
+  "security:acl" : [
+    {
+      "principal" : "everyone",
+      "granted" : [
+        "jcr:addChildNodes",
+        "jcr:modifyProperties"
+      ]
+    },
+    {
+      "principal" : "anonymous",
+      "denied" : [
+        "jcr:addChildNodes",
+        "jcr:modifyProperties"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This adds a new content-loading folder to 3akai-ux, "root" (to put things at the root folder).

(By the way, the build procedure could get simplified a bit by relocating "var" and "apps" there too. Let me know if you're interested.)
