### PR TITLE
SAKIII-2512

### DIFF
--- a/devwidgets/sharecontent/javascript/sharecontent.js
+++ b/devwidgets/sharecontent/javascript/sharecontent.js
@@ -472,7 +472,7 @@ require(["jquery", "sakai/sakai.api.core", "/dev/javascript/content_profile.js"]
                 sharecontentEditPermissionsLink.toggle();
             });
 
-            $(sharecontentEditPermissionsLink + " a").live("click", function(){
+            $(sharecontentEditPermissionsLink + " button").live("click", function(){
                 $(sharecontentEditPermissionsLink).toggle();
                 var changeTo;
                 if (sharecontentSelectedSharer !== "") {


### PR DESCRIPTION
Requesting pull for https://jira.sakaiproject.org/browse/SAKIII-2512 -- Changing the permissions for a user in the share content dialog does not work.  This was a simple fix of changing the event handler to use the new button tag instead of anchor tag.

Thanks,
Gaurav
