### PR TITLE
fix for duplicate messages in Sent

### DIFF
--- a/dev/lib/sakai/sakai.api.communication.js
+++ b/dev/lib/sakai/sakai.api.communication.js
@@ -82,7 +82,7 @@ define(["jquery", "sakai/sakai.api.user", "/dev/configuration/config.js"], funct
                 var toSend = {
                     "sakai:type": "smtp",
                     "sakai:sendstate": "pending",
-                    "sakai:messagebox": "outbox",
+                    "sakai:messagebox": "pending",
                     "sakai:to": toUsers,
                     "sakai:from": meData.user.userid,
                     "sakai:subject": subject,


### PR DESCRIPTION
Changed sakai:messagebox to 'pending' for email, which prevents them being added to the outbox, which means they don't show up twice.
