### PR TITLE
SAKIII-2831 Removed defaulting wildcard search from search api.

### DIFF
--- a/dev/lib/sakai/sakai.api.server.js
+++ b/dev/lib/sakai/sakai.api.server.js
@@ -571,7 +571,7 @@ define(["jquery", "/dev/configuration/config.js"], function($, sakai_conf) {
             if (advancedSearchRegex.test(searchString)) {
                 ret = searchString;
             } else {
-                ret = $.trim(searchString).split(" ").join("* AND ") + "*";
+                ret = $.trim(searchString).split(" ").join(" AND ");
             }
 
             return ret;


### PR DESCRIPTION
This is in response to the various backend changes that have been done to bolster searching without using wildcards.
