### PR TITLE
SAKIII-2963 stopped error from jcarousel by toggling start/stopAuto

### DIFF
--- a/devwidgets/lhnavigation/javascript/lhnavigation.js
+++ b/devwidgets/lhnavigation/javascript/lhnavigation.js
@@ -336,6 +336,10 @@ require(["jquery", "sakai/sakai.api.core", "jquery-ui"], function($, sakai) {
         var selectPage = function(newPageMode){
             var state = $.bbq.getState("l");
             var selected = state || false;
+            var jcarousel = $('#carousel_container');
+            if(jcarousel.data('jcarousel')){
+                jcarousel.data('jcarousel')[(state==="dashboard"?"start":"stop") + "Auto"]();
+            }
             // If no page is selected, select the first one from the nav
             if (!selected){
                 selected = getFirstSelectablePage(privstructure) || getFirstSelectablePage(pubstructure);


### PR DESCRIPTION
JIRA https://jira.sakaiproject.org/browse/SAKIII-2963

Toggle stopAuto/startAuto on jcarousel when changing left hand navigation to stop errors when carousel is set to display none.
