### PR TITLE
SAKIII-2992 Added workaround event for IE8 to use enter on form fields fo

### DIFF
--- a/devwidgets/topnavigation/javascript/topnavigation.js
+++ b/devwidgets/topnavigation/javascript/topnavigation.js
@@ -526,7 +526,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
             // Make up for IE8 to submit login on Enter
             // http://www.thefutureoftheweb.com/blog/submit-a-form-in-ie-with-enter
             $(topnavUserOptionsLoginForm + " input").keydown(function(e){
-                if (e.keyCode == 13) {
+                if (e.keyCode === 13) {
                     $(this).parents('form').submit();
                     return false;
                 }


### PR DESCRIPTION
SAKIII-2992 Added workaround event for IE8 to use enter on form fields for forms that aren't available during page load for IE8 to scan. Tested on FF4/Linux Chrome/Linux IE8/Win7 Safari/OSX

https://jira.sakaiproject.org/browse/SAKIII-2992
