### PR TITLE
Added redeploy profile for redeploying build artifact to running server.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,26 @@
         <dev.content></dev.content>
       </properties>
     </profile>
+    <profile>
+      <id>redeploy</id>
+      <build>
+       <plugins>
+         <plugin>
+          <groupId>org.apache.sling</groupId>
+          <artifactId>maven-sling-plugin</artifactId>
+          <version>2.0.5-SNAPSHOT</version>
+          <executions>
+            <execution>
+              <id>install-bundle</id>
+              <goals>
+                <goal>install</goal>
+              </goals>
+            </execution>
+          </executions>
+         </plugin>
+       </plugins>
+      </build>
+    </profile>
   </profiles>
   <build>
     <resources>


### PR DESCRIPTION
This is in the nakamura pom. It's useful for testing bundles and bundling in the server when not working with fsresource directly.
