### PR TITLE
KERN-1913 Querystring doesn't seem to handle UTF-8 characters

### DIFF
--- a/dev/lib/misc/querystring.js
+++ b/dev/lib/misc/querystring.js
@@ -18,7 +18,7 @@ function Querystring(qs) { // optionally pass a querystring to parse
 	
 // split out each name=value pair
 	for (var i = 0; i < args.length; i++) {
-		var pair = unescape(args[i].split('=')).split(",");
+		var pair = args[i].split('=');
 		var name = decodeURIComponent(pair[0]);
 		
 		var value = (pair.length==2)


### PR DESCRIPTION
KERN-1913 Querystring doesn't seem to handle UTF-8 characters. This fixes that. I'm also not sure why this unesacape+split(",") were in here in the first place.
