### PR TITLE
Sakiii 3148

### DIFF
--- a/devwidgets/addpeople/javascript/addpeople.js
+++ b/devwidgets/addpeople/javascript/addpeople.js
@@ -292,17 +292,17 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
          */
         var resetAutosuggest = function(h){
             sakai.api.Util.AutoSuggest.reset($addpeopleMembersAutoSuggestField);
-            h.w.hide();
-            if (h.o) {
-                h.o.remove();
-            }
             for(user in selectedUsers){
                 if(selectedUsers.hasOwnProperty(user) && selectedUsers[user].tmpsrc){
                     delete selectedUsers[user];
                 }
             }
             $("ul",$addpeopleSelectedContactsContainer).empty();
-            $(addpeopleCheckbox).add($addpeopleSelectAllContacts).removeAttr("checked");            
+            $(addpeopleCheckbox).add($addpeopleSelectAllContacts).removeAttr("checked");                 
+            h.w.hide();
+            if (h.o) {
+                h.o.remove();
+            }
         }
 
         var prepareSelectedContacts = function(success, data){


### PR DESCRIPTION
JIRA https://jira.sakaiproject.org/browse/SAKIII-3148
Modified addpeople to reset user list when canceling/closing modal by removing users/groups added via autosuggest and lefthand checklist. Also removes checked attribute on left chacklist items that were checked (including "All" checkbox).
