### PR TITLE
Sakiii 3185 Add area animation doesn't work in Chrome

### DIFF
--- a/devwidgets/addarea/javascript/addarea.js
+++ b/devwidgets/addarea/javascript/addarea.js
@@ -107,7 +107,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai){
                 $("#addarea_action_buttons").show();
                 $("#addarea_create_new_area").attr("disabled", true);
                 
-                 $addareaContentsContainerForm.css({"width":"1px","display":"block"}).animate({
+                $addareaContentsContainerForm.css({"width":"1px","display":"block"}).animate({
                     width: width
                 }, 300, "linear");
             }


### PR DESCRIPTION
JIRA https://jira.sakaiproject.org/browse/SAKIII-3185
Could not find a CSS solution, Chrome fails to calculate correctly when the elemnt's hidden.  Modified animate on form container, set width to 1px and display block, removed toggle and changed animation timing to match. Change single quotes on original to double for consistency
