### PR TITLE
SAKIII-3821 Replacing \n with <br/> on the content metadata

### DIFF
--- a/devwidgets/contentmetadata/contentmetadata.html
+++ b/devwidgets/contentmetadata/contentmetadata.html
@@ -30,10 +30,10 @@
 </div>
 
 <div id="contentmetadata_description_template" style="display:none;"><!--
-    {if data.mode === "edit"}
-        <textarea id="contentmetadata_description_description" class="contentmetadata_edit_input">${data.data["sakai:description"]}</textarea>
+    {if mode === "edit"}
+        <textarea id="contentmetadata_description_description" class="contentmetadata_edit_input">${description}</textarea>
     {else}
-        <span id="contentmetadata_description_display" class="contentmetadata_click">{if $.trim(data.data["sakai:description"]) != ""}${sakai.api.Security.escapeHTML(data.data["sakai:description"])}{else}{if data.isManager}<span class="contentmetadata_manager_edit">__MSG__CLICK_TO_EDIT_DESCRIPTION__</span>{else}__MSG__NO_DESCRIPTION__{/if}{/if}</span>
+        <span id="contentmetadata_description_display" class="contentmetadata_click">{if $.trim(description) != ""}${sakai.api.Security.saneHTML(description)}{else}{if data.isManager}<span class="contentmetadata_manager_edit">__MSG__CLICK_TO_EDIT_DESCRIPTION__</span>{else}__MSG__NO_DESCRIPTION__{/if}{/if}</span>
     {/if}
 --></div>
 

--- a/devwidgets/contentmetadata/javascript/contentmetadata.js
+++ b/devwidgets/contentmetadata/javascript/contentmetadata.js
@@ -106,9 +106,13 @@ require(["jquery", "sakai/sakai.api.core", "/dev/javascript/content_profile.js"]
          * @param {String|Boolean} mode Can be false or 'edit' depending on the mode you want to be in
          */
         var renderDescription = function(mode){
-            sakai_global.content_profile.content_data.mode = mode;
+            var description = sakai_global.content_profile.content_data.data["sakai:description"];
+            if (mode !== "edit") {
+                description = description.replace(new RegExp("\n", "g"),"<br/>");
+            }
             var json = {
-                data: sakai_global.content_profile.content_data,
+                description: description,
+                mode: mode,
                 sakai: sakai
             };
             $contentmetadataDescriptionContainer.html(sakai.api.Util.TemplateRenderer(contentmetadataDescriptionTemplate, json));


### PR DESCRIPTION
Replacing \n with <br/> on the content metadata. Simplified the template.

https://jira.sakaiproject.org/browse/SAKIII-3281
