### PR TITLE
SAKIII-3277 Adding page session=false, which keeps extra JSESSIONID sessi

### DIFF
--- a/apps/sling/servlet/errorhandler/403.jsp
+++ b/apps/sling/servlet/errorhandler/403.jsp
@@ -1,3 +1,4 @@
+<%@ page session="false" %>
 <%
 response.setStatus(403);
 %><!DOCTYPE HTML>

--- a/apps/sling/servlet/errorhandler/404.jsp
+++ b/apps/sling/servlet/errorhandler/404.jsp
@@ -1,3 +1,4 @@
+<%@ page session="false" %>
 <%
 response.setStatus(404);
 %><!DOCTYPE HTML>


### PR DESCRIPTION
SAKIII-3277 Adding page session=false, which keeps extra JSESSIONID session cookies from appearing (which OAE doesn't use, but Hybrid mode does)

https://jira.sakaiproject.org/browse/SAKIII-3277
