### PR TITLE
SAKIII-3201 Handle items saved to library from carousel

### DIFF
--- a/dev/javascript/user.js
+++ b/dev/javascript/user.js
@@ -194,7 +194,6 @@ require(["jquery","sakai/sakai.api.core"], function($, sakai) {
             }
             if (pageid === "library") {
                 pubdata.structure0[pageid]._count += newContent;
-                newContent = 0;
             }
         };
 
@@ -339,7 +338,7 @@ require(["jquery","sakai/sakai.api.core"], function($, sakai) {
 
         $(window).bind("done.newaddcontent.sakai", function(e, data, library) {
             if (data && data.length && library === sakai.data.me.user.userid) {
-                newContent = data.length;
+                newContent += data.length;
                 generateNav();
             }
         });

--- a/devwidgets/mycontent/javascript/mycontent.js
+++ b/devwidgets/mycontent/javascript/mycontent.js
@@ -119,7 +119,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
          */
         var handleContentData = function(success, data) {
             if(success) {
-                data = sakai_global.newaddcontent.getNewList(data, null, 0, 5);
+                data = sakai.api.Content.getNewList(data, null, 0, 5);
                 // parse & render data
                 // build array of up to five items; reverse chronological order
                 var contentjson = {

--- a/devwidgets/mylibrary/javascript/mylibrary.js
+++ b/devwidgets/mylibrary/javascript/mylibrary.js
@@ -389,7 +389,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                     if (!isOnPersonalDashboard()) {
                         library = mylibrary.contextId;
                     }
-                    data = sakai_global.newaddcontent.getNewList(data, library, mylibrary.currentPagenum - 1, mylibrary.itemsPerPage);
+                    data = sakai.api.Content.getNewList(data, library, mylibrary.currentPagenum - 1, mylibrary.itemsPerPage);
                 }
                 handleLibraryItems(success, data);
             };

--- a/devwidgets/newaddcontent/javascript/newaddcontent.js
+++ b/devwidgets/newaddcontent/javascript/newaddcontent.js
@@ -149,38 +149,16 @@ require(["jquery", "/dev/configuration/sakaidoc.js", "sakai/sakai.api.core"], fu
         // Get newly uploaded content //
         ////////////////////////////////
 
-        sakai_global.newaddcontent.getNewList = function(_data, library, offset, max) {
-            var data = $.extend({}, _data),
-                newAdditions = 0,
-                newContentLibrary = [];
+        sakai_global.newaddcontent.getNewContent = function(library) {
+            var newContentLibrary = [];
             // grab all of the newly uploaded content, regardless of target library
             if (!library) {
                 newContentLibrary = allNewContent;
             } else {
                 newContentLibrary = brandNewContent[library];
             }
-            if (newContentLibrary && newContentLibrary.length) {
-                var newContent = $.merge([], newContentLibrary);
-                // only use the amount from the current page number
-                newContent = _.rest(newContent, offset * max);
-                $.each(newContent, function(i, elt) {
-                    var exists = false;
-                    $.each(data.results, function(j, result) {
-                        if (result._path === elt._path) {
-                            exists = true;
-                        }
-                    });
-                    if (!exists) {
-                        // put the element as the first result
-                        data.results = $.merge([elt], data.results);
-                        // modify the results to be the proper length
-                        data.results = _.first(data.results, max);
-                        newAdditions++;
-                    }
-                });
-            }
-            data.total += newAdditions;
-            return data;
+            // return a copy
+            return $.merge([], newContentLibrary);
         };
 
         var deleteContent = function(e, obj) {

--- a/devwidgets/recentchangedcontent/javascript/recentchangedcontent.js
+++ b/devwidgets/recentchangedcontent/javascript/recentchangedcontent.js
@@ -345,7 +345,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                     sortOrder: "desc"
                 },
                 success: function(data){
-                    data = sakai_global.newaddcontent.getNewList(data, null, 0, 1);
+                    data = sakai.api.Content.getNewList(data, null, 0, 1);
                     handleRecentChangedContentData(true, data);
                 },
                 error: function(data){


### PR DESCRIPTION
Add items saved to library from carousel to the lhnav count and the user's library, just as they do when they're uploaded.

Needed a new API function for this, which was just the function from newaddcontent modified to pull from a couple places.

https://jira.sakaiproject.org/browse/SAKIII-3201
