### PR TITLE
SAKIII-3385 Allow for world configuration to only have one option.

### DIFF
--- a/devwidgets/lhnavigation/lhnavigation.html
+++ b/devwidgets/lhnavigation/lhnavigation.html
@@ -55,7 +55,7 @@
     </ul>
     <ul id="lhnavigation_public_pages" class="lhnavigation_menu_list" data-sakai-space="public">
         {for level in public.orderedItems}
-            {if level._childCount > 1}
+            {if level._childCount > 1 || !level._poolpath}
                 <li class="lhnavigation_menuitem lhnavigation_hoverable_item lhnavigation_hassubnav lhnavigation_outer" data-sakai-addcontextoption="${contextData.addArea}" data-sakai-savepath="${contextData.puburl}" data-sakai-pagesavepath="${level._poolpath}" data-sakai-ref="${level._ref}" data-sakai-path="${level._id}" data-sakai-noneditable="${level._nonEditable}" data-sakai-reorder-only="${level._reorderOnly}" data-sakai-manage="${level._canEdit}" data-sakai-submanage="${level._canSubedit}" {if level.canView === false} style="display:none;" {/if}>
                     <div class="lhnavigation_item_content">
                         <div class="lhnavigation_has_subnav"></div>


### PR DESCRIPTION
This should be the only place where _poolpath is undefined in lhnavigation.

I'd normally just push this small of a fix in, but lhnavigation is pretty core so I'd like to have another set of eyes and tests on this one. Please check in all the places that lhnavigation is used to make sure this works and doesn't cause any single-page lhnavigation items to have an arrow, except in the world creation space.

http://jira.sakaiproject.org/browse/SAKIII-3385
