### PR TITLE
SAKIII-3502 The logout logic depends on using the customized configuratio

### DIFF
--- a/dev/lib/sakai/sakai.api.user.js
+++ b/dev/lib/sakai/sakai.api.user.js
@@ -39,7 +39,7 @@ define(
         "sakai/sakai.api.l10n",
         "sakai/sakai.api.i18n",
         "sakai/sakai.api.util",
-        "config/config"
+        "config/config_custom"
     ],
     function($, sakai_serv, sakai_l10n, sakai_i18n, sakai_util, sakai_conf) {
 


### PR DESCRIPTION
SAKIII-3502 The logout logic depends on using the customized configuration rather than the default configuration. See SAKIII-2392 for background.
