### PR TITLE
SAKIII-3480 Fixing jsTree paths to the theme, as the path is relative in 

### DIFF
--- a/devwidgets/assignlocation/javascript/assignlocation.js
+++ b/devwidgets/assignlocation/javascript/assignlocation.js
@@ -241,7 +241,8 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                 },
                 "themes": {
                     "dots": false,
-                    "icons": false
+                    "icons": false,
+                    "url": "/dev/lib/jquery/plugins/jsTree/themes/default/style.css"
                 },
                 "search" : {
                     "case_insensitive" : true

--- a/devwidgets/navigation/javascript/navigation.js
+++ b/devwidgets/navigation/javascript/navigation.js
@@ -647,7 +647,8 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                 },
                 "themes": {
                     "dots": false,
-                    "icons": true
+                    "icons": true,
+                    "url": "/dev/lib/jquery/plugins/jsTree/themes/default/style.css"
                 },
                 "ui": {
                     "select_limit": 1,


### PR DESCRIPTION
Fixing jsTree paths to the theme, as the path is relative in jsTree and that breaks during a release build

https://jira.sakaiproject.org/browse/SAKIII-3480
