### PR TITLE
SAKIII-3449 Don't generate IDs twice

### DIFF
--- a/dev/javascript/user.js
+++ b/dev/javascript/user.js
@@ -87,9 +87,8 @@ require(["jquery","sakai/sakai.api.core"], function($, sakai) {
             sakai.api.Server.loadJSON(puburl, function(success, data){
                 if (!success){
                     pubdata = $.extend(true, {}, sakai.config.defaultpubstructure);
-                    publicToStore = $.extend(true, {}, sakai.config.defaultpubstructure);
                     setupProfile(pubdata);
-                    setupProfile(publicToStore);
+                    publicToStore = $.extend(true, {}, pubdata);
                 } else {
                     pubdata = data;
                     pubdata = sakai.api.Server.cleanUpSakaiDocObject(pubdata);


### PR DESCRIPTION
By setting up the profile twice we were generating IDs twice, one to save and one to use. This fix should only generate the IDs once and make what we save the first time be exactly what we use, preventing this issue from happening.

https://jira.sakaiproject.org/browse/SAKIII-3449
