### PR TITLE
SAKIII-3508 If the participant type in the list is group-id then we now p

### DIFF
--- a/devwidgets/participants/javascript/participants.js
+++ b/devwidgets/participants/javascript/participants.js
@@ -122,7 +122,8 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                                     "content": contentCount,
                                     "contacts": contactsCount,
                                     "memberships": membershipsCount,
-                                    "profilePicture": sakai.api.Groups.getProfilePicture(data[role].results[i])
+                                    "profilePicture": sakai.api.Groups.getProfilePicture(data[role].results[i]),
+                                    "membersCount": data[role].results[i].counts.membersCount
                                 });
                             } else {
                                 // Check if this user is a friend of us already.

--- a/devwidgets/participants/participants.html
+++ b/devwidgets/participants/participants.html
@@ -59,7 +59,7 @@
                 </a>
             {else}
                 <a href="/~${participant.id}#l=participants" class="s3d-regular-light-links participants_list_participant_details">
-                    ${participant.memberships} {if participant.memberships == 1} __MSG__PARTICIPANT__{else} __MSG__PARTICIPANTS__{/if}
+                    ${participant.membersCount} {if participant.membersCount == 1} __MSG__PARTICIPANT__{else} __MSG__PARTICIPANTS__{/if}
                 </a>
             {/if}
         </li>


### PR DESCRIPTION
SAKIII-3508 If the participant type in the list is group-id then we now push on the membersCount into the template context, and use that for the branch that renders the Group metadata. Previously we were using the Groups number of memberships in other groups, not the actual number of partipants in itself.

https://jira.sakaiproject.org/browse/SAKIII-3508
