### PR TITLE
SAKIII-2823 Fixing a long, what we thought was an intermittent issue, but

### DIFF
--- a/dev/s23/javascript/s23_site.js
+++ b/dev/s23/javascript/s23_site.js
@@ -196,7 +196,8 @@ sakai_global.s23_site = function(){
                 var otherframes = [];
                 for (var tool = 0; tool < page.tools.length; tool++){
                     // Some special Sakai 2 Sites start with ~ or !
-                    var iframe = $("#Main" + page.tools[tool].xid.replace(/([~!])/g,'\\$1')); 
+                    var siteSelector = "#Main" + page.tools[tool].xid.replace(/([~!])/g,'\\$1');
+                    var iframe = $(siteSelector); 
                     var srcUrl = sakai.config.SakaiDomain + "/portal/tool/" + page.tools[tool].url + "?panel=Main";                     
                     if(isSameOriginPolicy(window.location.href, srcUrl)) {
                         iframe.load(loadIframe);


### PR DESCRIPTION
SAKIII-2823 Fixing a long, what we thought was an intermittent issue, but really has to do with special Sakai 2 sites that start with ! or ~ that cant be used in jQuery selectors unless youre actually using them for the matching syntax they are a part of

https://jira.sakaiproject.org/browse/SAKIII-2823
