### PR TITLE
SAKIII-3708 Fixing authprofile paths - always should be using profile.json

### DIFF
--- a/dev/lib/sakai/sakai.api.communication.js
+++ b/dev/lib/sakai/sakai.api.communication.js
@@ -236,7 +236,7 @@ define(
             if (typeof(to) === "object") {
                 for (i = 0; i < to.length; i++) {
                     reqs[reqs.length] = {
-                        "url": "/~" + to[i] + "/public/authprofile.json",
+                        "url": "/~" + to[i] + "/public/authprofile.profile.json",
                         "method": "GET"
                     };
                 }

--- a/dev/lib/sakai/sakai.api.user.js
+++ b/dev/lib/sakai/sakai.api.user.js
@@ -755,7 +755,7 @@ define(
 
         getUpdatedCounts : function(medata, callback) {
             $.ajax({
-                url: medata.profile.homePath + "/public/authprofile.json",
+                url: medata.profile.homePath + "/public/authprofile.profile.json",
                 success: function(profile){
                     medata.profile.counts = profile.counts;
                     if ($.isFunction(callback)){

--- a/devwidgets/joingroup/javascript/joingroup.js
+++ b/devwidgets/joingroup/javascript/joingroup.js
@@ -71,7 +71,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
          * @param {Integer} value Value to adjust the number of participants by
          */
         var adjustParticipantCount = function (groupid, value) {
-            var participantCount = parseInt($("#searchgroups_result_participant_count_" + groupid).text());
+            var participantCount = parseInt($("#searchgroups_result_participant_count_" + groupid).text(), 10);
             participantCount = participantCount + value;
             $("#searchgroups_result_participant_count_" + groupid).text(participantCount);
             if (participantCount === 1) {
@@ -97,8 +97,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                 picsrc = sakai.api.Groups.getProfilePicture(member);
                 link = "~" + member.groupid;
                 displayname = member["sakai:group-title"];
-            }
-            else {
+            } else {
                 picsrc = sakai.api.User.getProfilePicture(member);
                 link = "~" + member.userid;
                 displayname = sakai.api.User.getDisplayName(member);
@@ -269,7 +268,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                             }
                             openTooltip(groupid, $(target), leaveAllowed);
                         }
-                    })
+                    });
                 }, "everyone");
                 return false;
             });


### PR DESCRIPTION
Fixing authprofile paths - always should be using authprofile.profile.json no matter what. This fixes cases where profile pics weren't being saved properly

https://jira.sakaiproject.org/browse/SAKIII-3708
