### PR TITLE
SAKIII-3711 Force value to string before splitting in case it's a number

### DIFF
--- a/devwidgets/newaddcontent/javascript/newaddcontent.js
+++ b/devwidgets/newaddcontent/javascript/newaddcontent.js
@@ -340,11 +340,11 @@ require(["jquery", "config/sakaidoc", "sakai/sakai.api.core"], function($, sakai
                         if (!$(item).is(":disabled")) {
                             var viewers = [];
                             if ($(item).data("sakai-pooled-content-viewer")){
-                                viewers = $(item).data("sakai-pooled-content-viewer").split(",");
+                                viewers = ("" + $(item).data("sakai-pooled-content-viewer")).split(",");
                             }
                             var managers = [];
                             if ($(item).data("sakai-pooled-content-manager")){
-                                managers = $(item).data("sakai-pooled-content-manager").split(",");
+                                managers = ("" + $(item).data("sakai-pooled-content-manager")).split(",");
                             }
                             var contentObj = {
                                 "title": $(item).next().text(),


### PR DESCRIPTION
At Berkeley user IDs are numeric, so the split call caused an error when there's a single user manager or viewer of an item. 
