### PR TITLE
SAKIII-3684 Changing positioning from absolute to relative for #topnaviga

### DIFF
--- a/devwidgets/topnavigation/css/topnavigation.css
+++ b/devwidgets/topnavigation/css/topnavigation.css
@@ -59,7 +59,7 @@
 .topnavigation_user_container #topnavigation_user_inbox_container {float:left;}
 .topnavigation_user_container #topnavigation_user_inbox_icon {background: url("/devwidgets/topnavigation/images/topnav_user_inbox.png") no-repeat scroll left top transparent;display: inline;float: left;height: 15px;margin: 2px 7px 0 0;width: 15px;}
 
-#topnavigation_user_options_login_fields {border-radius:5px 0 5px 5px;-moz-border-radius:5px 0 5px 5px;-webkit-border-radius:5px 0 5px 5px;margin-left: -150px;margin-top:0;position: absolute;width: 241px;z-index: 11000;}
+#topnavigation_user_options_login_fields {border-radius:5px 0 5px 5px;-moz-border-radius:5px 0 5px 5px;-webkit-border-radius:5px 0 5px 5px;margin-left: -150px;margin-top:0;position: relative;width: 241px;z-index: 11000;}
 #topnavigation_user_options_login_fields_container.s3d-dropdown-menu-content-container {padding:0 12px;}
 #topnavigation_user_options_login_fields_bottom_container {background-color: #F3F3F3; height: 28px; padding:0px 3px 0 12px;}
 #topnavigation_user_options_login_fields #topnavigation_user_options_login_form label{color: #424242;display: inline-block;margin-bottom: 5px;margin-top: 7px;font-size: 11px;}


### PR DESCRIPTION
SAKIII-3684 Changing positioning from absolute to relative for #topnavigation_user_options_login_fields, due to being unable to get all 4 browsers to line up the dropdown the same. (Actually firefox was different from all the others by a few pixels. This lines everything up on FF/IE/CHR/SAF, with the minor drawback that the Search Window moves about 2 pixels when you bring up the hover, which is not super noticable unless you go back and forth over the hover really fast. This may or may not be an acceptable tradeoff.

https://jira.sakaiproject.org/browse/SAKIII-3684
