### PR TITLE
SAKIII-3690 This issue is largely being caused by too many things being s

### DIFF
--- a/devwidgets/addarea/css/addarea.css
+++ b/devwidgets/addarea/css/addarea.css
@@ -46,7 +46,7 @@
 .addarea_widget #addarea_contents_container #addarea_contents_container_form #addarea_sakaidoc_existingdocscontainer li {list-style:none;padding:8px 12px;clear:both;color:#424242;cursor:pointer;}
 .addarea_widget #addarea_contents_container #addarea_contents_container_form #addarea_sakaidoc_existingdocs #addarea_sakaidoc_search {padding:5px 0 8px 12px;border-bottom:1px solid #CCC;}
 .addarea_widget #addarea_contents_container #addarea_contents_container_form #addarea_sakaidoc_existingdocs #addarea_sakaidoc_search_clear {font-size:11px;margin-top:3px;}
-.addarea_widget #addarea_contents_container #addarea_contents_container_form #addarea_sakaidoc_existingdocs input#addarea_sakaidoc_searchfield {width:200px;}
+.addarea_widget #addarea_contents_container #addarea_contents_container_form #addarea_sakaidoc_existingdocs input#addarea_sakaidoc_searchfield {width:150px;}
 .addarea_widget #addarea_contents_container #addarea_contents_container_form #addarea_sakaidoc_existingdocs #addarea_sakaidoc_existingdocs_sort {float:right;}
 .addarea_widget #addarea_contents_container #addarea_contents_container_form #addarea_sakaidoc_existingdocs .s3d-icon-16 {display:block;float:left;margin-right:5px;}
 .addarea_widget #addarea_contents_container #addarea_contents_container_form #addarea_sakaidoc_existingdocs #addarea_sakaidoc_search label {color:#424242;font-size:12px;margin:3px 7px 0 0;clear:none;}


### PR DESCRIPTION
SAKIII-3690 This issue is largely being caused by too many things being squished on the line, and so at certain font sizes/zoomlevels, the Clear label is droppping down when it hits the floated right Combo box. To balance this, I am dropping the Search box down to 150px from 200px, which still seems large enough (and about the same size as the one on the top navigation), and keeps everything on the same line unless you zoom the browser font really really small.

https://jira.sakaiproject.org/browse/SAKIII-3690
