### PR TITLE
SAKIII-3879 - Link to inbox in emailed messages is incorrect, results in 

### DIFF
--- a/dev/configuration/config.js
+++ b/dev/configuration/config.js
@@ -26,7 +26,7 @@ define(function(){
             GROUP_DEFAULT_ICON_URL: "/dev/images/group_avatar_icon_64x64_nob.png",
             I10N_BUNDLE_URL: "/dev/lib/misc/l10n/cultures/globalize.culture.__CODE__.js",
             I18N_BUNDLE_ROOT: "/dev/bundle/",
-            INBOX_URL: "/me#l=messages",
+            INBOX_URL: "/me#l=messages/inbox",
             LOGOUT_URL: "/logout",
             MY_DASHBOARD_URL: "/me#l=dashboard",
             PROFILE_EDIT_URL: "/profile/edit",


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAKIII-3879
