### PR TITLE
SAKIII-3926 More XSS Fixes

### DIFF
--- a/devwidgets/categories/categories.html
+++ b/devwidgets/categories/categories.html
@@ -42,7 +42,7 @@
                                 <hr class="s3d-split-line fl-push">
                                 {var thumbnail = sakai.api.Content.getThumbnail(item.content)}
                                 {if thumbnail}
-                                    <img src="${thumbnail}" class="categories_item_content_preview" alt="${item.content["sakai:pooled-content-file-name"]}"/>
+                                    <img src="${thumbnail}" class="categories_item_content_preview" alt="${item.content["sakai:pooled-content-file-name"]|safeOutput}"/>
                                 {else}
                                     <img src="${sakai.api.Content.getMimeTypeData(sakai.api.Content.getMimeType(item.content)).URL}" class="categories_item_content_preview"/>
                                 {/if}
@@ -59,7 +59,7 @@
                                     <span class="categories_content_tags">
                                         {for tag in tags}
                                             {if tag_index < 2}
-                                                <a href="/search#q=${tag}" class="s3d-action">${tag}</a>{if tag_index < tags.length-1 && tag_index < 1}, {/if}
+                                                <a href="/search#q=${tag|safeURL}" class="s3d-action">${tag|safeOutput}</a>{if tag_index < tags.length-1 && tag_index < 1}, {/if}
                                             {/if}
                                         {/for}
                                     </span>

--- a/devwidgets/mylibrary/javascript/mylibrary.js
+++ b/devwidgets/mylibrary/javascript/mylibrary.js
@@ -274,7 +274,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                 $.each(sakai.api.Util.formatTagsExcludeLocation(tags), function (i, name) {
                     formatted_tags.push({
                         name: name,
-                        link: "search#q=" + name
+                        link: "search#q=" + sakai.api.Util.safeURL(name)
                     });
                 });
                 return formatted_tags;

--- a/devwidgets/newaddcontent/javascript/newaddcontent.js
+++ b/devwidgets/newaddcontent/javascript/newaddcontent.js
@@ -618,6 +618,7 @@ require(["jquery", "config/sakaidoc", "sakai/sakai.api.core"], function($, sakai
                             });
                             $.each(lastUpload, function(i, item) {
                                 if (item._path === savedItem.hashpath) {
+                                    item["sakai:pooled-content-file-name"] = proofTitle(arrayItem.title);
                                     item["sakai:description"] = arrayItem.description;
                                     item["sakai:tags"] = arrayItem.tags;
                                 }

--- a/devwidgets/recentchangedcontent/recentchangedcontent.html
+++ b/devwidgets/recentchangedcontent/recentchangedcontent.html
@@ -99,7 +99,7 @@
 
     <div id="recentchangedcontent_item_comment_author_template"><!--
         <a class="recentchangedcontent_item_link s3d-widget-links s3d-bold" href="/~${author.authorId}" title="${author.authorName|safeOutput}">
-            ${author.authorName|safeOutput}
+            ${author.authorName}
         </a>
         {if commentCreated}
             <span class="recentchangedcontent_timeago"> (${sakai.api.Datetime.getTimeAgo(commentCreated)} __MSG__AGO__)</span>
@@ -108,7 +108,7 @@
 
     <div id="recentchangedcontent_item_related_content_author_template"><!--
         <a class="recentchangedcontent_item_link s3d-widget-links s3d-bold" href="/~${author.authorId}" title="${author.authorName|safeOutput}">
-            ${author.authorName|safeOutput}
+            ${author.authorName}
         </a>
     --></div>
 

--- a/devwidgets/recentmemberships/recentmemberships.html
+++ b/devwidgets/recentmemberships/recentmemberships.html
@@ -86,7 +86,7 @@
                     <span class="recentmemberships_content_mimetype">${content.type|safeOutput}</span>
                     <div>__MSG__BY__
                         <a class="recentmemberships_item_link s3d-widget-links s3d-bold" href="/~${author.authorId}">
-                            ${author.authorName|safeOutput}
+                            ${author.authorName}
                         </a>
                     </div>
                 </div>

--- a/devwidgets/recentmessages/javascript/recentmessages.js
+++ b/devwidgets/recentmessages/javascript/recentmessages.js
@@ -79,7 +79,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                 for(var item in response.results){
                     if(response.results.hasOwnProperty(item)){
                         response.results[item]["sakai:subject"] = sakai.api.Util.applyThreeDots(response.results[item]["sakai:subject"], $(".recentmessages_widget .s3d-widget-content").width() - 130, {max_rows: 1,whole_word: false}, "s3d-bold");
-                        response.results[item]["dotteduserFrom"] = sakai.api.Util.applyThreeDots(sakai.api.User.getDisplayName(response.results[item].userFrom[0]), 100, {max_rows: 1,whole_word: false});
+                        response.results[item]["dotteduserFrom"] = sakai.api.Util.applyThreeDots(sakai.api.User.getDisplayName(response.results[item].userFrom[0]), 100, {max_rows: 1,whole_word: false}, null, true);
                     }
                 }
                 // Only if everything went fine, show the recent messages


### PR DESCRIPTION
- Categories dropdown breaks when special characters are in tags
- mylibrary doesn't escape safeURL tags as it should
- recentchangedcontent and recentmemberships and recentmessages were double-escaping usernames (getDisplayName/applyThreeDots covers the escaping)
