### PR TITLE
SAKIII-3850 Fix issue where the user's name would be occasionally truncated to

### DIFF
--- a/dev/lib/sakai/sakai.api.util.js
+++ b/dev/lib/sakai/sakai.api.util.js
@@ -446,9 +446,18 @@ define(
             $container = $("<div class=\"" + optClass + "\" style=\"width:" + width + "px; ; word-wrap:break-word; visibility:hidden;\"><span style=\"word-wrap:break-word;\" class=\"ellipsis_text\">" + body + "</span></div>");
             $("body").append($container);
 
-            if ($($container).height() > 0) {
-                $container.ThreeDots(params);
+            // There seems to be a race condition where the
+            // newly-added element returns a height of zero.  This
+            // would cause ThreeDots to truncate the input string to
+            // the first letter.  Try a couple of times for a non-zero
+            // height and then give up.
+            for (var attempt = 0; attempt < 10; attempt++) {
+                if ($container.height() > 0) {
+                    $container.ThreeDots(params);
+                    break;
+                }
             }
+
             var dotted = $container.children("span").text();
             $container.remove();
             if (!alreadySecure) {


### PR DESCRIPTION
Hi Chris,

Here's that patch to fix the occasional truncation we're seeing when displaying the logged in user's name.  Things go bad when the element passed to ThreeDots has a height of zero, and there must be a race condition here around the element getting added to the DOM and given a height, but I didn't have any luck on that front.  This patch just checks the element's height and skips ThreeDots if it's zero...

http://jira.sakaiproject.org/browse/SAKIII-3850
