### PR TITLE
SAKIII-4098 Changing tool to page to match Sakai 2 parlance (and in case 

### DIFF
--- a/dev/s23/javascript/s23_site.js
+++ b/dev/s23/javascript/s23_site.js
@@ -114,7 +114,7 @@ sakai_global.s23_site = function(){
      */
     var loadPageTools = function(){
 
-        var pageid = $.bbq.getState("tool");
+        var pageid = $.bbq.getState("page");
         if (pageid) {
 
             // Remove the active class from the previous selected item
@@ -285,11 +285,11 @@ sakai_global.s23_site = function(){
             // Create xid's
             createxids();
 
-            if ($.bbq.getState("tool")) {
+            if ($.bbq.getState("page")) {
                 // If the pageid was passed in through the URL. This will sometimes be
                 // the result of a Sakai 2 portal being rewritten from:
                 // portal/site/{siteid}/page/{pageid}
-                loadPageTools($.bbq.getState("tool"));
+                loadPageTools($.bbq.getState("page"));
             }
             else {
                 // Pretend like you clicked on the first page

--- a/dev/s23/s23_site.html
+++ b/dev/s23/s23_site.html
@@ -53,8 +53,8 @@
         <div id="s23_site_menu_container_template"><!--
             {if site.pages.length > 0}
                 <ul>
-                {for tool in site.pages}
-                    <li class="s23_site_menu_item"><a href="#tool=${tool.id}" class="${tool.iconclass}" id="s23_site_menu_item_${tool.id}">${tool.name}</a></li>
+                {for page in site.pages}
+                    <li class="s23_site_menu_item"><a href="#page=${page.id}" class="${page.iconclass}" id="s23_site_menu_item_${page.id}">${page.name}</a></li>
                 {/for}
                 </ul>
             {else}


### PR DESCRIPTION
SAKIII-4098 Changing tool to page to match Sakai 2 parlance (and in case we need to pass in actual tool id's in the future.

https://jira.sakaiproject.org/browse/SAKIII-4098
