### PR TITLE
SAKIII-4173 Provide an alternative way to determine widget editability

### DIFF
--- a/dev/lib/sakai/sakai.api.widgets.js
+++ b/dev/lib/sakai/sakai.api.widgets.js
@@ -746,13 +746,17 @@ define(
             }
         },
 
-        canEditContainer: function(widgetData) {
+        canEditContainer: function(widgetData, tuid) {
             if (widgetData &&
                 widgetData.data &&
                 widgetData.data.currentPageShown &&
                 widgetData.data.currentPageShown.canEdit &&
                 !widgetData.data.currentPageShown.nonEditable) {
                 return true;
+            } else if (!widgetData && tuid) {
+                var ref = $("#" + tuid).parents("#s3d-page-container").children("div").attr("id");
+                var canEdit = $("li[data-sakai-ref='"+ ref +"']").data("sakai-manage");
+                return canEdit;
             } else {
                 return false;
             }


### PR DESCRIPTION
SAKIII-4173 Provide an alternative way to determine if a user can edit a widget based on it's container, when there is no widget data to draw from
