### PR TITLE
NOJIRA redirect to 'url' param when user is authenticated

### DIFF
--- a/devwidgets/topnavigation/javascript/topnavigation.js
+++ b/devwidgets/topnavigation/javascript/topnavigation.js
@@ -188,6 +188,17 @@ require(["jquery", "sakai/sakai.api.core", "jquery-plugins/jquery.fieldselection
             return redirectURL;
         }
 
+       /**
+         * Check if a redirect should be performed
+         */
+        var checkForRedirect = function() {
+            var qs = new Querystring();
+            // Check for url param and if user is logged in
+            if (qs.get("url") && !sakai.api.User.isAnonymous(sakai.data.me)) {
+                window.location = qs.get("url");
+            }
+        };
+
         ////////////////////////
         /////// MESSAGES ///////
         ////////////////////////
@@ -890,6 +901,7 @@ require(["jquery", "sakai/sakai.api.core", "jquery-plugins/jquery.fieldselection
          * Initialise the topnavigation widget
          */
         var doInit = function(){
+            checkForRedirect();
             renderMenu();
             renderUser();
             setCountUnreadMessages();


### PR DESCRIPTION
Hi Chris and co,

This is in response to a bug we had at NYU where Sakai wasn't redirecting to the desired URL upon returning from the SSO service.

When unauthenticated, Sakai redirects to home_url?url=desired_url.  This is the URL that the SSO service is given and thus returned to.  

This patch checks for the 'url' param and user's auth status and redirects to the 'url' if authenticated.

NYU JIRA: https://jira.nyu.edu/jira/browse/ATLASNAK-36

Cheers!
Payten
