### PR TITLE
NOJIRA redirect to 'url' param when user is authenticated (REOPENED)

### DIFF
--- a/devwidgets/topnavigation/javascript/topnavigation.js
+++ b/devwidgets/topnavigation/javascript/topnavigation.js
@@ -193,9 +193,11 @@ require(["jquery", "sakai/sakai.api.core", "jquery-plugins/jquery.fieldselection
          */
         var checkForRedirect = function() {
             var qs = new Querystring();
-            // Check for url param and if user is logged in
-            if (qs.get("url") && document.location.pathname === "/" && !sakai.api.User.isAnonymous(sakai.data.me)) {
-                window.location = qs.get("url");
+            // Check for url param, path and if user is logged in
+            if (qs.get("url") && !sakai.api.User.isAnonymous(sakai.data.me) &&
+                (window.location.pathname === "/" || window.location.pathname === "/dev/explore.html" ||
+                  window.location.pathname === "/index" || window.location.pathname === "/dev")) {
+                    window.location = qs.get("url");
             }
         };
 


### PR DESCRIPTION
See https://github.com/sakaiproject/3akai-ux/pull/1210

Have reopened to hopefully address the 404-infinite loop.

Have added a check for the root path.  This works for NYU as when SSO is enabled all unauthenticated checks are redirected to root.
