### PR TITLE
KERN-2274 change to make UI work with groups created in World Creation API

### DIFF
--- a/dev/lib/sakai/sakai.api.groups.js
+++ b/dev/lib/sakai/sakai.api.groups.js
@@ -528,7 +528,7 @@ define(
                 var managementRoles = [];
                 var roles = $.parseJSON(groupinfo["sakai:roles"]);
                 for (var r = 0; r < roles.length; r++) {
-                    if (roles[r].allowManage) {
+                    if (roles[r].isManagerRole) {
                         managementRoles.push(roles[r].id);
                     }
                 }


### PR DESCRIPTION
In server-based world template the old 'allowManage' property is now 'isManagerRole'.

Goes along with this Nakamura PR:

https://github.com/sakaiproject/nakamura/pull/400
