### PR TITLE
SAKIII-4304 Removing server side template for join_request emails since ...

### DIFF
--- a/dev/lib/sakai/sakai.api.communication.js
+++ b/dev/lib/sakai/sakai.api.communication.js
@@ -120,13 +120,6 @@ define(
                         toSend["sakai:templateParams"] = "sender=" + sender +
                         "|system=" + sakai_i18n.getValueForKey("SAKAI") + "|subject=" + subject + "|body=" + body + "|link=" + sakai_conf.SakaiDomain + sakai_conf.URL.INBOX_URL;
                         break;
-                    case "join_request":
-                        toSend["sakai:templatePath"] = "/var/templates/email/join_request";
-                        toSend["sakai:templateParams"] = "sender=" + sender +
-                        "|system=" + sakai_i18n.getValueForKey("SAKAI") + "|name=" + groupTitle +
-                        "|profilelink=" + sakai_conf.SakaiDomain + "/~" + sakai_util.safeURL(meData.user.userid) +
-                        "|acceptlink=" + sakai_conf.SakaiDomain + "/~" +  groupId + "#e=joinrequests";
-                        break;
                     case "group_invitation":
                         toSend["sakai:templatePath"] = "/var/templates/email/group_invitation";
                         toSend["sakai:templateParams"] = "sender=" + sender +


### PR DESCRIPTION
...it has been moved to i18n bundles (and updated and expanded since then. The issue here, was that the Join Buttons were using i18n bundle, adn the plus icons were using the templates, so it was a subtle issue with them being out of sync (the server side templates were never made to pass teh Group name in.

https://jira.sakaiproject.org/browse/SAKIII-4304
