### PR TITLE
SAKIII-4453 removed needless escaping of user ID so it is passed correct...

### DIFF
--- a/devwidgets/changepic/javascript/changepic.js
+++ b/devwidgets/changepic/javascript/changepic.js
@@ -428,8 +428,8 @@ require(["jquery", "sakai/sakai.api.core", "/dev/lib/jquery/plugins/imgareaselec
         var savePicture = function(){
             // The parameters for the cropit service.
             var data = {
-                img: "/~" + sakai.api.Util.safeURL(id) + "/public/profile/" + picture._name,
-                save: "/~" + sakai.api.Util.safeURL(id) + "/public/profile",
+                img: "/~" + id + "/public/profile/" + picture._name,
+                save: "/~" + id + "/public/profile",
                 x: Math.floor(userSelection.x1 * ratio),
                 y: Math.floor(userSelection.y1 * ratio),
                 width: Math.floor(userSelection.width * ratio),


### PR DESCRIPTION
Changed the JSON payload to the image crop service so the user's ID is not URL encoded. URL encoding is done (appropriately) when the image is first POSTed because the path to the image content is in the URL. In this instance the path the the image content is being passed within the JSON data POSTed to the crop service. Not only does the path not need to be URL encoded here, the backend is not decoding the path. So for any user with a reserved URL character in his/her username, the crop service will fail. This will be a problem particularly for any OAE instance which uses email addresses of scoped identifiers with an '@' in them for user IDs.
