### PR TITLE
SAKIII-4541 Fix path strings and JQuery versions

### DIFF
--- a/tools/hashfiles/config.properties
+++ b/tools/hashfiles/config.properties
@@ -3,6 +3,6 @@ hash_file_types: js, css
 need_to_change_file_types: html,js,jsp,css
 ignore_file_paths:
 require_base_url: /dev/lib/
-require_paths: jquery-plugins:jquery/plugins,jquery:jquery/jquery-1.5.2,jquery-ui:jquery/jquery-ui-1.8.13.custom,config:../configuration
+require_paths: jquery-plugins:jquery/plugins,jquery:jquery/jquery-1.7.0,jquery-ui:jquery/jquery-ui-1.8.16.custom,config:../configuration
 require_dependency_file: /dev/lib/sakai/sakai.dependencies.js
 folder_libs: dev/lib/MathJax,dev/lib/tinymce,dev/lib/misc/l10n

--- a/tools/hashfiles/src/main/java/org/sakaiproject/ux/tools/HashRefreshFiles.java
+++ b/tools/hashfiles/src/main/java/org/sakaiproject/ux/tools/HashRefreshFiles.java
@@ -338,9 +338,9 @@ public class HashRefreshFiles {
       Set<String> keys = hashedResults.keySet();
       for (String key : keys) {
         if (key.startsWith(this.requireBaseUrl)) {
-          String newKey = key.substring(this.requireBaseUrl.length() + 1);
+          String newKey = key.substring(this.requireBaseUrl.length());
           String newValue = hashedResults.get(key).substring(
-              this.requireBaseUrl.length() + 1);
+              this.requireBaseUrl.length());
           if (newKey.lastIndexOf('.') > 0)
             newKey = newKey.substring(0, newKey.lastIndexOf('.'));
           if (newValue.lastIndexOf('.') > 0)


### PR DESCRIPTION
Bad paths are being written to sakai.dependencies.js by the current hashing code. This is obvious if you look at the processed file, and causes multiple 404s if you deploy without the "optimize" step embedding all dependencies. When the "optimize" build step does embed dependency code, the bug might not be noticed since the browser does not need to request the messed-up paths.
