### PR TITLE
NOJIRA The tags macro was a local variable to the template so it either ...

### DIFF
--- a/dev/macros/search.html
+++ b/dev/macros/search.html
@@ -1,6 +1,6 @@
-{macro tags(i)}
+{macro tags(tags)}
     <ul class="s3d-taglist">
-        {for t in i.tagsProcessed}
+        {for t in tags}
             <li>
                 <a class="s3d-regular-light-links" href="${t.link}" title="${t.linkTitle}">
                     <span class="s3d-search-result-tag">${t.tagShort}</span>
@@ -58,7 +58,7 @@ ${macros["search.tags"] = tags |eat}
             <span class="searchcontent_result_description_grid">${i["sakai:description-shorter"]}</span>
         {/if}
         {if !$.isEmptyObject(i.tagsProcessed)}
-            ${tags(i)}
+            ${tags(i.tagsProcessed)}
         {/if}
         <div class="searchcontent_result_usedin">
             {var placeCount = sakai.api.Content.getPlaceCount(i)}

--- a/dev/search.html
+++ b/dev/search.html
@@ -163,7 +163,7 @@
                             {/if}
                         </div>
                         {if !$.isEmptyObject(i.tagsProcessed)}
-                            ${macro("search.tags", i)}
+                            ${macro("search.tags", i.tagsProcessed)}
                         {/if}
                     </div>
                 </li>
@@ -212,7 +212,7 @@
                             <div class="searchgroups_result_description_grid">${i["sakai:group-description-shorter"]}</div>
                         {/if}
                         {if !$.isEmptyObject(i.tagsProcessed)}
-                            ${macro("search.tags", i)}
+                            ${macro("search.tags", i.tagsProcessed)}
                         {/if}
                     </div>
                 </li>


### PR DESCRIPTION
...needed to be passed in as a variable to the search macro or moved to the global search macros. Ultimately I had to move it there because it was being used by multiple templates in the search (one for the regular page display, and one that refreshes the rows when counts are updated).
