### PR TITLE
NOJIRA specify not to skip clean in pom-bundle

### DIFF
--- a/pom-bundle.xml
+++ b/pom-bundle.xml
@@ -258,6 +258,12 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>


### PR DESCRIPTION
now that pom-bundle inherits from pom it was picking up its mvn-clean-plugin config
