### PR TITLE
SAKIII-4667 - The autosuggest text areas have an inner shadow on the top...

### DIFF
--- a/dev/css/sakai/sakai.base.css
+++ b/dev/css/sakai/sakai.base.css
@@ -437,7 +437,7 @@ input[type=text], input[type=password], input[type=email], input[type=url], text
 /*
  * AUTOSUGGEST
  */
-.requireUser ul.as-selections{box-shadow:none;-webkit-box-shadow:none;-moz-box-shadow:none;border:1px solid #a9a9a9;outline:1px dotted #000}
+.requireUser ul.as-selections{box-shadow:none;-webkit-box-shadow:none;-moz-box-shadow:none;border:1px solid #a9a9a9;}
 ul.as-selections.loading{background:#fff url(../../../dev/images/ajax_load.gif) center center no-repeat;}
 ul.as-selections li.as-original input {border:0;}
 ul.as-selections textarea.as-input, ul.as-selections input.as-input{border:0;resize:none;}


### PR DESCRIPTION
... on Webkit browsers

SAKIII-4667
The autosuggest text areas have an inner shadow on the top on Webkit browsers
https://jira.sakaiproject.org/browse/SAKIII-4667

Note: overriding AutoSuggest CSS. Tested in FF, Webkit, IE 8.
