### PR TITLE
SAKIII-4332 - hide loading spinner initially on list load and on error

### DIFF
--- a/dev/lib/jquery/plugins/jquery.infinitescroll-sakai.js
+++ b/dev/lib/jquery/plugins/jquery.infinitescroll-sakai.js
@@ -231,8 +231,7 @@
          */
         var showHideLoadingContainer = function(show){
             if (show){
-                $loadingContainer.hide();
-                $loadingContainer.show();
+                $loadingContainer.hide().show();
             } else {
                 $loadingContainer.hide();
             }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAKIII-4332
- When searches don't return, the loading gif doesn't go away
