### PR TITLE
SAKIII-4854 Don't cache the docstructure GET ajax call, as IE8's aggress...

### DIFF
--- a/devwidgets/addarea/javascript/addarea.js
+++ b/devwidgets/addarea/javascript/addarea.js
@@ -523,6 +523,7 @@ require(["jquery", "sakai/sakai.api.core", "underscore"], function($, sakai, _){
             // Refetch docstructure information
             $.ajax({
                  url: "/~" + sakai_global.group.groupId + "/docstructure.infinity.json",
+                 cache: false,
                  success: function(data){
 
                     var pubdata = sakai.api.Server.cleanUpSakaiDocObject(data);


### PR DESCRIPTION
...ive caching will prevent any new areas from being added (after the first)

https://jira.sakaiproject.org/browse/SAKIII-4854
