### PR TITLE
KERN-2546 Deal gracefully with pseudogroups that are 404

### DIFF
--- a/dev/lib/sakai/sakai.api.groups.js
+++ b/dev/lib/sakai/sakai.api.groups.js
@@ -987,7 +987,7 @@ define(
                         for (var i = 0; i < roles.length; i++) {
                             if (data.results.hasOwnProperty(i)) {
                                 var members = $.parseJSON(data.results[i].body);
-                                if ( members === null ) {
+                                if (members === null) {
                                   continue;
                                 }
                                 if ($.grep(members, isMatch).length > 0){


### PR DESCRIPTION
Deal gracefully with pseudogroups that are 404 due to ACL restrictions; also, main group should not be a viewer of its pseudogroups

http://jira.sakaiproject.org/browse/KERN-2546
