### PR TITLE
SAKIII-4808 - Message detail view should not link to itself

### DIFF
--- a/devwidgets/inbox/inbox.html
+++ b/devwidgets/inbox/inbox.html
@@ -143,7 +143,7 @@
                                         </div>
                                         {if !reply}
                                         <div class="inbox_subject">
-                                          <a href="#" class="s3d-regular-links s3d-bold">${message.subject|safeOutput}</a>
+                                          <span class="s3d-bold">${message.subject|safeOutput}</span>
                                         </div>
                                         {/if}
                                         <div class="inbox_excerpt">


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAKIII-4808
- Message detail view should not link to itself
