### PR TITLE
SAKIII-5009 - Add area screen has wild-floating _List Categories_ link

### DIFF
--- a/devwidgets/addarea/css/addarea.css
+++ b/devwidgets/addarea/css/addarea.css
@@ -83,5 +83,5 @@
 #addarea_container #addarea_actions {float:right;margin-top:15px;clear:both;}
 
 /* AutoSuggest */
-#addarea_container .autosuggest_wrapper ul.as-selections{width:340px;float:left;clear:both;min-height:50px;}
+#addarea_container .autosuggest_wrapper ul.as-selections{width:380px;float:left;clear:both;min-height:50px;}
 #addarea_container .autosuggest_wrapper ul.as-list{margin-top:0px;}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAKIII-5009
- Add area screen has wild-floating 'List Categories' link
- Adjusted the size of the autosuggest container so that the List Categories is not left hanging
