### PR TITLE
SAKIII-5180 Don't cut off the suggestions drop down

### DIFF
--- a/devwidgets/contentauthoring/css/contentauthoring.css
+++ b/devwidgets/contentauthoring/css/contentauthoring.css
@@ -56,7 +56,6 @@
     height: 100% !important;
     display: table-cell;
     vertical-align: top !important;
-    overflow: hidden;
 }
 
 .contentauthoring_widget .contentauthoring_cell_container {


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAKIII-5180

`overflow:hidden` was introduced in https://github.com/sakaiproject/3akai-ux/commit/4041215517799c5e8ff30fc454140a6908a525da. I've checked to see if this causes any regressions and it doesn't appear to.
