### PR TITLE
SAKIII-5211 Removing triggers to reload the content profile when the content permissions have changed

### DIFF
--- a/devwidgets/contentpermissions/javascript/contentpermissions.js
+++ b/devwidgets/contentpermissions/javascript/contentpermissions.js
@@ -178,6 +178,7 @@ require(["jquery", "sakai/sakai.api.core", "underscore", "/dev/javascript/conten
         var finishSavePermissions = function(){
             closeOverlay();
             if (globalPermissionsChanged || changesMade) {
+                $(window).trigger('sakai.entity.ready');
                 sakai.api.Util.notification.show($("#contentpermissions_permissions").text(), $("#contentpermissions_permissionschanged").text());
             }
         };


### PR DESCRIPTION
I can't come up with a reason why we'd need to refresh the content profile after changing permissions, and removing that solves this issue. If we do need this, I can dig into other solutions for this problem.

https://jira.sakaiproject.org/browse/SAKIII-5211
