### PR TITLE
SAKIII-5271 Don't double-escape group titles in my memberships

### DIFF
--- a/devwidgets/mymemberships/mymemberships.html
+++ b/devwidgets/mymemberships/mymemberships.html
@@ -123,8 +123,8 @@
                 <div class="mymemberships_item_right s3d-search-result-right">
                     <div>
                         <a class="s3d-bold s3d-regular-light-links" href="${group.url|safeOutput}" title="${group.title|safeOutput}">
-                            <span class="s3d-search-result-name">${group.titleShort|safeOutput}</span>
-                            <span class="s3d-search-result-name-grid">${group.titleShorter|safeOutput}</span>
+                            <span class="s3d-search-result-name">${group.titleShort}</span>
+                            <span class="s3d-search-result-name-grid">${group.titleShorter}</span>
                         </a>
                         {if group.type}
                             <span class="mymemberships_item_grouptype">${group.type.toUpperCase()}</span>


### PR DESCRIPTION
- They've already been escaped when applying three dots in the groups api

https://jira.sakaiproject.org/browse/SAKIII-5271
