### PR TITLE
SAKIII-5270 Add the collection managers group to the current user's subjects so they see the management interface when navigating there

### DIFF
--- a/dev/lib/sakai/sakai.api.content.js
+++ b/dev/lib/sakai/sakai.api.content.js
@@ -1408,7 +1408,11 @@ define(
 
                                     sakai_groups.addUsersToGroup(groupId, managershipsToProcess, sakai_user.data.me, true, function(){
                                         sakai_groups.addUsersToGroup(groupId, membershipsToProcess, sakai_user.data.me, false, function(){
-
+                                            // Add current user to the managers group for management functions before refresh
+                                            sakai_user.data.me.user.subjects.push(groupId + '-managers');
+                                            sakai_user.data.me.groups.push({
+                                                'sakai:group-id': groupId + '-managers'
+                                            });
                                             // 4g. Remove the creator as an explicit manager of all these groups
                                             batchRequests = [];
                                             var params = {


### PR DESCRIPTION
See #3 on https://jira.sakaiproject.org/browse/SAKIII-5270
