### PR TITLE
NOJIRA add shell scripts for modifying version numbers in the release process

### DIFF
--- a/tools/release/release_post_process_files.sh
+++ b/tools/release/release_post_process_files.sh
@@ -1,0 +1,32 @@
+#/bin/sh
+if [ $# -lt 2 ] ; then
+  echo "Usage: $0 <current version number> <next version number>"
+  echo "Don't include -SNAPSHOT."
+  exit 0
+fi
+set -o nounset
+set -o errexit
+cversion=$1
+nversion=$2
+
+function simple_replace {
+    sed "s/$cversion/$nversion-SNAPSHOT/g" $1 > $1.new
+    restore $1
+}
+
+function artifact_version_replace {
+    perl -pi.bak -e "undef $/; s/($1<\/artifactId>\n\s+<version)>$cversion/\$1>$nversion-SNAPSHOT/" $2
+    rm $2.bak
+    git add $2
+}
+
+function restore {
+    mv $1.new $1
+    git add $1
+}
+
+echo "Moving config files from $cversion to $nversion-SNAPSHOT"
+simple_replace build.xml
+artifact_version_replace org.sakaiproject.nakamura.hashfiles pom-bundle.xml
+
+git commit -m "release_post_process: Moving config files from $cversion to $nversion-SNAPSHOT"

--- a/tools/release/release_pre_process_files.sh
+++ b/tools/release/release_pre_process_files.sh
@@ -1,0 +1,33 @@
+#/bin/sh
+if [ $# -lt 1 ] ; then
+  echo "Usage: $0 <version number>"
+  echo "Don't include -SNAPSHOT."
+  exit 0
+fi
+set -o nounset
+set -o errexit
+cversion=$1
+
+
+function simple_replace {
+    sed "s/$cversion-SNAPSHOT/$cversion/g" $1 > $1.new
+    restore $1
+}
+
+function artifact_version_replace {
+    perl -pi.bak -e "undef $/; s/($1<\/artifactId>\n\s+<version)>$cversion-SNAPSHOT/\$1>$cversion/" $2
+    rm $2.bak
+    git add $2
+}
+
+function restore {
+    mv $1.new $1
+    git add $1
+}
+
+echo "Moving config files from $cversion-SNAPSHOT to $cversion"
+simple_replace build.xml
+artifact_version_replace org.sakaiproject.nakamura.hashfiles pom-bundle.xml
+
+git commit -m "release_pre_process: Moving config files from $cversion-SNAPSHOT to $cversion"
+


### PR DESCRIPTION
Whenever we perform a release, we need version numbers changed from, e.g. `1.2-SNAPSHOT` to `1.2` and then after the release is performed, we change from `1.2` to `1.3-SNAPSHOT`.

The maven release plugin does this, but it doesn't know about some of the places in our files where the version numbers need to be changed. That's where these two scripts come in.

There's one to pre-process our files for release, and one to post process. Here's how you would use them in conjunction with the maven release plugin:

```
./tools/release/release_pre_process_files.sh 1.2 \
&& mvn release:prepare -DpushChanges=false \
&& ./tools/release/release_post_process_files.sh 1.2 1.3
```
