### PR TITLE
SakIII-5503 Change <parent> of org.sakaiproject.nakamura.hashfiles to sonatype-parent and release independently of 3akai-ux in order to resolve dependency ordering issues.

### DIFF
--- a/tools/hashfiles/pom.xml
+++ b/tools/hashfiles/pom.xml
@@ -24,6 +24,25 @@
     <version>1.2-SNAPSHOT</version>
     <name>Sakai 3 UX File Hasher</name>
     <description>Hashes files and appends the hash to the name to trigger proper caching</description>
+    <scm>
+      <connection>scm:git:git://github.com/sakaiproject/3akai-ux.git</connection>
+      <developerConnection>scm:git:git@github.com:sakaiproject/3akai-ux.git</developerConnection>
+      <url>http://github.com/sakaiproject/3akai-ux/</url>
+    </scm>
+    <pluginRepositories> 
+      <pluginRepository>
+        <id>default</id>
+        <name>Maven Repository Switchboard</name>
+        <layout>default</layout>
+        <url>http://repo1.maven.org/maven2</url>
+        <releases>
+         <enabled>true</enabled>
+        </releases>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+      </pluginRepository>
+    </pluginRepositories>
     <build>
       <plugins>
         <plugin>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAKIII-5503
