### PR TITLE
NOJIRA ignore zxcvbn.js from hashing, as it will fail in a release build otherwise

### DIFF
--- a/tools/hashfiles/config.properties
+++ b/tools/hashfiles/config.properties
@@ -1,7 +1,7 @@
 basedir: target/processed-resources
 hash_file_types: js, css
 need_to_change_file_types: html,js,jsp,css
-ignore_file_paths:
+ignore_file_paths: zxcvbn.js
 require_base_url: /dev/lib/
 # If you change these paths, please check out https://confluence.sakaiproject.org/x/sq_CB
 require_paths: jquery-plugins:jquery/plugins,jquery:jquery/jquery-1.7.0,jquery-ui:jquery/jquery-ui-1.8.16.custom,underscore:misc/underscore,config:../configuration


### PR DESCRIPTION
After testing in a release build, the method of requiring zxcvbn.js in create_new_account.js only proved to be unworkable in a release build, as the hashing caused the lookup for the file to fail. As this is a library file, it won't be modified often (if ever), so ignoring it in the hashing should be fine.

This fix is needed to ensure that the registration page continues to work in a release build on master.
