### PR TITLE
SAKIII-5322 Improve performance of poor related-content search.

### DIFF
--- a/devwidgets/recentchangedcontent/javascript/recentchangedcontent.js
+++ b/devwidgets/recentchangedcontent/javascript/recentchangedcontent.js
@@ -230,7 +230,10 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
                 }
             }
             else {
-                urlterm = '*' + term + '*';
+                urlterm = split[0];
+                if (urlterm === '') {
+                    urlterm = '*';
+                }
             }
             return urlterm;
         };
@@ -238,27 +241,9 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
         /**
          * Fetches the related content
          */
-        var getRelatedContent = function(contentData) {
-
-            var managersList = '';
-            var viewersList = '';
-            if (contentData['sakai:pooled-content-manager']) {
-                for (var i = 0; i < contentData['sakai:pooled-content-manager'].length; i++) {
-                    if (contentData['sakai:pooled-content-manager'][i]) {
-                        managersList += ' ' + (contentData['sakai:pooled-content-manager'][i]);
-                    }
-                }
-            }
-            if (contentData['sakai:pooled-content-viewer']) {
-                for (var z = 0; z < contentData['sakai:pooled-content-viewer'].length; z++) {
-                    if (contentData['sakai:pooled-content-viewer'][z]) {
-                        viewersList += ' ' + (contentData['sakai:pooled-content-viewer'][z]);
-                    }
-                }
-            }
-
-            var searchterm = contentData['sakai:pooled-content-file-name'].substring(0,400) + ' ' + managersList + ' ' + viewersList;
-            var searchquery = prepSearchTermForURL(searchterm);
+        var getRelatedContent = function(contentData){
+            var searchterm = contentData["sakai:pooled-content-file-name"].substring(0,400);
+            searchquery = prepSearchTermForURL(searchterm);
 
             // get related content for contentData
             // return some search results for now


### PR DESCRIPTION
This is intended as a low-impact performance fix for the relief of 1.3 deployers.
Functionally speaking, the "related content" code in recentchangedcontent is still nearly useless. This patch just delivers terrible results much more quickly. For details, see:
https://jira.sakaiproject.org/browse/SAKIII-5322
