### PR TITLE
SAKIII-5507 - Multiple clicks on the 'Show more' button in related content fire multiple requests

### DIFF
--- a/devwidgets/relatedcontent/javascript/relatedcontent.js
+++ b/devwidgets/relatedcontent/javascript/relatedcontent.js
@@ -141,7 +141,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
                         $(relatedcontentShowMore).hide();
                         $("#relatedcontent_footer").addClass("relatedcontent_footer_norelated");
                     } else {
-                        $(relatedcontentShowMore).show();
+                        $(relatedcontentShowMore).removeAttr('disabled').show();
                         $("#relatedcontent_footer").removeClass("relatedcontent_footer_norelated");
                     }
                 }
@@ -194,6 +194,7 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
         };
 
         var showMore = function(){
+            $(relatedcontentShowMore).attr('disabled','disabled');
             page++;
             getRelatedContent();
             getRelatedContent(true);


### PR DESCRIPTION
Fix to disable "Show More" button on related content until request is complete in order to prevent request queue buildup.
https://jira.sakaiproject.org/browse/SAKIII-5507
