### PR TITLE
SAKIII-5413:

### DIFF
--- a/devwidgets/collectionviewer/css/collectionviewer.css
+++ b/devwidgets/collectionviewer/css/collectionviewer.css
@@ -33,9 +33,6 @@
     margin: 0 10px;
 }
 .collectionviewer_widget #collectionviewer_expanded_content_container ul li.s3d-search-result {
-    border-bottom: none;
-}
-.collectionviewer_widget #collectionviewer_expanded_content_container ul li.s3d-search-result:hover, .collectionviewer_widget #collectionviewer_expanded_content_container ul li.s3d-search-result.hovered {
     border: 2px solid #c4d9e1;
     padding: 8px;
     border-radius: 6px;
@@ -57,12 +54,6 @@
 .collectionviewer_widget #collectionviewer_expanded_content_container .collectionviewer_download_button {
     height: 21px;
     line-height: 22px;
-}
-.collectionviewer_widget #collectionviewer_expanded_content_container .collectionviewer_item_actions {
-    display: none;
-}
-.collectionviewer_widget #collectionviewer_expanded_content_container .s3d-search-result:hover .collectionviewer_item_actions, .collectionviewer_widget #collectionviewer_expanded_content_container .s3d-search-result.hovered .collectionviewer_item_actions {
-    display: inline;
 }
 .collectionviewer_widget .s3d-button.collectionviewer_comments_button {
     float: right;


### PR DESCRIPTION
.collectionviewer_widget #collectionviewer_expanded_content_container ul li.s3d-search-result
- removed the :hover and .hovered css declarations
- removed the display:none and removed the display:inline from the :hover and .hovered
- also removed an extra "border-bottom: none;" declaration which was getting overridden alway.

Pull request: https://jira.sakaiproject.org/browse/SAKIII-5413
