### PR TITLE
SAKIII-5514 - The icon in the "Add" button is still clickable when the rest of the button is inactive.

### DIFF
--- a/devwidgets/savecontent/javascript/savecontent.js
+++ b/devwidgets/savecontent/javascript/savecontent.js
@@ -296,6 +296,12 @@ require(["jquery", "sakai/sakai.api.core"], function($, sakai) {
 
         $(".savecontent_trigger").live("click", function(el){
             clickedEl = $(this);
+            
+            //SAKIII-5514 Fix for disabled buttons in Chrome
+            if (!$(el.target).is(clickedEl) && clickedEl.attr('disabled')) {
+                return false;
+            }
+            
             idArr = clickedEl.attr("data-entityid");
             if(idArr.length > 1 && !$.isArray(idArr)){
                 idArr = idArr.split(",");


### PR DESCRIPTION
Fix for Chrome disabled button issue.
https://jira.sakaiproject.org/browse/SAKIII-5514
