### PR TITLE
SAKIII-5413 Collection Viewer doc/collection header exposes features only on hover

### DIFF
--- a/devwidgets/collectionviewer/css/collectionviewer.css
+++ b/devwidgets/collectionviewer/css/collectionviewer.css
@@ -58,12 +58,6 @@
     height: 21px;
     line-height: 22px;
 }
-.collectionviewer_widget #collectionviewer_expanded_content_container .collectionviewer_item_actions {
-    display: none;
-}
-.collectionviewer_widget #collectionviewer_expanded_content_container .s3d-search-result:hover .collectionviewer_item_actions, .collectionviewer_widget #collectionviewer_expanded_content_container .s3d-search-result.hovered .collectionviewer_item_actions {
-    display: inline;
-}
 .collectionviewer_widget .s3d-button.collectionviewer_comments_button {
     float: right;
     margin-left: 10px;


### PR DESCRIPTION
.collectionviewer_widget #collectionviewer_expanded_content_container ul li.s3d-search-result
- removed the :hover and .hovered css declarations
- removed the display:none and removed the display:inline from the :hover and .hovered
- also removed an extra "border-bottom: none;" declaration which was getting overridden alway.

JIRA: https://jira.sakaiproject.org/browse/SAKIII-5413
