### PR TITLE
SAKIII-5288 - Sakai2Tools widget not shown in CA interface

### DIFF
--- a/devwidgets/sakai2tools/config.json
+++ b/devwidgets/sakai2tools/config.json
@@ -1,5 +1,5 @@
 {
-    "sakaidocs": false,
+    "sakaidocs": true,
     "ca":true,
     "hasSettings": true,
     "id":"sakai2tools",


### PR DESCRIPTION
Setting sakaidocs to true in sakai2tools widget config so that it shows up in the Content Authoring Interface.
https://jira.sakaiproject.org/browse/SAKIII-5288
