### PR TITLE
KERN-2805 Remove unnecessary wildcards

### DIFF
--- a/devwidgets/inserter/javascript/inserter.js
+++ b/devwidgets/inserter/javascript/inserter.js
@@ -637,7 +637,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
          */
         var showCollection = function(item) {
             inCollection = true;
-            var query = $.trim($(inserterCollectionContentSearch, $rootel).val()) || '*';
+            var query = $.trim($(inserterCollectionContentSearch, $rootel).val());
             var mimetype = $inserterMimetypeFilter.val() || '';
 
             var params = {

--- a/devwidgets/mylibrary/javascript/mylibrary.js
+++ b/devwidgets/mylibrary/javascript/mylibrary.js
@@ -195,7 +195,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
          */
         var showLibraryContent = function () {
             resetView();
-            var query = $mylibrary_livefilter.val() || '*';
+            var query = $mylibrary_livefilter.val();
             // Disable the previous infinite scroll
             if (mylibrary.infinityScroll) {
                 mylibrary.infinityScroll.kill();

--- a/devwidgets/newaddcontent/javascript/newaddcontent.js
+++ b/devwidgets/newaddcontent/javascript/newaddcontent.js
@@ -1108,7 +1108,7 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore', 'jquery-plugins/jquery.
          */
         var renderExistingContent = function(q, pagenum) {
             if (!q) {
-                q = '*';
+                q = '';
             }
             switch(currentExistingContext) {
                 case 'everything':


### PR DESCRIPTION
This is a performance/scalability fix for the incorrect wildcard usage I found while investigating "My Library" slowdowns. Pull requests for the "Explore" widgets will hopefully follow soon.

I'm about to enter a related pull request (specifically aimed at "My Library" and other-user Library widgets) for Nakamura, and will add a pointer when that's done. When both are applied to our local production data, "My Library" results consistently show up in less than 0.5 second. Before the change, results typically didn't show up for more than 4 seconds.

https://jira.sakaiproject.org/browse/KERN-2805
