### PR TITLE
SAKIII-5629 - Clean up widget configuration files

### DIFF
--- a/devwidgets/_template/config.json
+++ b/devwidgets/_template/config.json
@@ -32,19 +32,19 @@
  *    when Sakai OAE wants to display the widget
  */
 {
-    "id": "WIDGET_ID",
-    "type": "contrib",
-    "enabled": false,
+    "enabled": false, 
     "hasSettings": false,
-    "url": "/devwidgets/WIDGET_ID/WIDGET_ID.html",
-    "img": "/devwidgets/WIDGET_ID/images/WIDGET_ID.png",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/WIDGET_ID/bundles/default.properties",
-            "name": "WIDGET_ID_NAME",
-            "description":"WIDGET_ID_DESCRIPTION"
+            "description": "WIDGET_ID_DESCRIPTION",
+            "name": "WIDGET_ID_NAME"
         }
     },
+    "id": "WIDGET_ID",
+    "img": "/devwidgets/WIDGET_ID/images/WIDGET_ID.png",
     "personalportal": false,
-    "sakaidocs": false
+    "sakaidocs": false,
+    "type": "contrib",
+    "url": "/devwidgets/WIDGET_ID/WIDGET_ID.html"
 }

--- a/devwidgets/accountpreferences/config.json
+++ b/devwidgets/accountpreferences/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"accountpreferences",
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/accountpreferences/bundles/default.properties",
-            "description":"Account preferences",
-            "name":"Account preferences"
+            "description": "Account preferences",
+            "name": "Account preferences"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/accountpreferences/bundles/es_ES.properties"
-        } 
+        }
     },
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/accountpreferences/accountpreferences.html"
+    "id": "accountpreferences",
+    "type": "core", 
+    "url": "/devwidgets/accountpreferences/accountpreferences.html"
 }

--- a/devwidgets/activegroups/config.json
+++ b/devwidgets/activegroups/config.json
@@ -1,15 +1,15 @@
 {
-    "personalportal":true,
-    "hasSettings": false,
-    "id": "activegroups",
-    "type": "sakai",
     "enabled": true,
-    "url":"/devwidgets/activegroups/activegroups.html",
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/activegroups/bundles/default.properties",
-            "name": "Most active groups",
-            "description": "Most active groups"
+            "description": "Most active groups",
+            "name": "Most active groups"
         }
     }
+    "id": "activegroups",
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/activegroups/activegroups.html"
 }

--- a/devwidgets/addarea/config.json
+++ b/devwidgets/addarea/config.json
@@ -4,15 +4,15 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/addarea/bundles/default.properties",
-            "name": "Add area widget",
-            "description":"Add area widget"
+            "description": "Add area widget"
+            "name": "Add area widget"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/addarea/bundles/es_ES.properties"
         }
     },
     "id": "addarea",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/addarea/addarea.html",
+    "url": "/devwidgets/addarea/addarea.html"
 }

--- a/devwidgets/addpeople/config.json
+++ b/devwidgets/addpeople/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"addpeople",
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/addpeople/bundles/default.properties",
-            "name": "Add people",
-            "description":"Add people"
+            "description": "Add people",
+            "name": "Add people"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/addpeople/bundles/es_ES.properties"
         }
     },
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/addpeople/addpeople.html"
+    "id": "addpeople",
+    "type": "core",
+    "url": "/devwidgets/addpeople/addpeople.html"
 }

--- a/devwidgets/addpeoplegroups/config.json
+++ b/devwidgets/addpeoplegroups/config.json
@@ -1,14 +1,14 @@
 {
-    "id":"addpeoplegroups",
-    "hasSettings":false,
-    "type":"sakai",
-    "enabled":true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/addpeoplegroups/bundles/default.properties",
-            "name":"addpeoplegroups",
-            "description":"Adds people or groups as a member on groups"
+            "description": "Adds people or groups as a member on groups",
+            "name": "addpeoplegroups"
         }
     },
-    "url":"/devwidgets/addpeoplegroups/addpeoplegroups.html"
+    "id": "addpeoplegroups",
+    "type": "sakai",
+    "url": "/devwidgets/addpeoplegroups/addpeoplegroups.html"
 }

--- a/devwidgets/addtocontacts/config.json
+++ b/devwidgets/addtocontacts/config.json
@@ -1,21 +1,21 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/addtocontacts/bundles/default.properties",
-            "name":"Add a contact",
-            "description":"Add a contact"
+            "description": "Add a contact",
+            "name": "Add a contact"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/addtocontacts/bundles/es_ES.properties"
         },
         "zh_CN": {
             "bundle": "/devwidgets/addtocontacts/bundles/zh_CN.properties",
-            "name": "\u901A\u77E5\u5728\u901A\u77E5\u6E05\u5355\u91CC\u5C06\u5982\u4F55\u663E\u793A",
-            "description":"\u901A\u77E5\u5728\u901A\u77E5\u6E05\u5355\u91CC\u5C06\u5982\u4F55\u663E\u793A"
+            "description": "\u901A\u77E5\u5728\u901A\u77E5\u6E05\u5355\u91CC\u5C06\u5982\u4F55\u663E\u793A",
+            "name": "\u901A\u77E5\u5728\u901A\u77E5\u6E05\u5355\u91CC\u5C06\u5982\u4F55\u663E\u793A"    
         }
     },
-    "id":"addtocontacts",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/addtocontacts/addtocontacts.html"
+    "id": "addtocontacts",
+    "type": "core",
+    "url": "/devwidgets/addtocontacts/addtocontacts.html"
 }

--- a/devwidgets/allcategories/config.json
+++ b/devwidgets/allcategories/config.json
@@ -5,11 +5,11 @@
         "default": {
             "bundle": "/devwidgets/allcategories/bundles/default.properties",
             "name": "All categories widget",
-            "description":"All categories widget"
+            "description": "All categories widget"
         }
     },
     "id": "allcategories",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/allcategories/allcategories.html",
+    "url": "/devwidgets/allcategories/allcategories.html"
 }

--- a/devwidgets/areapermissions/config.json
+++ b/devwidgets/areapermissions/config.json
@@ -4,15 +4,15 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/areapermissions/bundles/default.properties",
-            "name": "Area permissions",
-            "description":"Area permissions"
+            "description": "Area permissions",
+            "name": "Area permissions"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/areapermissions/bundles/es_ES.properties"
         }
     },
     "id": "areapermissions",
     "personalportal": false,
     "type": "core",
-    "url": "/devwidgets/areapermissions/areapermissions.html",
+    "url": "/devwidgets/areapermissions/areapermissions.html"
 }

--- a/devwidgets/assignlocation/config.json
+++ b/devwidgets/assignlocation/config.json
@@ -1,17 +1,17 @@
 {
+    "enabled": true,
     "hasSettings": false,
-    "id": "assignlocation",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/assignlocation/bundles/default.properties",
-            "name": "Assign location",
-            "description": "Assign a directory location to an entity"
+            "description": "Assign a directory location to an entity",
+            "name": "Assign location"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/assignlocation/bundles/es_ES.properties"
         }
     },
-    "type":"core",
-    "enabled":true,
+    "id": "assignlocation",
+    "type": "core",
     "url": "/devwidgets/assignlocation/assignlocation.html"
 }

--- a/devwidgets/basiclti/config.json
+++ b/devwidgets/basiclti/config.json
@@ -1,16 +1,16 @@
 {
-    "sakaidocs": true,
+    "enabled": true,
     "hasSettings": true,
-    "id":"basiclti",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/basiclti/bundles/default.properties",
-            "name":"Basic LTI",
-            "description":"Basic LTI widget"
+            "description": "Basic LTI widget",
+            "name": "Basic LTI"
         }
     },
-    "img":"/devwidgets/basiclti/images/basiclti.png",
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/basiclti/basiclti.html"
+    "id": "basiclti",
+    "img": "/devwidgets/basiclti/images/basiclti.png",
+    "sakaidocs": true,
+    "type": "sakai",
+    "url": "/devwidgets/basiclti/basiclti.html"
 }

--- a/devwidgets/branding/config.json
+++ b/devwidgets/branding/config.json
@@ -1,13 +1,13 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/branding/bundles/default.properties",
-            "name":"branding",
-            "description":"branding"
+            "description": "branding",
+            "name": "branding"
         }
     },
-    "id":"branding",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/branding/branding.html"
+    "id": "branding",
+    "type": "core",
+    "url": "/devwidgets/branding/branding.html"
 }

--- a/devwidgets/captcha/config.json
+++ b/devwidgets/captcha/config.json
@@ -1,13 +1,13 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/captcha/bundles/default.properties",
-            "name": "Captcha widget",
-            "description": "Display a captcha widget"
+            "description": "Display a captcha widget",
+            "name": "Captcha widget"
         }
     },
-    "id":"captcha",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/captcha/captcha.html"
+    "id": "captcha",
+    "type": "core",
+    "url": "/devwidgets/captcha/captcha.html"
 }

--- a/devwidgets/carousel/config.json
+++ b/devwidgets/carousel/config.json
@@ -4,15 +4,15 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/carousel/bundles/default.properties",
-            "name": "Carousel",
-            "description":"Carousel widget"
+            "description": "Carousel widget",
+            "name": "Carousel"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/carousel/bundles/es_ES.properties"
         }
     },
     "id": "carousel",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/carousel/carousel.html",
+    "url": "/devwidgets/carousel/carousel.html"
 }

--- a/devwidgets/categories/config.json
+++ b/devwidgets/categories/config.json
@@ -4,15 +4,15 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/categories/bundles/default.properties",
-            "name": "Categories widget",
-            "description":"Categories widget"
+            "description": "Categories widget",
+            "name": "Categories widget"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/categories/bundles/es_ES.properties"
         }
     },
     "id": "categories",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/categories/categories.html",
+    "url": "/devwidgets/categories/categories.html"
 }

--- a/devwidgets/changepic/config.json
+++ b/devwidgets/changepic/config.json
@@ -1,11 +1,12 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/changepic/bundles/default.properties",
-            "name":"Change profile picture",
-            "description":"Change profile picture"
+            "description": "Change profile picture",
+            "name": "Change profile picture"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/changepic/bundles/es_ES.properties"
         },
         "en_US": {
@@ -15,8 +16,7 @@
             "bundle": "/devwidgets/changepic/bundles/zh_CN.properties"
         }
     },
-    "id":"changepic",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/changepic/changepic.html"
+    "id": "changepic",
+    "type": "core",
+    "url": "/devwidgets/changepic/changepic.html"
 }

--- a/devwidgets/collectionviewer/config.json
+++ b/devwidgets/collectionviewer/config.json
@@ -1,19 +1,19 @@
 {
     "enabled": true,
+    "hashParams": ["ls", "so"],
     "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/collectionviewer/bundles/default.properties",
-            "name": "Collections Viewer",
-            "description":"Displays a collection through different views"
+            "description": "Displays a collection through different views",
+            "name": "Collections Viewer"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/collectionviewer/bundles/es_ES.properties"
         }
     },
     "id": "collectionviewer",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/collectionviewer/collectionviewer.html",
-    "hashParams": ["ls", "so"]
+    "url": "/devwidgets/collectionviewer/collectionviewer.html"
 }

--- a/devwidgets/comments/config.json
+++ b/devwidgets/comments/config.json
@@ -1,17 +1,17 @@
 {
-    "hasSettings":true,
-    "id":"comments",
+    "enabled": true,
+    "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/comments/bundles/default.properties",
-            "name":"Comment stream",
-            "description":"Comments"
+            "description": "Comments",
+            "name": "Comment stream"
         }
     },
-    "img":"/devwidgets/comments/images/comments.png",
+    "id": "comments",
+    "img": "/devwidgets/comments/images/comments.png",
     "imghover": "/devwidgets/comments/images/comments_hover.png",
-    "type":"sakai",
-    "enabled":true,
     "sakaidocs": true,
-    "url":"/devwidgets/comments/comments.html"
+    "type": "sakai",
+    "url": "/devwidgets/comments/comments.html"
 }

--- a/devwidgets/contacts/config.json
+++ b/devwidgets/contacts/config.json
@@ -1,18 +1,18 @@
 {
+    "enabled": true,
+    "hashParams": ["cq", "cp", "cso", "ls"],
     "i18n": {
         "default": {
             "bundle": "/devwidgets/contacts/bundles/default.properties",
-            "name": "contacts",
-            "description": "Contacts"
+            "description": "Contacts",
+            "name": "contacts"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/contacts/bundles/es_ES.properties"
         }
     },
     "id": "contacts",
-    "personalportal":false,
+    "personalportal": false,
     "type": "sakai",
-    "enabled": true,
-    "url":"/devwidgets/contacts/contacts.html",
-    "hashParams": ["cq", "cp", "cso", "ls"]
+    "url": "/devwidgets/contacts/contacts.html"    
 }

--- a/devwidgets/contentauthoring/config.json
+++ b/devwidgets/contentauthoring/config.json
@@ -1,16 +1,16 @@
 {
-    "id": "contentauthoring",
-    "type": "core",
     "enabled": true,
     "hasSettings": false,
-    "url": "/devwidgets/contentauthoring/contentauthoring.html",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/contentauthoring/bundles/default.properties",
-            "name": "Content Authoring",
-            "description":"Content Authoring"
+            "description": "Content Authoring",
+            "name": "Content Authoring"
         }
     },
+    "id": "contentauthoring",
     "personalportal": false,
-    "sakaidocs": false
+    "sakaidocs": false,
+    "type": "core",
+    "url": "/devwidgets/contentauthoring/contentauthoring.html"
 }

--- a/devwidgets/contentcomments/config.json
+++ b/devwidgets/contentcomments/config.json
@@ -1,18 +1,18 @@
 {
-    "hasSettings":true,
-    "id":"contentcomments",
+    "enabled": true,
+    "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/contentcomments/bundles/default.properties",
-            "name":"Content comments",
-            "description":"Content comments"
+            "description": "Content comments",
+            "name": "Content comments"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/contentcomments/bundles/es_ES.properties"
         }
     },
-    "img":"/devwidgets/contentcomments/images/comments.png",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/contentcomments/contentcomments.html"
+    "id": "contentcomments",
+    "img": "/devwidgets/contentcomments/images/comments.png",
+    "type": "core",
+    "url": "/devwidgets/contentcomments/contentcomments.html"
 }

--- a/devwidgets/contentmetadata/config.json
+++ b/devwidgets/contentmetadata/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"contentmetadata",
-    "type":"core",
-    "enabled":true,
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/contentmetadata/bundles/default.properties",
-            "name": "Content metadata",
-            "description": "Content metadata"
+            "description": "Content metadata",
+            "name": "Content metadata"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/contentmetadata/bundles/es_ES.properties"
         }
     },
-    "url":"/devwidgets/contentmetadata/contentmetadata.html"
+    "id": "contentmetadata",
+    "type": "core",
+    "url": "/devwidgets/contentmetadata/contentmetadata.html"
 }

--- a/devwidgets/contentpermissions/config.json
+++ b/devwidgets/contentpermissions/config.json
@@ -1,17 +1,17 @@
 {
+    "enabled": true,
     "hasSettings": false,
-    "id": "contentpermissions",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/contentpermissions/bundles/default.properties",
-            "name": "Content permissions",
-            "description":"Content permissions widget"
+            "description": "Content permissions widget"
+            "name": "Content permissions"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/contentpermissions/bundles/es_ES.properties"
         }
     },
-    "type":"core",
-    "enabled":true,
+    "id": "contentpermissions",
+    "type": "core",
     "url": "/devwidgets/contentpermissions/contentpermissions.html"
 }

--- a/devwidgets/contentpreview/config.json
+++ b/devwidgets/contentpreview/config.json
@@ -1,14 +1,14 @@
 {
-    "id":"contentpreview",
-    "hasSettings":false,
-    "type":"core",
-    "enabled":true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/contentpreview/bundles/default.properties",
-            "name":"Content preview",
-            "description":"Content preview"
+            "description": "Content preview",
+            "name": "Content preview"
         }
     },
-    "url":"/devwidgets/contentpreview/contentpreview.html"
+    "id": "contentpreview",
+    "type": "core",
+    "url": "/devwidgets/contentpreview/contentpreview.html"
 }

--- a/devwidgets/createpage/config.json
+++ b/devwidgets/createpage/config.json
@@ -1,13 +1,13 @@
 {
-    "id": "createpage",
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/createpage/bundles/default.properties",
-            "name": "Create page",
-            "description": "Create page widget"
+            "description": "Create page widget",
+            "name": "Create page"
         }
     },
-    "type":"core",
-    "enabled":true,
+    "id": "createpage",
+    "type": "core",
     "url": "/devwidgets/createpage/createpage.html"
 }

--- a/devwidgets/dashboard/config.json
+++ b/devwidgets/dashboard/config.json
@@ -1,18 +1,18 @@
 {
-    "hasSettings":true,
-    "id":"dashboard",
+    "enabled": true,
+    "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/dashboard/bundles/default.properties",
-            "name":"Dashboard",
-            "description":"Dashboard"
+            "description": "Dashboard"
+            "name": "Dashboard"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/dashboard/bundles/es_ES.properties"
         }
     },
-    "img":"/devwidgets/comments/images/comments.png",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/dashboard/dashboard.html"
+    "id": "dashboard",
+    "img": "/devwidgets/comments/images/comments.png",
+    "type": "core",
+    "url": "/devwidgets/dashboard/dashboard.html"
 }

--- a/devwidgets/dashboardactivity/config.json
+++ b/devwidgets/dashboardactivity/config.json
@@ -4,8 +4,8 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/dashboardactivity/bundles/default.properties",
-            "name": "Dashboard Activity",
-            "description":"Shows activity on the users dashboard"
+            "description": "Shows activity on the users dashboard",
+            "name": "Dashboard Activity"
         }
     },
     "id": "dashboardactivity",

--- a/devwidgets/deletecontent/config.json
+++ b/devwidgets/deletecontent/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"deletecontent",
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/deletecontent/bundles/default.properties",
-            "name": "Delete content",
-            "description":"Delete content widget"
+            "description": "Delete content widget",
+            "name": "Delete content"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/deletecontent/bundles/es_ES.properties"
         }
     },
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/deletecontent/deletecontent.html"
+    "id": "deletecontent",
+    "type": "core",
+    "url": "/devwidgets/deletecontent/deletecontent.html"
 }

--- a/devwidgets/deletegroup/config.json
+++ b/devwidgets/deletegroup/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"deletegroup",
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/deletegroup/bundles/default.properties",
             "name": "Delete group",
-            "description":"Delete group widget"
+            "description": "Delete group widget"
         },
         "es_ES": { 
             "bundle": "/devwidgets/deletegroup/bundles/es_ES.properties"
         }
     },
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/deletegroup/deletegroup.html"
+    "id": "deletegroup",
+    "type": "core",
+    "url": "/devwidgets/deletegroup/deletegroup.html"
 }

--- a/devwidgets/discussion/config.json
+++ b/devwidgets/discussion/config.json
@@ -1,26 +1,26 @@
 {
-    "id":"discussion",
-    "img":"/devwidgets/discussion/images/discussion.png",
-    "imghover":"/devwidgets/discussion/images/discussion_hover.png",
+    "enabled": true,
+    "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/discussion/bundles/default.properties",
-            "name": "Discussion forum",
-            "description":"Discussion widget"
+            "description": "Discussion widget",
+            "name": "Discussion forum"
         },
         "en_US": {
             "bundle": "/devwidgets/discussion/bundles/en_US.properties"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/discussion/bundles/es_ES.properties"
         },
         "zh_CN": {
             "bundle": "/devwidgets/discussion/bundles/zh_CN.properties"
         }
     },
-    "hasSettings": true,
-    "type":"sakai",
-    "enabled":true,
+    "id": "discussion",
+    "img": "/devwidgets/discussion/images/discussion.png",
+    "imghover": "/devwidgets/discussion/images/discussion_hover.png",
     "sakaidocs": true,
-    "url":"/devwidgets/discussion/discussion.html"
+    "type": "sakai",
+    "url": "/devwidgets/discussion/discussion.html"
 }

--- a/devwidgets/displayprofilesection/config.json
+++ b/devwidgets/displayprofilesection/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"displayprofilesection",
-    "type":"core",
-    "enabled":true,
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/displayprofilesection/bundles/default.properties",
-            "name": "Profile section",
-            "description": "Show a profile section"
+            "description": "Show a profile section",
+            "name": "Profile section"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/displayprofilesection/bundles/es_ES.properties"
         }
     },
-    "url":"/devwidgets/displayprofilesection/displayprofilesection.html"
+    "id": "displayprofilesection",
+    "type": "core",
+    "url": "/devwidgets/displayprofilesection/displayprofilesection.html"
 }

--- a/devwidgets/documentviewer/config.json
+++ b/devwidgets/documentviewer/config.json
@@ -1,14 +1,14 @@
 {
-    "id":"documentviewer",
-    "hasSettings":false,
-    "type":"core",
-    "enabled":true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/documentviewer/bundles/default.properties",
-            "name":"Document viewer",
-            "description":"Document viewer"
+            "description": "Document viewer",
+            "name": "Document viewer"
         }
     },
-    "url":"/devwidgets/documentviewer/documentviewer.html"
+    "id": "documentviewer",
+    "type": "core",
+    "url": "/devwidgets/documentviewer/documentviewer.html"
 }

--- a/devwidgets/embedcontent/config.json
+++ b/devwidgets/embedcontent/config.json
@@ -1,25 +1,25 @@
 {
-    "hasSettings": true,
-    "sakaidocs": false,
-    "id":"embedcontent",
-    "i18n": {
-        "default": {
-            "bundle": "/devwidgets/embedcontent/bundles/default.properties",
-            "name": "Files and documents",
-            "description": "Embed content on a page"
-        }
-    },
     "defaultOptions": {
         "embedmethod": "original",
         "layout": "vertical",
-        "showName": false,
         "showDetails": false,
-        "showDownload": false
+        "showDownload": false,
+        "showName": false
     },
-    "img":"/devwidgets/embedcontent/images/content.png",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/embedcontent/embedcontent.html",
+    "enabled": true,
+    "hasSettings": true,
+    "i18n": {
+        "default": {
+            "bundle": "/devwidgets/embedcontent/bundles/default.properties",
+            "description": "Embed content on a page",
+            "name": "Files and documents"
+        }
+    },
+    "id": "embedcontent",
+    "img": "/devwidgets/embedcontent/images/content.png",
+    "indexFields": ["title", "description"],
+    "sakaidocs": false,
     "settingsWidth": 785,
-    "indexFields": ["title", "description"]
+    "type": "core",
+    "url": "/devwidgets/embedcontent/embedcontent.html"
 }

--- a/devwidgets/entity/config.json
+++ b/devwidgets/entity/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"entity",
-    "url":"/devwidgets/entity/entity.html",
-    "type":"core",
-    "enabled":true,
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/entity/bundles/default.properties",
-            "name": "Entity widget",
-            "description": "Entity widget"
+            "description": "Entity widget",
+            "name": "Entity widget"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/entity/bundles/es_ES.properties"
         }
     }
+    "id": "entity",
+    "type": "core",
+    "url": "/devwidgets/entity/entity.html"
 }

--- a/devwidgets/faceted/config.json
+++ b/devwidgets/faceted/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"faceted",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/faceted/faceted.html",
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/faceted/bundles/default.properties",
-            "name": "Faceted",
-            "description": "Faceted"
+            "description": "Faceted",
+            "name": "Faceted"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/faceted/bundles/es_ES.properties"
         }
     }
+    "id": "faceted",
+    "type": "core",
+    "url": "/devwidgets/faceted/faceted.html"
 }

--- a/devwidgets/featuredcontent/config.json
+++ b/devwidgets/featuredcontent/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/featuredcontent/bundles/default.properties",
-            "name": "Featured content widget",
-            "description":"Featured content widget"
+            "description": "Featured content widget",
+            "name": "Featured content widget"
         }
     },
     "id": "featuredcontent",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/featuredcontent/featuredcontent.html",
+    "url": "/devwidgets/featuredcontent/featuredcontent.html"
 }

--- a/devwidgets/featuredpeople/config.json
+++ b/devwidgets/featuredpeople/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/featuredpeople/bundles/default.properties",
-            "name": "Featured people widget",
-            "description":"Featured people widget"
+            "description": "Featured people widget",
+            "name": "Featured people widget"
         }
     },
     "id": "featuredpeople",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/featuredpeople/featuredpeople.html",
+    "url": "/devwidgets/featuredpeople/featuredpeople.html"
 }

--- a/devwidgets/featuredworlds/config.json
+++ b/devwidgets/featuredworlds/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/featuredworlds/bundles/default.properties",
-            "name": "Featured worlds widget",
-            "description":"Featured worlds widget"
+            "description": "Featured worlds widget",
+            "name": "Featured worlds widget"
         }
     },
     "id": "featuredworlds",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/featuredworlds/featuredworlds.html",
+    "url": "/devwidgets/featuredworlds/featuredworlds.html"
 }

--- a/devwidgets/footer/config.json
+++ b/devwidgets/footer/config.json
@@ -1,9 +1,10 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/footer/bundles/default.properties",
-            "name": "Dynamic footer",
-            "description": "Dynamic Footer with Debug Info"
+            "description": "Dynamic Footer with Debug Info",
+            "name": "Dynamic footer"
         },
         "en_US": {
             "bundle": "/devwidgets/footer/bundles/en_US.properties"
@@ -15,8 +16,7 @@
             "bundle": "/devwidgets/footer/bundles/zh_CN.properties"
         }
     },
-    "id":"footer",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/footer/footer.html"
+    "id": "footer",
+    "type": "core",
+    "url": "/devwidgets/footer/footer.html"
 }

--- a/devwidgets/ggadget/config.json
+++ b/devwidgets/ggadget/config.json
@@ -1,26 +1,26 @@
 {
-    "sakaidocs": true,
-    "id":"ggadget",
-    "i18n": {
-        "default": {
-            "bundle": "/devwidgets/ggadget/bundles/default.properties",
-            "name": "Google Gadget",
-            "description":"Embed Google Gadgets in your page or dashboard"
-        }
-    },
-    "img":"/devwidgets/ggadget/images/ggadget.png",
-    "hasSettings": true,
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/ggadget/ggadget.html",
     "defaultConfiguration": {
         "ggadget": {
             "border_color": "cccccc",
-	        "border_size": 0,
+            "border_size": 0,
             "height": 350,
             "url": "http://www.gmodules.com/ig/ifr?url=http://static.die.net/moon/gadget.xml&up_size=medium&up_info=1&up_date=0&synd=open&w=320&h=170&title=Moon+Phase&border=%23ffffff%7C3px%2C1px+solid+%23999999&output=html",
-	        "width": 600,
+            "width": 600,
             "width_unit": "px"
         }
-    }
+    },
+    "enabled": true,
+    "hasSettings": true,
+    "i18n": {
+        "default": {
+            "bundle": "/devwidgets/ggadget/bundles/default.properties",
+            "description": "Embed Google Gadgets in your page or dashboard",
+            "name": "Google Gadget"
+        }
+    },
+    "id": "ggadget",
+    "img": "/devwidgets/ggadget/images/ggadget.png",
+    "sakaidocs": true,
+    "type": "sakai",
+    "url": "/devwidgets/ggadget/ggadget.html"
 }

--- a/devwidgets/googlemaps/config.json
+++ b/devwidgets/googlemaps/config.json
@@ -1,11 +1,14 @@
 {
-    "sakaidocs": true,
+    "defaultLat":52.2025441,
+    "defaultLng":0.1312368,
+    "defaultZoom":8,
+    "enabled": true,
     "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/googlemaps/bundles/default.properties",
-            "name": "Google map",
-            "description":"Google maps"
+            "description": "Google maps",
+            "name": "Google map"
         },
         "en_US": {
             "bundle": "/devwidgets/googlemaps/bundles/en_US.properties"
@@ -14,14 +17,11 @@
             "bundle": "/devwidgets/googlemaps/bundles/zh_CN.properties"
         }
     },
-    "id":"googlemaps",
-    "img":"/devwidgets/googlemaps/images/googlemaps.png",
-    "imghover":"/devwidgets/googlemaps/images/googlemaps_hover.png",
-    "type":"sakai",
-    "enabled":true,
-    "defaultLat":52.2025441,
-    "defaultLng":0.1312368,
-    "defaultZoom":8,
-    "url":"/devwidgets/googlemaps/googlemaps.html",
-    "indexFields": ["mapinput", "maphtml"]
+    "id": "googlemaps",
+    "img": "/devwidgets/googlemaps/images/googlemaps.png",
+    "imghover": "/devwidgets/googlemaps/images/googlemaps_hover.png",
+    "indexFields": ["mapinput", "maphtml"],
+    "sakaidocs": true,
+    "type": "sakai",
+    "url": "/devwidgets/googlemaps/googlemaps.html"
 }

--- a/devwidgets/helloworld/config.json
+++ b/devwidgets/helloworld/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/helloworld/bundles/default.properties",
-            "name": "Hello world",
-            "description":"Sakai OAE widget SDK demonstration widget"
+            "description": "Sakai OAE widget SDK demonstration widget",
+            "name": "Hello world"
         }
     },
     "id": "helloworld",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/helloworld/helloworld.html",
+    "url": "/devwidgets/helloworld/helloworld.html"
 }

--- a/devwidgets/help/config.json
+++ b/devwidgets/help/config.json
@@ -1,14 +1,14 @@
 {
-    "id":"help",
-    "hasSettings":false,
-    "type":"sakai",
-    "enabled":true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/help/bundles/default.properties",
-            "name":"Help",
-            "description":"Help"
+            "description": "Help",
+            "name": "Help"
         }
     },
-    "url":"/devwidgets/help/help.html"
+    "id": "help",
+    "type": "sakai",
+    "url": "/devwidgets/help/help.html"
 }

--- a/devwidgets/htmlblock/config.json
+++ b/devwidgets/htmlblock/config.json
@@ -1,17 +1,17 @@
 {
-    "id": "htmlblock",
-    "type": "contrib",
     "enabled": false,
     "hasSettings": false,
-    "url": "/devwidgets/htmlblock/htmlblock.html",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/htmlblock/bundles/default.properties",
-            "name": "HTML Block",
-            "description":"Block of HTML"
+            "description": "Block of HTML",
+            "name": "HTML Block"
         }
     },
+    "id": "htmlblock",
+    "indexFields": ["content"],
     "personalportal": false,
     "sakaidocs": false,
-    "indexFields": ["content"]
+    "type": "contrib",
+    "url": "/devwidgets/htmlblock/htmlblock.html"
 }

--- a/devwidgets/inbox/config.json
+++ b/devwidgets/inbox/config.json
@@ -1,18 +1,18 @@
 {
+    "enabled": true,
+    "hashParams": ["message", "newmessage", "reply", "iq"],
     "i18n": {
         "default": {
             "bundle": "/devwidgets/inbox/bundles/default.properties",
-            "name": "inbox",
-            "description": "Inbox"
+            "description": "Inbox",
+            "name": "inbox"
         },
         "es_ES": { 
             "bundle": "/devwidgets/inbox/bundles/es_ES.properties"
         }
     },
     "id": "inbox",
-    "personalportal":false,
+    "personalportal": false,
     "type": "sakai",
-    "enabled": true,
-    "url":"/devwidgets/inbox/inbox.html",
-    "hashParams": ["message", "newmessage", "reply", "iq"]
+    "url": "/devwidgets/inbox/inbox.html"
 }

--- a/devwidgets/inserter/config.json
+++ b/devwidgets/inserter/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/inserter/bundles/default.properties",
-            "name": "Inserter",
-            "description":"Insert content from collections"
+            "description": "Insert content from collections",
+            "name": "Inserter"
         }
     },
     "id": "inserter",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/inserter/inserter.html",
+    "url": "/devwidgets/inserter/inserter.html"
 }

--- a/devwidgets/inserterbar/config.json
+++ b/devwidgets/inserterbar/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/inserterbar/bundles/default.properties",
-            "name": "Inserter Bar",
-            "description":"Content Authoring Inserter Bar"
+            "description": "Content Authoring Inserter Bar",
+            "name": "Inserter Bar"
         }
     },
     "id": "inserterbar",
     "personalportal": false,
     "type": "core",
-    "url": "/devwidgets/inserterbar/inserterbar.html",
+    "url": "/devwidgets/inserterbar/inserterbar.html"
 }

--- a/devwidgets/institutionalskinning/config.json
+++ b/devwidgets/institutionalskinning/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/institutionalskinning/bundles/default.properties",
-            "name": "Institutional skinning",
-            "description":"Institutional skinning widget"
+            "description": "Institutional skinning widget",
+            "name": "Institutional skinning"
         }
     },
     "id": "institutionalskinning",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/institutionalskinning/institutionalskinning.html",
+    "url": "/devwidgets/institutionalskinning/institutionalskinning.html"
 }

--- a/devwidgets/joingroup/config.json
+++ b/devwidgets/joingroup/config.json
@@ -1,17 +1,17 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/joingroup/bundles/default.properties",
-            "name": "Join group overlay",
-            "description": "Join group overlay"
+            "description": "Join group overlay",
+            "name": "Join group overlay"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/joingroup/bundles/es_ES.properties"
         }
     },
     "id": "joingroup",
-    "personalportal":false,
+    "personalportal": false,
     "type": "sakai",
-    "enabled": true,
-    "url":"/devwidgets/joingroup/joingroup.html"
+    "url": "/devwidgets/joingroup/joingroup.html"
 }

--- a/devwidgets/joinrequestbuttons/config.json
+++ b/devwidgets/joinrequestbuttons/config.json
@@ -1,15 +1,15 @@
 {
-    "id":"joinrequestbuttons",
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/joinrequestbuttons/bundles/default.properties",
-            "name":"Join request buttons",
-            "description":"Display join/leave/pending buttons to match the context"
+            "description": "Display join/leave/pending buttons to match the context",
+            "name": "Join request buttons",
         }
     },
-    "personalportal":false,
-    "hasSettings":false,
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/joinrequestbuttons/joinrequestbuttons.html"
+    "id": "joinrequestbuttons",
+    "personalportal": false,
+    "type": "core",
+    "url": "/devwidgets/joinrequestbuttons/joinrequestbuttons.html"
 }

--- a/devwidgets/joinrequests/config.json
+++ b/devwidgets/joinrequests/config.json
@@ -1,18 +1,18 @@
 {
-    "id":"joinrequests",
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/joinrequests/bundles/default.properties",
-            "name":"Join requests",
-            "description":"Manage join requests for a specific group"
+            "description": "Manage join requests for a specific group",
+            "name": "Join requests"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/joinrequests/bundles/es_ES.properties"
         }
     },
-    "personalportal":false,
-    "hasSettings":false,
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/joinrequests/joinrequests.html"
+    "id": "joinrequests",
+    "personalportal": false,
+    "type": "core",
+    "url": "/devwidgets/joinrequests/joinrequests.html"
 }

--- a/devwidgets/lhnavigation/config.json
+++ b/devwidgets/lhnavigation/config.json
@@ -1,19 +1,19 @@
 {
     "enabled": true,
+    "hashParams": ["newPageMode", "l"],
     "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/lhnavigation/bundles/default.properties",
-            "name": "Left hand navigation",
-            "description":"Left hand navigation widget"
+            "description": "Left hand navigation widget",
+            "name": "Left hand navigation"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/lhnavigation/bundles/es_ES.properties"
         }
     },
     "id": "lhnavigation",
     "personalportal": false,
     "type": "core",
-    "url": "/devwidgets/lhnavigation/lhnavigation.html",
-    "hashParams": ["newPageMode", "l"]
+    "url": "/devwidgets/lhnavigation/lhnavigation.html"
 }

--- a/devwidgets/listgeneral/config.json
+++ b/devwidgets/listgeneral/config.json
@@ -1,14 +1,14 @@
 {
+    "enabled": true,
     "hasSettings": false,
-    "id": "listgeneral",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/listgeneral/bundles/default.properties",
-            "name": "General lister",
-            "description":"General space, site and content lister widget"
+            "description": "General space, site and content lister widget",
+            "name": "General lister"
         }
     },
-    "type":"core",
-    "enabled":true,
+    "id": "listgeneral",
+    "type": "core",
     "url": "/devwidgets/listgeneral/listgeneral.html"
 }

--- a/devwidgets/listpeople/config.json
+++ b/devwidgets/listpeople/config.json
@@ -1,15 +1,15 @@
 {
+    "enabled": true,
     "hasSettings": false,
-    "id": "listpeople",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/listpeople/bundles/default.properties",
-            "name": "People lister",
-            "description":"General people lister widget"
+            "description": "General people lister widget",
+            "name": "People lister"
         }
     },
-    "url": "/devwidgets/listpeople/listpeople.html",
-    "type":"core",
-    "enabled":true,
+    "id": "listpeople",
     "subNameInfoContent": "mimeTypeDescripton"
+    "type": "core",
+    "url": "/devwidgets/listpeople/listpeople.html"
 }

--- a/devwidgets/listpeopleinnode/config.json
+++ b/devwidgets/listpeopleinnode/config.json
@@ -1,14 +1,14 @@
 {
+    "enabled": true,
     "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/listpeopleinnode/bundles/default.properties",
-            "name": "listpeopleinnode",
-            "description": "Browsing people in this node of the directory"
+            "description": "Browsing people in this node of the directory",
+            "name": "listpeopleinnode"
         }
     },
     "id": "listpeopleinnode",
-    "type":"core",
-    "enabled":true,
+    "type": "core",
     "url": "/devwidgets/listpeopleinnode/listpeopleinnode.html"
 }

--- a/devwidgets/listpeoplewrappergroup/config.json
+++ b/devwidgets/listpeoplewrappergroup/config.json
@@ -1,15 +1,15 @@
 {
+    "enabled": true,
+    "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/listpeoplewrappergroup/bundles/default.properties",
-            "name": "Member/content list",
-            "description": "Group lister"
+            "description": "Group lister",
+            "name": "Member/content list"
         }
     },
-    "hasSettings": true,
     "id": "listpeoplewrappergroup",
-    "img":"/devwidgets/listpeoplewrappergroup/images/icon.png",
-    "type":"core",
-    "enabled":true,
+    "img": "/devwidgets/listpeoplewrappergroup/images/icon.png",
+    "type": "core",
     "url": "/devwidgets/listpeoplewrappergroup/listpeoplewrappergroup.html"
 }

--- a/devwidgets/login/config.json
+++ b/devwidgets/login/config.json
@@ -1,14 +1,14 @@
 {
+    "enabled": true,
+    "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/login/bundles/default.properties",
-            "name": "Login",
-            "description":"Login"
+            "description": "Login",
+            "name": "Login"
         }
     },
-    "id":"login",
-    "hasSettings":true,
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/login/login.html"
+    "id": "login",
+    "type": "core",
+    "url": "/devwidgets/login/login.html"
 }

--- a/devwidgets/mycontacts/config.json
+++ b/devwidgets/mycontacts/config.json
@@ -1,11 +1,10 @@
 {
-    "id":"mycontacts",
-    "multipleinstance": false,
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/mycontacts/bundles/default.properties",
-            "name": "My contacts",
-            "description":"My contacts"
+            "description": "My contacts",
+            "name": "My contacts"
         },
         "en_US": {
             "bundle": "/devwidgets/mycontacts/bundles/en_US.properties"
@@ -14,8 +13,9 @@
             "bundle": "/devwidgets/mycontacts/bundles/zh_CN.properties"
         }
     },
-    "personalportal":true,
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/mycontacts/mycontacts.html"
+    "id": "mycontacts",
+    "multipleinstance": false,
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/mycontacts/mycontacts.html"
 }

--- a/devwidgets/mycontent/config.json
+++ b/devwidgets/mycontent/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"mycontent",
+    "deletable": true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/mycontent/bundles/default.properties",
-            "name":"My content",
-            "description":"My content"
+            "description": "My content",
+            "name": "My content"
         }
     },
-    "personalportal":true,
-    "hasSettings":false,
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/mycontent/mycontent.html",
-    "deletable":true
+    "id": "mycontent",
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/mycontent/mycontent.html"
 }

--- a/devwidgets/mygroups/config.json
+++ b/devwidgets/mygroups/config.json
@@ -1,9 +1,11 @@
 {
+    "deletable": true,
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/mygroups/bundles/default.properties",
-            "name": "My memberships",
-            "description": "My memberships"
+            "description": "My memberships",
+            "name": "My memberships"
         },
         "en_US": {
             "bundle": "/devwidgets/mygroups/bundles/en_US.properties"
@@ -12,10 +14,8 @@
             "bundle": "/devwidgets/mygroups/bundles/zh_CN.properties"
         }
     },
-    "id":"mygroups",
-    "personalportal":true,
-    "deletable": true,
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/mygroups/mygroups.html"
+    "id": "mygroups",
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/mygroups/mygroups.html"
 }

--- a/devwidgets/mylibrary/config.json
+++ b/devwidgets/mylibrary/config.json
@@ -1,19 +1,19 @@
 {
     "enabled": true,
+    "hashParams": ["ls", "lq"],
     "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/mylibrary/bundles/default.properties",
-            "name": "My library",
-            "description":"View and manage a user's library items"
+            "description": "View and manage a user's library items",
+            "name": "My library"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/mylibrary/bundles/es_ES.properties"
         }
     },
     "id": "mylibrary",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/mylibrary/mylibrary.html",
-    "hashParams": ["ls", "lq"]
+    "url": "/devwidgets/mylibrary/mylibrary.html"    
 }

--- a/devwidgets/mymemberships/config.json
+++ b/devwidgets/mymemberships/config.json
@@ -1,18 +1,18 @@
 {
+    "enabled": true,
+    "hashParams": ["mq", "mp", "mso", "ls"],
     "i18n": {
         "default": {
             "bundle": "/devwidgets/mymemberships/bundles/default.properties",
-            "name": "My memberships",
-            "description": "My memberships"
+            "description": "My memberships",
+            "name": "My memberships"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/mymemberships/bundles/es_ES.properties"
         }
     },
     "id": "mymemberships",
-    "personalportal":false,
+    "personalportal": false,
     "type": "sakai",
-    "enabled": true,
-    "url":"/devwidgets/mymemberships/mymemberships.html",
-    "hashParams": ["mq", "mp", "mso", "ls"]
+    "url": "/devwidgets/mymemberships/mymemberships.html"
 }

--- a/devwidgets/mysakai2/config.json
+++ b/devwidgets/mysakai2/config.json
@@ -1,21 +1,21 @@
 {
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/mysakai2/bundles/default.properties",
-            "name":" My Sakai 2 favorites",
-            "description":" My Sakai 2 favorites"
+            "name": " My Sakai 2 favorites",
+            "description": " My Sakai 2 favorites"
         },
         "en_GB": {
             "bundle": "/devwidgets/mysakai2/bundles/en_GB.properties",
-            "name":"My Sakai 2 favourites",
-            "description":"My Sakai 2 favourites"
+            "name": "My Sakai 2 favourites",
+            "description": "My Sakai 2 favourites"
         }
     },
-    "img":"/devwidgets/mysakai2/images/s2icon.png",
-    "id":"mysakai2",
-    "personalportal":false,
-    "type":"sakai",
-    "enabled":true,
-    "hasSettings":false,
-    "url":"/devwidgets/mysakai2/mysakai2.html"
+    "id": "mysakai2",
+    "img": "/devwidgets/mysakai2/images/s2icon.png",
+    "personalportal": false,
+    "type": "sakai",
+    "url": "/devwidgets/mysakai2/mysakai2.html"
 }

--- a/devwidgets/navigation/config.json
+++ b/devwidgets/navigation/config.json
@@ -1,19 +1,19 @@
 {
+    "enabled": true,
     "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/navigation/bundles/default.properties",
-            "name": "Pages",
-            "description": "Navigate all the pages contained within this group or site"
+            "description": "Navigate all the pages contained within this group or site",
+            "name": "Pages"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/navigation/bundles/es_ES.properties"
         }
     },
     "id": "navigation",
     "img": "/devwidgets/navigation/images/icon.png",
     "showinsidebar": true,
-    "type":"core",
-    "enabled":true,
+    "type": "core",
     "url": "/devwidgets/navigation/navigation.html"
 }

--- a/devwidgets/newaddcontent/config.json
+++ b/devwidgets/newaddcontent/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"newaddcontent",
-    "type":"core",
-    "enabled":true,
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/newaddcontent/bundles/default.properties",
-            "name":"Add resource",
-            "description":"Add resource to a site"
+            "description": "Add resource to a site",
+            "name": "Add resource"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/newaddcontent/bundles/es_ES.properties"
         }
     },
-    "url":"/devwidgets/newaddcontent/newaddcontent.html"
+    "id": "newaddcontent",
+    "type": "core",
+    "url": "/devwidgets/newaddcontent/newaddcontent.html"
 }

--- a/devwidgets/newcreategroup/config.json
+++ b/devwidgets/newcreategroup/config.json
@@ -1,19 +1,19 @@
-{ 
-    "id":"newcreategroup",
+{
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/newcreategroup/bundles/default.properties",
-            "name":"Create group",
-            "description":"Create group"
+            "description": "Create group",
+            "name": "Create group"
         },
         "en_US": {
             "bundle": "/devwidgets/newcreategroup/bundles/en_US.properties"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/newcreategroup/bundles/es_ES.properties"
         }
     },
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/newcreategroup/newcreategroup.html"
+    "id": "newcreategroup",
+    "type": "core",
+    "url": "/devwidgets/newcreategroup/newcreategroup.html"
 }

--- a/devwidgets/newsharecontent/config.json
+++ b/devwidgets/newsharecontent/config.json
@@ -1,22 +1,22 @@
 {
-    "hasSettings": false,
-    "id": "newsharecontent",
-    "i18n": {
-        "default": {
-            "bundle": "/devwidgets/newsharecontent/bundles/default.properties",
-            "name": "Share content",
-            "description":"Share content widget"
-        },
-        "es_ES": { 
-            "bundle": "/devwidgets/newsharecontent/bundles/es_ES.properties"
-        }
-    },
-    "type":"core",
-    "enabled":true,
-    "url": "/devwidgets/newsharecontent/newsharecontent.html",
     "defaultConfiguration": {
         "newsharecontent": {
             "addThisAccountId": "xa-4db72a071927628b"
         }
-    }
+    },
+    "enabled": true,
+    "hasSettings": false,
+    "i18n": {
+        "default": {
+            "bundle": "/devwidgets/newsharecontent/bundles/default.properties",
+            "description": "Share content widget",
+            "name": "Share content"
+        },
+        "es_ES": {
+            "bundle": "/devwidgets/newsharecontent/bundles/es_ES.properties"
+        }
+    },
+    "id": "newsharecontent",
+    "type": "core",
+    "url": "/devwidgets/newsharecontent/newsharecontent.html"
 }

--- a/devwidgets/pagetitle/config.json
+++ b/devwidgets/pagetitle/config.json
@@ -1,17 +1,15 @@
 {
-    "id": "pagetitle",
-    "type": "contrib",
     "enabled": false,
     "hasSettings": false,
-    "url": "/devwidgets/pagetitle/pagetitle.html",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/pagetitle/bundles/default.properties",
-            "name": "Page Title",
-            "description":"Title element"
+            "description": "Title element",
+            "name": "Page Title"
         }
     },
+    "indexFields": ["content"],
     "personalportal": false,
     "sakaidocs": false,
-    "indexFields": ["content"]
+    "url": "/devwidgets/pagetitle/pagetitle.html"
 }

--- a/devwidgets/pageviewer/config.json
+++ b/devwidgets/pageviewer/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/pageviewer/bundles/default.properties",
-            "name": "Page Viewer",
-            "description":"Show single level pages"
+            "description": "Show single level pages",
+            "name": "Page Viewer"
         }
     },
     "id": "pageviewer",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/pageviewer/pageviewer.html",
+    "url": "/devwidgets/pageviewer/pageviewer.html"
 }

--- a/devwidgets/participants/config.json
+++ b/devwidgets/participants/config.json
@@ -1,19 +1,19 @@
 {
     "enabled": false,
+    "hashParams": ["pq", "psb", "ls"],
     "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/participants/bundles/default.properties",
-            "name": "Participants",
-            "description":"List participants of a group"
+            "description": "List participants of a group",
+            "name": "Participants"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/participants/bundles/es_ES.properties"
         }
     },
     "id": "participants",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/participants/participants.html",
-    "hashParams": ["pq", "psb", "ls"]
+    "url": "/devwidgets/participants/participants.html"
 }

--- a/devwidgets/personinfo/config.json
+++ b/devwidgets/personinfo/config.json
@@ -1,14 +1,14 @@
 {
-    "id":"personinfo",
-    "hasSettings":false,
-    "type":"sakai",
-    "enabled":true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/personinfo/bundles/default.properties",
-            "name":"Personinfo",
-            "description":"Overlay that displays person info"
+            "description": "Overlay that displays person info",
+            "name": "Personinfo"
         }
     },
-    "url":"/devwidgets/personinfo/personinfo.html"
+    "id": "personinfo",
+    "type": "sakai",
+    "url": "/devwidgets/personinfo/personinfo.html"
 }

--- a/devwidgets/pickeradvanced/config.json
+++ b/devwidgets/pickeradvanced/config.json
@@ -1,14 +1,14 @@
 {
+    "enabled": true,
     "hasSettings": false,
-    "id": "pickeradvanced",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/pickeradvanced/bundles/default.properties",
-            "name": "Advanced search picker",
-            "description":"Advanced search picker widget"
+            "description": "Advanced search picker widget",
+            "name": "Advanced search picker"
         }
     },
-    "type":"core",
-    "enabled":true,
+    "id": "pickeradvanced",
+    "type": "core",
     "url": "/devwidgets/pickeradvanced/pickeradvanced.html"
 }

--- a/devwidgets/pickeruser/config.json
+++ b/devwidgets/pickeruser/config.json
@@ -1,14 +1,14 @@
 {
+    "enabled": true,
     "hasSettings": false,
-    "id": "pickeruser",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/pickeruser/bundles/default.properties",
-            "name": "People picker",
-            "description":"General people picker widget"
+            "description": "General people picker widget"
+            "name": "People picker"
         }
-    },    
-    "type":"core",
-    "enabled":true,
+    },
+    "id": "pickeruser",   
+    "type": "core",
     "url": "/devwidgets/pickeruser/pickeruser.html"
 }

--- a/devwidgets/poll/config.json
+++ b/devwidgets/poll/config.json
@@ -1,14 +1,14 @@
 {
-    "id":"poll",
-    "img":"/devwidgets/poll/images/poll.png",
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/poll/bundles/default.properties",
-            "name":"Poll",
-            "description":"Poll widget"
+            "description": "Poll widget",
+            "name": "Poll"
         }
     },
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/poll/poll.html"
+    "id": "poll",
+    "img": "/devwidgets/poll/images/poll.png",
+    "type": "sakai",
+    "url": "/devwidgets/poll/poll.html"
 }

--- a/devwidgets/popularcontent/config.json
+++ b/devwidgets/popularcontent/config.json
@@ -1,15 +1,15 @@
 {
-    "personalportal":true,
-    "hasSettings": false,
-    "id": "popularcontent",
-    "type": "sakai",
     "enabled": true,
-    "url":"/devwidgets/popularcontent/popularcontent.html",
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/popularcontent/bundles/default.properties",
-            "name": "Most active content",
-            "description": "Most active content"
+            "description": "Most active content",
+            "name": "Most active content"
         }
     }
+    "id": "popularcontent",
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/popularcontent/popularcontent.html"
 }

--- a/devwidgets/recentactivity/config.json
+++ b/devwidgets/recentactivity/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/recentactivity/bundles/default.properties",
-            "name": "Recent activity widget",
-            "description":"Recent activity widget"
+            "description": "Recent activity widget",
+            "name": "Recent activity widget"
         }
     },
     "id": "recentactivity",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/recentactivity/recentactivity.html",
+    "url": "/devwidgets/recentactivity/recentactivity.html"
 }

--- a/devwidgets/recentchangedcontent/config.json
+++ b/devwidgets/recentchangedcontent/config.json
@@ -1,16 +1,17 @@
 {
-    "id":"recentchangedcontent",
+    "deletable": true
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/recentchangedcontent/bundles/default.properties",
-            "name": "My recent content",
-            "description": "My recent content"
+            "description": "My recent content",
+            "name": "My recent content"
+            
         }
     },
-    "personalportal":true,
-    "hasSettings":false,
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/recentchangedcontent/recentchangedcontent.html",
-    "deletable":true
+    "id": "recentchangedcontent",
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/recentchangedcontent/recentchangedcontent.html"
 }

--- a/devwidgets/recentcontactsnew/config.json
+++ b/devwidgets/recentcontactsnew/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"recentcontactsnew",
+    "deletable": true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/recentcontactsnew/bundles/default.properties",
-            "name": "My recent contacts",
-            "description":"My recent contacts"
+            "description": "My recent contacts",
+            "name": "My recent contacts"
         }
     },
-    "personalportal":true,
-    "hasSettings":false,
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/recentcontactsnew/recentcontactsnew.html",
-    "deletable":true
+    "id": "recentcontactsnew",
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/recentcontactsnew/recentcontactsnew.html"
 }

--- a/devwidgets/recentmemberships/config.json
+++ b/devwidgets/recentmemberships/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"recentmemberships",
+    "deletable": true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/recentmemberships/bundles/default.properties",
-            "name":"My recent memberships",
-            "description":"My recent memberships"
+            "description": "My recent memberships",
+            "name": "My recent memberships"
         }
     },
-    "personalportal":true,
-    "hasSettings":false,
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/recentmemberships/recentmemberships.html",
-    "deletable":true
+    "id": "recentmemberships",
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/recentmemberships/recentmemberships.html"
 }

--- a/devwidgets/recentmessages/config.json
+++ b/devwidgets/recentmessages/config.json
@@ -1,17 +1,17 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/recentmessages/bundles/default.properties",
-            "name": "My recent messages",
-            "description": "My recent messages"
+            "description": "My recent messages",
+            "name": "My recent messages"
         },
         "en_US": {
             "bundle": "/devwidgets/recentmessages/bundles/en_US.properties"
         }
     },
-    "id":"recentmessages",
-    "personalportal":true,
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/recentmessages/recentmessages.html"
+    "id": "recentmessages",
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/recentmessages/recentmessages.html"
 }

--- a/devwidgets/relatedcontent/config.json
+++ b/devwidgets/relatedcontent/config.json
@@ -1,17 +1,17 @@
 {
-    "id":"relatedcontent",
-    "hasSettings":false,
-    "type":"core",
-    "enabled":true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/relatedcontent/bundles/default.properties",
-            "name":"Related content",
-            "description":"Related content"
+            "description": "Related content",
+            "name": "Related content"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/relatedcontent/bundles/es_ES.properties"
         }
     },
-    "url":"/devwidgets/relatedcontent/relatedcontent.html"
+    "id": "relatedcontent",
+    "type": "core",
+    "url": "/devwidgets/relatedcontent/relatedcontent.html"
 }

--- a/devwidgets/remotecontent/config.json
+++ b/devwidgets/remotecontent/config.json
@@ -1,21 +1,4 @@
 {
-    "sakaidocs": false,
-    "i18n": {
-        "default": {
-            "bundle": "/devwidgets/remotecontent/bundles/default.properties",
-            "name":"Remote content",
-            "description":"Remote content"
-        },
-        "en_US": {
-            "bundle": "/devwidgets/remotecontent/bundles/en_US.properties"
-        }
-    },
-    "id":"remotecontent",
-    "img":"/devwidgets/remotecontent/images/remotecontent.png",
-    "hasSettings": true,
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/remotecontent/remotecontent.html",
     "defaultConfiguration": {
         "remotecontent": {
             "border_color": "cccccc",
@@ -25,5 +8,22 @@
             "width": "100",
             "width_unit": "%"
         }
-    }
+    },
+    "enabled": true,
+    "hasSettings": true,
+    "i18n": {
+        "default": {
+            "bundle": "/devwidgets/remotecontent/bundles/default.properties",
+            "description": "Remote content",
+            "name": "Remote content"
+        },
+        "en_US": {
+            "bundle": "/devwidgets/remotecontent/bundles/en_US.properties"
+        }
+    },
+    "id": "remotecontent",
+    "img": "/devwidgets/remotecontent/images/remotecontent.png",
+    "sakaidocs": false,
+    "type": "sakai",
+    "url": "/devwidgets/remotecontent/remotecontent.html"
 }

--- a/devwidgets/rss/config.json
+++ b/devwidgets/rss/config.json
@@ -1,25 +1,4 @@
 {
-    "sakaidocs": true,
-    "hasSettings":true,
-    "id":"rss",
-    "img":"/devwidgets/rss/images/rss.png",
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/rss/rss.html",
-    "i18n": {
-        "default": {
-            "bundle": "/devwidgets/rss/bundles/default.properties",
-            "name": "RSS reader",
-            "description":"RSS feed reader"
-        },
-        "en_US": {
-            "bundle": "/devwidgets/rss/bundles/en_US.properties"
-        },
-        "nl_NL": {
-            "bundle": "/devwidgets/rss/bundles/nl_NL.properties"
-        }
-    },
-    "indexFields": ["title"],
     "defaultConfiguration": {
         "rss": {
             "displayHeadlines": false,
@@ -29,5 +8,26 @@
             "title": "The Sakai Project",
             "urlFeeds": ["http://sakaiproject.org/rss.xml"]
         }
-    }
+    },
+    "enabled": true,
+    "hasSettings": true,
+    "i18n": {
+        "default": {
+            "bundle": "/devwidgets/rss/bundles/default.properties",
+            "description": "RSS feed reader",
+            "name": "RSS reader"
+        },
+        "en_US": {
+            "bundle": "/devwidgets/rss/bundles/en_US.properties"
+        },
+        "nl_NL": {
+            "bundle": "/devwidgets/rss/bundles/nl_NL.properties"
+        }
+    },
+    "id": "rss",
+    "img": "/devwidgets/rss/images/rss.png",
+    "indexFields": ["title"],
+    "sakaidocs": true,
+    "type": "sakai",
+    "url": "/devwidgets/rss/rss.html"
 }

--- a/devwidgets/sakai2favourites/config.json
+++ b/devwidgets/sakai2favourites/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"sakai2favourites",
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/sakai2favourites/bundles/default.properties",
-            "name": "Sakai 2 favourites",
-            "description": "Sakai 2 favourites"
+            "description": "Sakai 2 favourites",
+            "name": "Sakai 2 favourites"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/sakai2favourites/bundles/es_ES.properties"
         }
     },
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/sakai2favourites/sakai2favourites.html"
+    "id": "sakai2favourites",
+    "type": "core",
+    "url": "/devwidgets/sakai2favourites/sakai2favourites.html"
 }

--- a/devwidgets/sakai2tools/config.json
+++ b/devwidgets/sakai2tools/config.json
@@ -1,19 +1,19 @@
 {
-    "sakaidocs": false,
+    "enabled": true,
     "hasSettings": true,
-    "id":"sakai2tools",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/sakai2tools/bundles/default.properties",
-            "name":"Sakai 2 tools",
-            "description":"Sakai 2 tools"
+            "description": "Sakai 2 tools",
+            "name": "Sakai 2 tools"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/sakai2tools/bundles/es_ES.properties"
         }
     },
-    "img":"/devwidgets/sakai2tools/images/sakai2tools.png",
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/sakai2tools/sakai2tools.html"
+    "id": "sakai2tools",
+    "img": "/devwidgets/sakai2tools/images/sakai2tools.png",
+    "sakaidocs": false,
+    "type": "sakai",
+    "url": "/devwidgets/sakai2tools/sakai2tools.html"
 }

--- a/devwidgets/savecontent/config.json
+++ b/devwidgets/savecontent/config.json
@@ -1,17 +1,17 @@
 {
-    "id":"savecontent",
-    "hasSettings":false,
-    "type":"sakai",
-    "enabled":true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/savecontent/bundles/default.properties",
-            "name":"Savecontent",
-            "description":"Saves content into the users library"
+            "description": "Saves content into the users library",
+            "name": "Savecontent"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/savecontent/bundles/es_ES.properties"
         }
     },
-    "url":"/devwidgets/savecontent/savecontent.html"
+    "id": "savecontent",
+    "type": "sakai",
+    "url": "/devwidgets/savecontent/savecontent.html"
 }

--- a/devwidgets/searchall/config.json
+++ b/devwidgets/searchall/config.json
@@ -4,15 +4,15 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/searchall/bundles/default.properties",
-            "name": "Search all",
-            "description":"Search all"
+            "description": "Search all",
+            "name": "Search all"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/searchall/bundles/es_ES.properties"
         }
     },
     "id": "searchallold",
     "personalportal": false,
     "type": "core",
-    "url": "/devwidgets/searchall/searchall.html",
+    "url": "/devwidgets/searchall/searchall.html"
 }

--- a/devwidgets/searchcontent/config.json
+++ b/devwidgets/searchcontent/config.json
@@ -4,15 +4,15 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/searchcontent/bundles/default.properties",
-            "name": "Search content",
-            "description":"Search content"
+            "description": "Search content",
+            "name": "Search content"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/searchcontent/bundles/es_ES.properties"
         }
     },
     "id": "searchcontent",
     "personalportal": false,
     "type": "core",
-    "url": "/devwidgets/searchcontent/searchcontent.html",
+    "url": "/devwidgets/searchcontent/searchcontent.html"
 }

--- a/devwidgets/searchgroups/config.json
+++ b/devwidgets/searchgroups/config.json
@@ -4,15 +4,15 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/searchgroups/bundles/default.properties",
-            "name": "Search groups",
-            "description":"Search groups"
+            "description": "Search groups",
+            "name": "Search groups"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/searchgroups/bundles/es_ES.properties"
         }
     },
     "id": "searchgroups",
     "personalportal": false,
     "type": "core",
-    "url": "/devwidgets/searchgroups/searchgroups.html",
+    "url": "/devwidgets/searchgroups/searchgroups.html"
 }

--- a/devwidgets/searchpeople/config.json
+++ b/devwidgets/searchpeople/config.json
@@ -4,15 +4,15 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/searchpeople/bundles/default.properties",
-            "name": "Search people",
-            "description":"Search people"
+            "description": "Search people",
+            "name": "Search people"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/searchpeople/bundles/es_ES.properties"
         }
     },
     "id": "searchpeople",
     "personalportal": false,
     "type": "core",
-    "url": "/devwidgets/searchpeople/searchpeople.html",
+    "url": "/devwidgets/searchpeople/searchpeople.html"
 }

--- a/devwidgets/searchsakai2/config.json
+++ b/devwidgets/searchsakai2/config.json
@@ -1,16 +1,16 @@
 {
-    "id": "searchsakai2",
-    "type": "core",
     "enabled": false,
     "hasSettings": false,
-    "url": "/devwidgets/searchsakai2/searchsakai2.html",
     "i18n": {
         "default": {
             "bundle": "/devwidgets/searchsakai2/bundles/default.properties",
-            "name": "Search Sakai 2",
-            "description":"Search Sakai 2"
+            "description": "Search Sakai 2",
+            "name": "Search Sakai 2"
         }
     },
+    "id": "searchsakai2",
     "personalportal": false,
-    "sakaidocs": false
+    "sakaidocs": false,
+    "type": "core",
+    "url": "/devwidgets/searchsakai2/searchsakai2.html"
 }

--- a/devwidgets/selecttemplate/config.json
+++ b/devwidgets/selecttemplate/config.json
@@ -1,16 +1,16 @@
 {
-    "id":"selecttemplate",
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/selecttemplate/bundles/default.properties",
-            "name":"Select template",
-            "description":"Select template"
+            "description": "Select template",
+            "name": "Select template"
         },
         "en_US": {
             "bundle": "/devwidgets/selecttemplate/bundles/en_US.properties"
         }
     },
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/selecttemplate/selecttemplate.html"
+    "id": "selecttemplate",
+    "type": "core",
+    "url": "/devwidgets/selecttemplate/selecttemplate.html"
 }

--- a/devwidgets/sendmessage/config.json
+++ b/devwidgets/sendmessage/config.json
@@ -1,19 +1,19 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/sendmessage/bundles/default.properties",
-            "name":"Send a message",
-            "description":"Send a message"
+            "description": "Send a message",
+            "name": "Send a message"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/sendmessage/bundles/es_ES.properties"
         },
         "zh_CN": {
             "bundle": "/devwidgets/sendmessage/bundles/zh_CN.properties"
         }
     },
-    "id":"sendmessage",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/sendmessage/sendmessage.html"
+    "id": "sendmessage",
+    "type": "core",
+    "url": "/devwidgets/sendmessage/sendmessage.html"
 }

--- a/devwidgets/siterecentactivity/config.json
+++ b/devwidgets/siterecentactivity/config.json
@@ -1,16 +1,16 @@
 {
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/siterecentactivity/bundles/default.properties",
-            "name":"Recent activity",
-            "description":"Site recent activity"
+            "description": "Site recent activity",
+            "name": "Recent activity"
         }
     },
-    "hasSettings": false,
-    "id":"siterecentactivity",
-    "img":"/devwidgets/siterecentactivity/images/icon.png",
-    "showinsidebar":true,
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/siterecentactivity/siterecentactivity.html"
+    "id": "siterecentactivity",
+    "img": "/devwidgets/siterecentactivity/images/icon.png",
+    "showinsidebar": true,
+    "type": "core",
+    "url": "/devwidgets/siterecentactivity/siterecentactivity.html"
 }

--- a/devwidgets/systemtour/config.json
+++ b/devwidgets/systemtour/config.json
@@ -1,14 +1,14 @@
 {
-    "hasSettings":false,
-    "id":"systemtour",
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/systemtour/bundles/default.properties",
-            "name":"System tour",
-            "description":"Tracks system tour progress"
+            "description": "Tracks system tour progress",
+            "name": "System tour"
         }
     },
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/systemtour/systemtour.html"
+    "id": "systemtour",
+    "type": "sakai",
+    "url": "/devwidgets/systemtour/systemtour.html"
 }

--- a/devwidgets/tags/config.json
+++ b/devwidgets/tags/config.json
@@ -1,15 +1,15 @@
 {
-    "personalportal":true,
-    "hasSettings": false,
-    "id": "tags",
-    "type": "sakai",
     "enabled": true,
-    "url":"/devwidgets/tags/tags.html",
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/tags/bundles/default.properties",
-            "name": "Most popular tags",
-            "description": "Most popular tags"
+            "description": "Most popular tags",
+            "name": "Most popular tags"
         }
-    }
+    },
+    "id": "tags",
+    "personalportal": true,
+    "type": "sakai",
+    "url": "/devwidgets/tags/tags.html"
 }

--- a/devwidgets/templategenerator/config.json
+++ b/devwidgets/templategenerator/config.json
@@ -1,18 +1,4 @@
 {
-    "enabled": true,
-    "i18n": {
-        "default": {
-            "bundle": "/devwidgets/templategenerator/bundles/default.properties",
-            "name": "Template generator widget",
-            "description": "Export sites to templates"
-        },
-        "es_ES": {
-            "bundle": "/devwidgets/templategenerator/bundles/es_ES.properties"
-        }
-    },
-    "id": "templategenerator",
-    "type": "core",
-    "url": "/devwidgets/templategenerator/templategenerator.html",
     "defaultConfiguration": {
         "templategenerator": {
             "targetUser": "admin",
@@ -23,5 +9,19 @@
                 "comments"
             ]
         }
-    }
+    },
+    "enabled": true,
+    "i18n": {
+        "default": {
+            "bundle": "/devwidgets/templategenerator/bundles/default.properties",
+            "description": "Export sites to templates",
+            "name": "Template generator widget"
+        },
+        "es_ES": {
+            "bundle": "/devwidgets/templategenerator/bundles/es_ES.properties"
+        }
+    },
+    "id": "templategenerator",
+    "type": "core",
+    "url": "/devwidgets/templategenerator/templategenerator.html"
 }

--- a/devwidgets/text/config.json
+++ b/devwidgets/text/config.json
@@ -1,15 +1,15 @@
 {
-    "hasSettings": true,
-    "id": "text",
-    "type": "sakai",
     "enabled": true,
-    "url":"/devwidgets/text/text.html",
+    "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/text/bundles/default.properties",
-            "name": "Text widget",
-            "description": "Text"
+            "description": "Text",
+            "name": "Text widget"
         }
     },
-    "indexFields": ["data/text"]
+    "id": "text",
+    "indexFields": ["data/text"],
+    "type": "sakai",
+    "url": "/devwidgets/text/text.html"
 }

--- a/devwidgets/tooltip/config.json
+++ b/devwidgets/tooltip/config.json
@@ -1,14 +1,14 @@
 {
-    "id":"tooltip",
-    "hasSettings":false,
-    "type":"sakai",
-    "enabled":true,
+    "enabled": true,
+    "hasSettings": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/tooltip/bundles/default.properties",
-            "name":"Tooltip",
-            "description":"Displays tooltip help dialog boxes"
+            "description": "Displays tooltip help dialog boxes",
+            "name": "Tooltip"
         }
     },
-    "url":"/devwidgets/tooltip/tooltip.html"
+    "id": "tooltip",
+    "type": "sakai",
+    "url": "/devwidgets/tooltip/tooltip.html"
 }

--- a/devwidgets/topnavigation/config.json
+++ b/devwidgets/topnavigation/config.json
@@ -1,14 +1,15 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/topnavigation/bundles/default.properties",
-            "name":"topnavigation",
-            "description":"topnavigation"
+            "description": "topnavigation",
+            "name": "topnavigation"
         },
         "en_US": {
             "bundle": "/devwidgets/topnavigation/bundles/en_US.properties"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/topnavigation/bundles/es_ES.properties"
         },
         "nl_NL": {
@@ -18,8 +19,7 @@
             "bundle": "/devwidgets/topnavigation/bundles/zh_CN.properties"
         }
     },
-    "id":"topnavigation",
-    "type":"core",
-    "enabled":true,
-    "url":"/devwidgets/topnavigation/topnavigation.html"
+    "id": "topnavigation",
+    "type": "core",
+    "url": "/devwidgets/topnavigation/topnavigation.html"
 }

--- a/devwidgets/uploadcontent/config.json
+++ b/devwidgets/uploadcontent/config.json
@@ -1,13 +1,13 @@
 {
+    "enabled": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/uploadcontent/bundles/default.properties",
-            "name": "Upload content",
-            "description": "Upload content to Sakai OAE"
+            "description": "Upload content to Sakai OAE",
+            "name": "Upload content"
         }
     },
     "id": "uploadcontent",
-    "type":"core",
-    "enabled":true,
+    "type": "core",
     "url": "/devwidgets/uploadcontent/uploadcontent.html"
 }

--- a/devwidgets/uploadnewversion/config.json
+++ b/devwidgets/uploadnewversion/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/uploadnewversion/bundles/default.properties",
-            "name": "Upload new version widget",
-            "description":"Upload new version widget"
+            "description": "Upload new version widget",
+            "name": "Upload new version widget"
         }
     },
     "id": "uploadnewversion",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/uploadnewversion/uploadnewversion.html",
+    "url": "/devwidgets/uploadnewversion/uploadnewversion.html"
 }

--- a/devwidgets/userpermissions/config.json
+++ b/devwidgets/userpermissions/config.json
@@ -4,15 +4,15 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/userpermissions/bundles/default.properties",
-            "name": "User permissions",
-            "description":"User permissions"
+            "description": "User permissions",
+            "name": "User permissions"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/userpermissions/bundles/es_ES.properties"
         }
     },
     "id": "userpermissions",
     "personalportal": false,
     "type": "core",
-    "url": "/devwidgets/userpermissions/userpermissions.html",
+    "url": "/devwidgets/userpermissions/userpermissions.html"
 }

--- a/devwidgets/versions/config.json
+++ b/devwidgets/versions/config.json
@@ -5,7 +5,7 @@
         "default": {
             "bundle": "/devwidgets/versions/bundles/default.properties",
             "name": "Version widget",
-            "description":"Version widget"
+            "description": "Version widget"
         },
         "es_ES": { 
             "bundle": "/devwidgets/versions/bundles/es_ES.properties"

--- a/devwidgets/video/config.json
+++ b/devwidgets/video/config.json
@@ -1,16 +1,16 @@
 {
-    "hasSettings":true,
-    "id":"video",
-    "img":"/devwidgets/video/images/video.png",
-    "type":"sakai",
-    "enabled":true,
-    "url":"/devwidgets/video/video.html",
+    "enabled": true,
+    "hasSettings": true,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/video/bundles/default.properties",
-            "name":"Video",
-            "description":"Video"
+            "description": "Video",
+            "name": "Video"
         }
     },
-    "indexFields": ["source", "title", "url"]
+    "id": "video",
+    "img": "/devwidgets/video/images/video.png",
+    "indexFields": ["source", "title", "url"],
+    "type": "sakai",
+    "url": "/devwidgets/video/video.html"
 }

--- a/devwidgets/welcome/config.json
+++ b/devwidgets/welcome/config.json
@@ -4,12 +4,12 @@
     "i18n": {
         "default": {
             "bundle": "/devwidgets/welcome/bundles/default.properties",
-            "name": "Welcome widget",
-            "description":"Welcome widget"
+            "description": "Welcome widget",
+            "name": "Welcome widget"
         }
     },
     "id": "welcome",
     "personalportal": false,
     "type": "sakai",
-    "url": "/devwidgets/welcome/welcome.html",
+    "url": "/devwidgets/welcome/welcome.html"
 }

--- a/devwidgets/worldsettings/config.json
+++ b/devwidgets/worldsettings/config.json
@@ -1,19 +1,19 @@
 {
     "enabled": true,
     "hasSettings": false,
-    "sakaidocs": false,
     "i18n": {
         "default": {
             "bundle": "/devwidgets/worldsettings/bundles/default.properties",
-            "name": "World settings",
-            "description":"Edit world settings"
+            "description": "Edit world settings",
+            "name": "World settings"
         },
-        "es_ES": { 
+        "es_ES": {
             "bundle": "/devwidgets/worldsettings/bundles/es_ES.properties"
         }
     },
     "id": "worldsettings",
     "personalportal": false,
+    "sakaidocs": false,
     "type": "core",
-    "url": "/devwidgets/worldsettings/worldsettings.html",
+    "url": "/devwidgets/worldsettings/worldsettings.html"
 }


### PR DESCRIPTION
1.) Removed excess whitespace
2.) Removed the following properties: ca, groupdashboard, grouppages, userdashboard, userpages
3.) Removed name and description as top-level properties, putting them inside of i18n.

https://jira.sakaiproject.org/browse/SAKIII-5629
