### PR TITLE
SAKIII-5701 - Only load jquery.tagcloud when we need it

### DIFF
--- a/dev/lib/sakai/sakai.dependencies.js
+++ b/dev/lib/sakai/sakai.dependencies.js
@@ -131,7 +131,6 @@ require(
         "jquery-plugins/gritter/jquery.gritter.sakai-edit",
         "jquery-plugins/jquery.jcarousel.sakai-edit",
         "jquery-plugins/jquery.jeditable.sakai-edited",
-        "jquery-plugins/jquery.tagcloud",
         "jquery-plugins/jquery.infinitescroll-sakai"
     ],
     function($, sakai) {


### PR DESCRIPTION
Removing jquery.tagcloud from sakai dependencies.
https://jira.sakaiproject.org/browse/SAKIII-5701
