### PR TITLE
SAKIII-5715 Do not send empty "q" parameter to /var/search/pool/all.json

### DIFF
--- a/devwidgets/newaddcontent/javascript/newaddcontent.js
+++ b/devwidgets/newaddcontent/javascript/newaddcontent.js
@@ -1057,7 +1057,7 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore', 'jquery-plugins/jquery.
             var sortOn = $(newaddcontentExistingItemsListContainerActionsSort + ' option:selected').attr('data-sort-on');
             switch(currentExistingContext) {
                 case 'everything':
-                    if (q === '*') {
+                    if (!q || (q === '*')) {
                         searchURL = '/var/search/pool/all-all.infinity.json?items=10&page=' + (pagenum - 1) + '&sortOrder=' + sortOrder + '&sortOn=' + sortOn;
                     } else {
                         searchURL = '/var/search/pool/all.infinity.json?items=10&page=' + (pagenum - 1) + '&sortOrder=' + sortOrder + '&sortOn=' + sortOn + '&q=' + q;


### PR DESCRIPTION
This bug was caused by my earlier pull request for KERN-2805. I missed testing this workflow.

https://jira.sakaiproject.org/browse/SAKIII-5715
