### PR TITLE
SAKIII-6090 Make content-author display use the correct Profile URL

### DIFF
--- a/dev/lib/sakai/sakai.api.content.js
+++ b/dev/lib/sakai/sakai.api.content.js
@@ -1156,7 +1156,7 @@ define(
 
         getCreatorProfile : function(content, callback) {
             $.ajax({
-                url: "/~" + content["sakai:pool-content-created-for"] + "/public/authprofile.infinity.json",
+                url: "/~" + content["sakai:pool-content-created-for"] + "/public/authprofile.profile.json",
                 success: function(profile){
                     if ($.isFunction(callback)) {
                        callback(true, profile);


### PR DESCRIPTION
This bit of JavaScript got missed when other User Profile references were fixed to use the ".profile" selector.

> update by @christianv - Add jira URL:
> https://jira.sakaiproject.org/browse/SAKIII-6090
