### PR TITLE
SAKIII-6087 Display narrowly shared Collection correctly

### DIFF
--- a/dev/lib/sakai/sakai.api.groups.js
+++ b/dev/lib/sakai/sakai.api.groups.js
@@ -957,7 +957,10 @@ define(
                                 var groupid = urlToGroupMapping[membershiplist.url].groupid;
                                 var roleid = urlToGroupMapping[membershiplist.url].role;
                                 // Add the members to the response
-                                var members = $.parseJSON(membershiplist.body);
+                                var members = []
+                                if (membershiplist.status === 200) {
+                                    members = $.parseJSON(membershiplist.body);
+                                }
                                 dataToReturn[groupid] = dataToReturn[groupid] || {};
                                 dataToReturn[groupid][roleid] = {"results": members};
                                 if (sakaiGroupsAPI.groupData[groupid]){


### PR DESCRIPTION
Shared collections can show up in your "My Library" and then show a blank content profile thanks to this client-side bug.

https://jira.sakaiproject.org/browse/SAKIII-6087
