### PR TITLE
SAKIII-5096 - Contrast in error message for google gadget is low making reading message difficult.

### DIFF
--- a/devwidgets/ggadget/css/ggadget.css
+++ b/devwidgets/ggadget/css/ggadget.css
@@ -29,9 +29,8 @@
     margin-bottom: 3px;
 }
 #ggadget_remotecontent_settings_url_error {
-    color: #9f3333;
+    font-size: 12px;
     font-weight: bold;
-    padding: 0 0 10px 15px;
 }
 #ggadget_remotecontent_settings_help {
     color: #666;


### PR DESCRIPTION
Changed Google Gadgets URL error message color to comply with style guide.
https://jira.sakaiproject.org/browse/SAKIII-5906
