### PR TITLE
resolve error "Rendering of template "admin_header_template" failed: TypeError: Cannot read property 'displayName' of undefined

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -92,7 +92,7 @@
                 <div class="span10" id="admin_header_content">
                     {if !oae.data.me.anon}
                         <div id="admin_header_user">
-                            <span>Hi, ${oae.data.me.profile.displayName}</span>
+                            <span>Hi, ${oae.data.me.displayName}</span>
                             <button type="button" class="btn btn-inverse" id="admin_header_user_logout">Log out</button>
                         </div>
                     {/if}


### PR DESCRIPTION
On administration login page, after entering the "administrator" as name and password, blank page shows up. Both of Chrome console and Firfox firebug throw the error

![displayName_Error](https://f.cloud.github.com/assets/1701213/185052/61188110-7cf8-11e2-8b7e-74027284538f.png)

Inspecting the "oae.data.me" object, there is no "profile" field defined in this object. Eliminating profile solves the problem since "displayName" is defined as a property of oae.data.me object.
