### PR TITLE
use the npm module for grunt-git-describe

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt": "latest",
     "grunt-clean": "latest",
     "grunt-contrib-requirejs": "latest",
-    "grunt-git-describe": "git://github.com/mikaelkaron/grunt-git-describe.git#master",
+    "grunt-git-describe": "latest",
     "grunt-imagine": "latest",
     "grunt-ver": "git://github.com/sakaiproject/grunt-ver.git#v0.1.4-hilary-0.1",
     "shelljs": "latest"


### PR DESCRIPTION
grunt-git-describe is now available from npm, so we don't have to pull from the author's github
