### PR TITLE
Tenant information

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -30,9 +30,9 @@
                             <div id="admin-login" class="admin-login-container">
                                 <form id="admin-login-form" form method="POST" class="form-horizontal">
                                     <div class="control-group">
-                                        <label for="admin-login-form-name" class="control-label">Name</label>
+                                        <label for="admin-login-form-username" class="control-label">Username</label>
                                         <div class="controls">
-                                            <input type="text" id="admin-login-form-name" name="username" class="required"/>
+                                            <input type="text" id="admin-login-form-username" name="username" class="required"/>
                                         </div>
                                     </div>
                                     <div class="control-group">
@@ -77,7 +77,7 @@
                     {if context.isGlobalAdminServer && !context.host}
                         <h1>Global administration UI</h1>
                     {else}
-                        <h1>${context.name}</h1>
+                        <h1>${context.displayName}</h1>
                     {/if}
                 </div>
             </div>
@@ -121,7 +121,7 @@
                             {for tenant in tenants}
                                 {if tenant.alias}
                                     <li>
-                                        <a href="/tenant/${tenant.alias}" title="${tenant.name} administration">${tenant.name}</a>
+                                        <a href="/tenant/${tenant.alias}" title="${tenant.displayName} administration">${tenant.displayName}</a>
                                     </li>
                                 {/if}
                             {/for}
@@ -162,15 +162,15 @@
                         {if tenant.alias}
                             <tr>
                                 {if isMainGlobalAdmin}
-                                    <td><a href="/tenant/${tenant.alias}" title="Edit ${tenant.name}"><i class="icon-pencil"></i></a></td>
+                                    <td><a href="/tenant/${tenant.alias}" title="Edit ${tenant.displayName}"><i class="icon-pencil"></i></a></td>
                                 {/if}
                                 <td>${tenant.alias}</td>
                                 {if oae.data.me.isGlobalAdmin}
-                                    <td class="jeditable-container"><div class="jeditable-field" data-alias="${tenant.alias}">${tenant.name}</div></td>
+                                    <td class="jeditable-container"><div class="jeditable-field" data-alias="${tenant.alias}">${tenant.displayName}</div></td>
                                 {else}
-                                    <td>${tenant.name}</td>
+                                    <td>${tenant.displayName}</td>
                                 {/if}
-                                <td><a href="http://${tenant.host}" title="${tenant.name}" target="_blank">${tenant.host}</a></td>
+                                <td><a href="http://${tenant.host}" title="${tenant.displayName}" target="_blank">${tenant.host}</a></td>
                                 <td>
                                     {if tenant.active}
                                         <span class="text-success">Running</span>
@@ -181,15 +181,15 @@
                                 <td>
                                     {if true || oae.data.me.isGlobalAdmin}
                                         {if tenant.active}
-                                            <button type="button" class="btn btn-warning stop-tenant" data-alias="${tenant.alias}" data-name="${tenant.name}">Stop</button>
+                                            <button type="button" class="btn btn-warning stop-tenant" data-alias="${tenant.alias}" data-displayName="${tenant.displayName}">Stop</button>
                                         {else}
-                                            <button type="button" class="btn btn-success start-tenant" data-alias="${tenant.alias}" data-name="${tenant.name}">Start</button>
+                                            <button type="button" class="btn btn-success start-tenant" data-alias="${tenant.alias}" data-displayName="${tenant.displayName}">Start</button>
                                         {/if}
                                     {/if}
                                 </td>
                                 {if oae.data.me.isGlobalAdmin}
                                     <td>
-                                        <button type="button" class="btn btn-danger delete-tenant" data-alias="${tenant.alias}" data-name="${tenant.name}">Delete</button>
+                                        <button type="button" class="btn btn-danger delete-tenant" data-alias="${tenant.alias}" data-displayName="${tenant.displayName}">Delete</button>
                                     </td>
                                     <td>
                                         <button type="button" class="btn btn-primary login-tenant" data-alias="${tenant.alias}">Login</button>
@@ -218,9 +218,9 @@
                                     </div>
                                 </div>
                                 <div class="control-group">
-                                    <label for="createtenant-name" class="control-label">Name:</label>
+                                    <label for="createtenant-displayName" class="control-label">Name:</label>
                                     <div class="controls">
-                                        <input type="text" name="name" id="createtenant-name" placeholder="Name" class="required"/>
+                                        <input type="text" name="displayName" id="createtenant-displayName" placeholder="Name" class="required"/>
                                     </div>
                                 </div>
                                 <div class="control-group">

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -47,7 +47,7 @@ require(['jquery', 'underscore', 'oae.core', '/admin/js/admin.util.js', 'jquery.
                     'type': 'POST',
                     'data': {
                         'alias': $(this).attr('data-alias'),
-                        'name': value
+                        'displayName': value
                     },
                     'success': function() {
                         oae.api.util.notification('Tenant name updated', 'The tenant name has been successfully updated.');
@@ -149,11 +149,11 @@ require(['jquery', 'underscore', 'oae.core', '/admin/js/admin.util.js', 'jquery.
             'type': 'POST',
             'data': {
                 'alias': $.trim($('#createtenant-alias').val()),
-                'name': $.trim($('#createtenant-name').val()),
+                'displayName': $.trim($('#createtenant-displayName').val()),
                 'host': $.trim($('#createtenant-host').val())
             },
             'success': function() {
-                oae.api.util.notification('Tenant created', 'The new tenant "' + $('#createtenant-name').val() + '" has been successfully created.');
+                oae.api.util.notification('Tenant created', 'The new tenant "' + $('#createtenant-displayName').val() + '" has been successfully created.');
                 reloadTenants()
             },
             'error': function(jqXHR, textStatus) {
@@ -285,14 +285,14 @@ require(['jquery', 'underscore', 'oae.core', '/admin/js/admin.util.js', 'jquery.
      * Deletes a single tenant and shows a confirmation message
      */
     var deleteTenantHandler = function() {
-        var tenantName = $(this).attr('data-name');
+        var tenantDisplayName = $(this).attr('data-displayName');
         var tenantAlias = $(this).attr('data-alias');
         adminUtil.showConfirmationModal({
             'id': 'deletetenant-modal',
-            'title': 'Delete tenant "' + tenantName + '"',
-            'message': 'Are you sure you want to delete tenant "' + tenantName + '"?',
+            'title': 'Delete tenant "' + tenantDisplayName + '"',
+            'message': 'Are you sure you want to delete tenant "' + tenantDisplayName + '"?',
             'cancel': 'Cancel',
-            'confirm': 'Yes, delete "' + tenantName + '"',
+            'confirm': 'Yes, delete "' + tenantDisplayName + '"',
             'confirmclass': 'btn-danger',
             'confirmed': function() {
                 deleteTenants([tenantAlias], function(err) {
@@ -302,7 +302,7 @@ require(['jquery', 'underscore', 'oae.core', '/admin/js/admin.util.js', 'jquery.
                     if (err) {
                         oae.api.util.notification('Tenant not deleted', 'The tenant could not be deleted.', 'error');
                     } else {
-                        oae.api.util.notification('Tenant deleted', 'Tenant ' + tenantName + ' was successfully deleted.');
+                        oae.api.util.notification('Tenant deleted', 'Tenant ' + tenantDisplayName + ' was successfully deleted.');
                     }
                 });
             }
@@ -313,14 +313,14 @@ require(['jquery', 'underscore', 'oae.core', '/admin/js/admin.util.js', 'jquery.
      * Stops a single tenant and shows a confirmation message
      */
     var stopTenantHandler = function() {
-        var tenantName = $(this).attr('data-name');
+        var tenantDisplayName = $(this).attr('data-displayName');
         var tenantAlias = $(this).attr('data-alias');
         adminUtil.showConfirmationModal({
             'id': 'stoptenant-modal',
-            'title': 'Stop tenant "' + tenantName + '"',
-            'message': 'Are you sure you want to stop tenant "' + tenantName + '"?',
+            'title': 'Stop tenant "' + tenantDisplayName + '"',
+            'message': 'Are you sure you want to stop tenant "' + tenantDisplayName + '"?',
             'cancel': 'Cancel',
-            'confirm': 'Yes, stop "' + tenantName + '"',
+            'confirm': 'Yes, stop "' + tenantDisplayName + '"',
             'confirmclass': 'btn-warning',
             'confirmed': function() {
                 stopTenants([tenantAlias], function(err) {
@@ -330,7 +330,7 @@ require(['jquery', 'underscore', 'oae.core', '/admin/js/admin.util.js', 'jquery.
                     if (err) {
                         oae.api.util.notification('Tenant not stopped', 'The tenant could not be stopped.', 'error');
                     } else {
-                        oae.api.util.notification('Tenant stopped', 'Tenant ' + tenantName + ' was successfully stopped.');
+                        oae.api.util.notification('Tenant stopped', 'Tenant ' + tenantDisplayName + ' was successfully stopped.');
                     }
                 });
             }
@@ -341,14 +341,14 @@ require(['jquery', 'underscore', 'oae.core', '/admin/js/admin.util.js', 'jquery.
      * Starts a single tenant and shows a confirmation message
      */
     var startTenantHandler = function() {
-        var tenantName = $(this).attr('data-name');
+        var tenantDisplayName = $(this).attr('data-displayName');
         var tenantAlias = $(this).attr('data-alias');
         adminUtil.showConfirmationModal({
             'id': 'starttenant-modal',
-            'title': 'start tenant "' + tenantName + '"',
-            'message': 'Are you sure you want to start tenant "' + tenantName + '"?',
+            'title': 'start tenant "' + tenantDisplayName + '"',
+            'message': 'Are you sure you want to start tenant "' + tenantDisplayName + '"?',
             'cancel': 'Cancel',
-            'confirm': 'Yes, start ' + tenantName,
+            'confirm': 'Yes, start ' + tenantDisplayName,
             'confirmclass': 'btn-success',
             'confirmed': function() {
                 startTenants([tenantAlias], function(err) {
@@ -358,7 +358,7 @@ require(['jquery', 'underscore', 'oae.core', '/admin/js/admin.util.js', 'jquery.
                     if (err) {
                         oae.api.util.notification('Tenant not started', 'The tenant could not be started.', 'error');
                     } else {
-                        oae.api.util.notification('Tenant started', 'Tenant ' + tenantName + ' was successfully started.');
+                        oae.api.util.notification('Tenant started', 'Tenant ' + tenantDisplayName + ' was successfully started.');
                     }
                 });
             }
@@ -381,7 +381,7 @@ require(['jquery', 'underscore', 'oae.core', '/admin/js/admin.util.js', 'jquery.
      * Set up the log in handler
      */
     var login = function() {
-        oae.api.authentication.login($('#admin-login-form-name').val(), $('#admin-login-form-password').val(), function(err) {
+        oae.api.authentication.login($('#admin-login-form-username').val(), $('#admin-login-form-password').val(), function(err) {
             if (err) {
                 // Show the error message
                 oae.api.util.notification('Login failed', 'Invalid username or password.', 'error');

--- a/node_modules/oae-core/register/css/register.css
+++ b/node_modules/oae-core/register/css/register.css
@@ -25,7 +25,7 @@
 #register-username-available {
     position: absolute;
     top: 5px;
-    left: 220px;
+    left: 210px;
     font-size: 18px;
 }
 

--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -553,7 +553,7 @@ div.oae-thumbnail i[class^="icon-"] {
 
 .oae-clip .oae-clip-content > button i.icon-caret-down,
 .oae-clip .oae-clip-content > button i.icon-caret-up {
-    margin-left: 5px;
+    line-height: 16px;
     position: relative;
     top: 2px;
 }
@@ -567,7 +567,7 @@ div.oae-thumbnail i[class^="icon-"] {
     display: inline-block;
     font-size: 16px;
     line-height: 1;
-    margin: 0;
+    margin: 0 10px 0 0;
     font-weight: 600;
     max-width: 500px;
     word-wrap: break-word;

--- a/ui/macros/list.html
+++ b/ui/macros/list.html
@@ -123,14 +123,13 @@
 {macro renderMetadata(entityData, metadata)}
     {if !metadata}
         {if entityData.resourceType === 'user'}
-            <!-- TODO: Add proper tenant metadata and i18n -->
-            ${metadata = 'Cambridge University' |eat}
+            {var metadata = entityData.tenant.displayName}
         {elseif entityData.resourceType === 'group'}
             <!-- TODO: Add proper metadata and i18n -->
-            ${metadata = 'Group' |eat}
+            {var metadata = 'Group'}
         {elseif entityData.resourceType === 'content'}
             <!-- TODO: Add proper document type and i18n -->
-            ${metadata = 'Other document' |eat}
+            {var metadata = 'Other document'}
         {/if}
     {/if}
 

--- a/ui/me.html
+++ b/ui/me.html
@@ -36,7 +36,7 @@
                                     <div>
                                         <h1>${oae.data.me.displayName|safeUserInput}</h1>
                                         <i class="icon-caret-down"></i>
-                                        <small>${oae.data.me.department}</small>
+                                        <small>${oae.data.me.tenant.displayName}</small>
                                     </div>
                                 </div>
                             </button>


### PR DESCRIPTION
Follow up on Hilary#449:
- Made admin UI work with new tenant displayName property
- Showing tenant information in lists and me clip
- Fixed horizontal centering in clip when metadata is displayed

NOTES: The creategroup and setpermissions widget will need to be adjusted to use the tenant display name as well, but this can be done in a follow-up PR.
