### PR TITLE
Space should be usable for inline edit

### DIFF
--- a/shared/oae/js/jquery-plugins/jquery.jeditable-focus.js
+++ b/shared/oae/js/jquery-plugins/jquery.jeditable-focus.js
@@ -22,7 +22,6 @@ define(['jquery'], function (jQuery) {
         $(document).on('focus', '.jeditable-field', function(ev) {
             $(this).keypress(function(ev) {
                 if (ev.which == 13 || ev.which == 32){
-                    ev.preventDefault();
                     $(this).trigger('click.editable');
                 }
             });


### PR DESCRIPTION
Keyboard accessibility rules prescribe that we should be able to use space to activate an inline edit field (as well as Enter).
