### PR TITLE
Unable to login in to the account from Internet Explorer 9

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -123,6 +123,7 @@ http {
         }
 
         location /api/ {
+            expires -1;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $http_host;


### PR DESCRIPTION
User cannot login to the account using IE 9 browser even though the account exist.
