### PR TITLE
Nginx: Support more mimetypes.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -306,6 +306,12 @@ http {
 
     }
 
+    ###############
+    ###############
+    ## MIMETYPES ##
+    ###############
+    ###############
+
     # A set of mime types that can be used by nginx (determined by the file extension).
     # Borrowed from HTML5Boilerplate server configs.
     # See: https://github.com/Akkuma/html5-boilerplate-server-configs/blob/master/nginx-mime.types


### PR DESCRIPTION
Added support for more mimetypes, mainly supported font/\* to avoid errors in the Google Chrome console.

You'll have to manually copy the nginx.mime.types file to /usr/local/nginx/mime.types before reloading nginx.

I'll submit a PR/fix to puppet-hilary once this gets accepted.
