### PR TITLE
Remove sakai_global from content and group

### DIFF
--- a/node_modules/oae-core/contentcomments/js/contentcomments.js
+++ b/node_modules/oae-core/contentcomments/js/contentcomments.js
@@ -177,12 +177,8 @@ define(['jquery', 'oae.core', 'jquery.timeago'], function($, oae) {
 
         /**
          * Initialize a new infinite scroll container that fetches the content comments.
-         *
-         * @param  {Object}   ev            The `oae.context.send` event
-         * @param  {Object}   contentData   The content profile data
          */
-        var setUpInfiniteScroll = function(ev, contentData) {
-            contentProfile = contentData;
+        var setUpInfiniteScroll = function() {
             infinityScroll = $('#contentcomments-content-container', $rootel).infiniteScroll('/api/content/' + contentProfile.id + '/comments', null, $('#contentcomments-comment-template'), {
                 'postProcessor': function(data) {
                     data.canManage = contentProfile.isManager;
@@ -197,7 +193,10 @@ define(['jquery', 'oae.core', 'jquery.timeago'], function($, oae) {
         };
 
         // Receive the content profile information and set up the infinite scroll for comments
-        $(document).on('oae.context.send', setUpInfiniteScroll);
+        $(document).on('oae.context.send', function(ev, contentData) {
+            contentProfile = contentData;
+            setUpInfiniteScroll();
+        });
 
         // Request the content profile information
         $(document).trigger('oae.context.get');

--- a/ui/js/content.js
+++ b/ui/js/content.js
@@ -53,8 +53,6 @@ require(['jquery','oae.core'], function($, oae) {
 
             contentProfile = profile;
 
-            $(window).trigger('ready.content.oae');
-
             // Render the entity information
             setUpClip();
 


### PR DESCRIPTION
As we now have the get context functions, we no longer need the sakai_global variables. These should be removed in content and group, and any issues coming out of this should be fixed. 
