### PR TITLE
Bootstrap modal override causes JS error

### DIFF
--- a/shared/oae/js/bootstrap-plugins/bootstrap.modal.js
+++ b/shared/oae/js/bootstrap-plugins/bootstrap.modal.js
@@ -22,17 +22,19 @@
  *     e.g. $('#widget-modal').modal('unlock');
  */
 
-$.extend($.fn.modal.Constructor.prototype, {
-    'lock': function() {
-        // Set isShown to false. https://github.com/twitter/bootstrap/issues/1202#issuecomment-3698674
-        this.$element.data('modal').isShown = false;
-        // Disable buttons that dismiss the modal
-        $('#' + this.$element.attr('id') + ' [data-dismiss="modal"]').attr('disabled', 'disabled');
-    },
-    'unlock': function() {
-        // Set isShown to true. https://github.com/twitter/bootstrap/issues/1202#issuecomment-3698674
-        this.$element.data('modal').isShown = true;
-        // Enable buttons that dismiss the modal
-        $('#' + this.$element.attr('id') + ' [data-dismiss="modal"]').removeAttr('disabled', 'disabled');
-    }
+define(['jquery', 'bootstrap'], function($, bootstrap) {
+    $.extend($.fn.modal.Constructor.prototype, {
+        'lock': function() {
+            // Set isShown to false. https://github.com/twitter/bootstrap/issues/1202#issuecomment-3698674
+            this.$element.data('modal').isShown = false;
+            // Disable buttons that dismiss the modal
+            $('#' + this.$element.attr('id') + ' [data-dismiss="modal"]').attr('disabled', 'disabled');
+        },
+        'unlock': function() {
+            // Set isShown to true. https://github.com/twitter/bootstrap/issues/1202#issuecomment-3698674
+            this.$element.data('modal').isShown = true;
+            // Enable buttons that dismiss the modal
+            $('#' + this.$element.attr('id') + ' [data-dismiss="modal"]').removeAttr('disabled', 'disabled');
+        }
+    });
 });


### PR DESCRIPTION
Occasionally, I see an error in the JavaScript, which I think is caused by the bootstrap modal override that is trying to initialise before bootstrap is initialised. The appropriate dependencies should be added around that plugin.

Assigning to @dieterc.

![screen shot 2013-05-13 at 01 02 23](https://f.cloud.github.com/assets/109850/493685/2c809326-bb63-11e2-9dd4-e8854649f526.png)
