### PR TITLE
Checking refine by type checkbox doesn't select correct checkbox

### DIFF
--- a/node_modules/oae-core/addpeoplegroups/javascript/addpeoplegroups.js
+++ b/node_modules/oae-core/addpeoplegroups/javascript/addpeoplegroups.js
@@ -166,7 +166,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
         };
 
         var saveMemberships = function() {
-            $(addpeoplegroupsSave, $rootel).attr('disabled', true);
+            $(addpeoplegroupsSave, $rootel).prop('disabled', true);
             var $addPeopleGroupsSelect = $('#addpeoplegroups_select');
             if (!$addPeopleGroupsSelect.children('option:selected').data('redirect') === true) {
                 var groupsToAdd = [];
@@ -180,7 +180,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
                     });
                 });
                 sakai.api.Groups.addUsersToGroup($addPeopleGroupsSelect.val(), groupsToAdd, sakai.data.me);
-                $(addpeoplegroupsSave, $rootel).removeAttr('disabled');
+                $(addpeoplegroupsSave, $rootel).prop('disabled', false);
                 toggleVisibility();
                 sakai.api.Util.notification.show(sakai.api.i18n.getValueForKey('SUCCESSFULLY_ADDED', 'addpeoplegroups'), sakai.api.Util.TemplateRenderer('addpeoplegroups_added_template', {
                     groupsToAdd: getSelected(),

--- a/node_modules/oae-core/contentpermissions/js/contentpermissions.js
+++ b/node_modules/oae-core/contentpermissions/js/contentpermissions.js
@@ -172,7 +172,7 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.autoSuggest'], function($, _
                     return data.results;
                 },
                 'selectionAdded': function(elem) {
-                    $('#contentpermissions_members_autosuggest_permissions').removeAttr('disabled');
+                    $('#contentpermissions_members_autosuggest_permissions').prop('disabled', false);
                 },
                 'selectionRemoved': function(elem) {
                     // We need to remove the element from the DOM explicitly.
@@ -181,7 +181,7 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.autoSuggest'], function($, _
                     // If there are no other members in the list, we disable the visibility drop down.
                     var members = getNewMembers();
                     if (members.length === 0) {
-                        $('#contentpermissions_members_autosuggest_permissions').attr('disabled', 'disabled');
+                        $('#contentpermissions_members_autosuggest_permissions').prop('disabled', true);
                     }
                 }
             });
@@ -272,7 +272,7 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.autoSuggest'], function($, _
 
             // By default, disable the dropdown next to the autosuggest field.
             // We'll enable it when a user/group has been selected.
-            $('#contentpermissions_members_autosuggest_permissions').attr('disabled', 'disabled');
+            $('#contentpermissions_members_autosuggest_permissions').prop('disabled', true);
 
             // Show the overlay.
             initializeOverlay();

--- a/node_modules/oae-core/createcollabdoc/js/createcollabdoc.js
+++ b/node_modules/oae-core/createcollabdoc/js/createcollabdoc.js
@@ -113,7 +113,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
          */
         var createCollabDoc = function() {
             // Disable the form
-            $('#createcollabdoc-form *', $rootel).attr('disabled', 'disabled');
+            $('#createcollabdoc-form *', $rootel).prop('disabled', true);
 
             var displayName = $.trim($('#createcollabdoc-name', $rootel).val());
 

--- a/node_modules/oae-core/creategroup/js/creategroup.js
+++ b/node_modules/oae-core/creategroup/js/creategroup.js
@@ -26,7 +26,7 @@ define(['jquery', 'oae.core'], function($, oae) {
         var setUpReset = function() {
             $('#creategroup-modal').on('hidden', function() {
                 $('#creategroup-form', $rootel)[0].reset();
-                $('#creategroup-form *', $rootel).removeAttr('disabled');
+                $('#creategroup-form *', $rootel).prop('disabled', false);
             });
         };
 
@@ -50,7 +50,7 @@ define(['jquery', 'oae.core'], function($, oae) {
          */
         var createGroup = function() {
             // Disable the form
-            $('#creategroup-form *', $rootel).attr('disabled', 'disabled');
+            $('#creategroup-form *', $rootel).prop('disabled', true);
 
             // Create the group
             var displayName = $('#creategroup-name', $rootel).val();

--- a/node_modules/oae-core/createlink/js/createlink.js
+++ b/node_modules/oae-core/createlink/js/createlink.js
@@ -53,12 +53,12 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
             $('#createlink-modal > .modal-footer', $rootel).show();
 
             // Reset controls
-            $('#createlink-next', $rootel).attr('disabled', 'disabled');
+            $('#createlink-next', $rootel).prop('disabled', true);
             $('#createlink-next', $rootel).show();
             $('#createlink-link-dump', $rootel).val('');
             $('#createlink-create', $rootel).hide();
-            $('#createlink-create', $rootel).removeAttr('disabled');
-            $('#createlink-change-permissions', $rootel).removeAttr('disabled');
+            $('#createlink-create', $rootel).prop('disabled', false);
+            $('#createlink-change-permissions', $rootel).prop('disabled', false);
 
             // Reset the progress bar
             $('.progress', $rootel).hide();
@@ -302,9 +302,9 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
                 $('.progress', $rootel).show();
 
                 // Disable editing on link creation
-                $('#createlink-create', $rootel).attr('disabled', 'disabled');
-                $('.createlink-trash', $rootel).attr('disabled', 'disabled');
-                $('#createlink-change-permissions', $rootel).attr('disabled', 'disabled');
+                $('#createlink-create', $rootel).prop('disabled', true);
+                $('.createlink-trash', $rootel).prop('disabled', true);
+                $('#createlink-change-permissions', $rootel).prop('disabled', true);
                 $('.jeditable-field', $rootel).editable('destroy');
                 $('[rel="tooltip"]', $rootel).tooltip('destroy');
 
@@ -374,9 +374,9 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
                     });
 
                     if (valid) {
-                        $('#createlink-next', $rootel).removeAttr('disabled');
+                        $('#createlink-next', $rootel).prop('disabled', false);
                     } else {
-                        $('#createlink-next', $rootel).attr('disabled', 'disabled');
+                        $('#createlink-next', $rootel).prop('disabled', true);
                     }
                 }, 1);
             });

--- a/node_modules/oae-core/displayprofilesection/js/displayprofilesection.js
+++ b/node_modules/oae-core/displayprofilesection/js/displayprofilesection.js
@@ -222,7 +222,7 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
          */
         var enableUpdate = function() {
             if (allowUpdate) {
-                $('button.profile-section-save-button', $rootel).removeAttr('disabled');
+                $('button.profile-section-save-button', $rootel).prop('disabled', false);
             }
         };
 
@@ -284,7 +284,7 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
             }
 
             // Disable the save button.
-            $('button.profile-section-save-button', $rootel).attr('disabled', 'disabled');
+            $('button.profile-section-save-button', $rootel).prop('disabled', true);
             return false;
         };
 

--- a/node_modules/oae-core/grouppermissions/javascript/grouppermissions.js
+++ b/node_modules/oae-core/grouppermissions/javascript/grouppermissions.js
@@ -174,7 +174,7 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.autoSuggest'], function($, _
                     return data.results;
                 },
                 'selectionAdded': function(elem) {
-                    $('#grouppermissions_members_autosuggest_permissions').removeAttr('disabled');
+                    $('#grouppermissions_members_autosuggest_permissions').prop('disabled', false);
                 },
                 'selectionRemoved': function(elem) {
                     // We need to remove the element from the DOM explicitly.
@@ -183,7 +183,7 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.autoSuggest'], function($, _
                     // If there are no other members in the list, we disable the visibility drop down.
                     var members = getNewMembers();
                     if (members.length === 0) {
-                        $('#grouppermissions_members_autosuggest_permissions').attr('disabled', 'disabled');
+                        $('#grouppermissions_members_autosuggest_permissions').prop('disabled', true);
                     }
                 }
             });
@@ -287,7 +287,7 @@ define(['jquery', 'underscore', 'oae.core', 'jquery.autoSuggest'], function($, _
 
             // By default, disable the dropdown next to the autosuggest field.
             // We'll enable it when a user/group has been selected.
-            $('#grouppermissions_members_autosuggest_permissions').attr('disabled', 'disabled');
+            $('#grouppermissions_members_autosuggest_permissions').prop('disabled', true);
 
             // Show the overlay.
             initializeOverlay();

--- a/node_modules/oae-core/groupsettings/js/groupsettings.js
+++ b/node_modules/oae-core/groupsettings/js/groupsettings.js
@@ -57,7 +57,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
             var newVisibilityVal = $.trim(newVisibility.val());
             var oldVisibilityVal = sakai_global.group.groupData['sakai:group-visible'];
             var oldVisibilityIndex = parseInt(newVisibility.find('option[value="' + sakai_global.group.groupData['sakai:group-visible'] + '"]').attr('index'), 10);
-            if (sakai_global.group.groupData['sakai:group-visible'] === newVisibilityVal || parseInt(newVisibility.attr('selectedIndex'), 10) > oldVisibilityIndex || newVisibilityVal === 'members-only' || oldVisibilityVal === 'public') {
+            if (sakai_global.group.groupData['sakai:group-visible'] === newVisibilityVal || parseInt(newVisibility.prop('selectedIndex'), 10) > oldVisibilityIndex || newVisibilityVal === 'members-only' || oldVisibilityVal === 'public') {
                 $groupsettingsForm.submit();
             } else {
                 $('#groupsettings_warning_container_text').html(sakai.api.Util.TemplateRenderer('groupsettings_warning_container_text_template', {
@@ -74,7 +74,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
         ////////////////////
 
         var handleSubmit = function(form) {
-            $groupsettingsContainer.find('select, input').attr('disabled','disabled');
+            $groupsettingsContainer.find('select, input').prop('disabled', true);
             var worldTitle = $.trim($(groupsettingsTitle).val());
             var worldDescription = $.trim($(groupsettingsDescription).val());
             var foundIn = $.trim($(groupsettingsCanBeFoundIn).val());
@@ -90,7 +90,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
             };
 
             sakai.api.Groups.updateGroupProfile(worldId, worldData, worldTags, sakai_global.group.groupData, function( success ) {
-                $groupsettingsContainer.find('select, input').removeAttr('disabled');
+                $groupsettingsContainer.find('select, input').prop('disabled', false);
 
                 $(window).trigger('updatedTitle.groupsettings.sakai', worldTitle);
                 sakai.api.Util.notification.show($('#groupsettings_success_title').html(), $('#groupsettings_success_body').html());

--- a/node_modules/oae-core/library/js/library.js
+++ b/node_modules/oae-core/library/js/library.js
@@ -31,8 +31,8 @@ define(['jquery', 'oae.core'], function($, oae) {
         };
 
         /**
-         * Initialize a new infinite scroll container that fetches a user's memberships. 
-         * This will detect when a search is happening and will change the endpoint 
+         * Initialize a new infinite scroll container that fetches a user's memberships.
+         * This will detect when a search is happening and will change the endpoint
          * accordingly.
          */
         var getLibrary = function() {
@@ -73,7 +73,7 @@ define(['jquery', 'oae.core'], function($, oae) {
          */
         var setUpAnon = function() {
             if (oae.data.me.anon) {
-                $('.oae-list-options-toggle', $rootel).attr('disabled', 'disabled');
+                $('.oae-list-options-toggle', $rootel).prop('disabled', true);
             }
         };
 
@@ -113,7 +113,7 @@ define(['jquery', 'oae.core'], function($, oae) {
             // Replace the current History.js state to have the query information. This
             // is necessary because a newly loaded page will not contain the data object in its
             // state. Calling the replaceState function will automatically trigger the statechange
-            // event, which will take care of the library listing. The random number is added to 
+            // event, which will take care of the library listing. The random number is added to
             // the data object to make sure that the statechange event is triggered after a page reload.
             History.replaceState(newState);
         };

--- a/node_modules/oae-core/managegroupmembers/js/managegroupmembers.js
+++ b/node_modules/oae-core/managegroupmembers/js/managegroupmembers.js
@@ -126,7 +126,7 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore'], function($, sakai, _) 
                 $.each($managegroupmembersSelectedAllPermissions.children(), function() {
                     var roleId = $(this).val();
                     if (!sakai.api.Groups.hasManagementRights(currentUserRoleData, roleId) && currentUserRoleData.id !== roleId) {
-                        $(this).attr('disabled', 'disabled');
+                        $(this).prop('disabled', true);
                     }
                 });
             }
@@ -149,11 +149,11 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore'], function($, sakai, _) 
 
         var enableDisableControls = function(disable) {
             if (disable) {
-                $managegroupmembersRemoveSelected.attr('disabled','disabled');
-                $managegroupmembersSelectedAllPermissions.attr('disabled','disabled');
+                $managegroupmembersRemoveSelected.prop('disabled', true);
+                $managegroupmembersSelectedAllPermissions.prop('disabled', true);
             }else{
-                $managegroupmembersRemoveSelected.removeAttr('disabled');
-                $managegroupmembersSelectedAllPermissions.removeAttr('disabled');
+                $managegroupmembersRemoveSelected.prop('disabled', false);
+                $managegroupmembersSelectedAllPermissions.prop('disabled', false);
             }
         };
 
@@ -163,7 +163,7 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore'], function($, sakai, _) 
             }else{
                 enableDisableControls(true);
             }
-            $managegroupmembersSelectAllSelectedContacts.removeAttr('checked');
+            $managegroupmembersSelectAllSelectedContacts.prop('checked', false);
         };
 
         /**
@@ -258,20 +258,20 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore'], function($, sakai, _) 
          */
         var checkAll = function(el, peopleContainer) {
             if ($(el).is(':checked')) {
-                $(peopleContainer + ':not(:disabled)').attr('checked','checked');
+                $(peopleContainer + ':not(:disabled)').prop('checked', true);
                 if (peopleContainer !== managegroupmembersSelectedCheckbox) {
                     $(peopleContainer).change();
                     renderSelectedContacts();
-                }else{
+                } else {
                     enableDisableControls(false);
                 }
             }else{
-                $(peopleContainer).removeAttr('checked');
+                $(peopleContainer).prop('checked', false);
                 if (peopleContainer !== managegroupmembersSelectedCheckbox) {
-                    $(peopleContainer).removeAttr('checked');
+                    $(peopleContainer).prop('checked', false);
                     $(peopleContainer).change();
                     renderSelectedContacts();
-                    $managegroupmembersSelectAllSelectedContacts.removeAttr('checked');
+                    $managegroupmembersSelectAllSelectedContacts.prop('checked', false);
                 } else {
                     enableDisableControls(true);
                 }
@@ -282,7 +282,7 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore'], function($, sakai, _) 
          * Construct a user object when adding a user to the list of selected users
          */
         var constructSelecteduser = function() {
-            $managegroupmembersSelectAllSelectedContacts.removeAttr('checked');
+            $managegroupmembersSelectAllSelectedContacts.prop('checked', false);
             var selectedId = $(this).attr('data-userid');
             if ($(this).is(':checked')) {
                 if (!selectedUsers[selectedId]) {
@@ -302,8 +302,8 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore'], function($, sakai, _) 
             } else {
                 delete selectedUsers[selectedId];
                 renderSelectedContacts();
-                $managegroupmembersSelectAllSelectedContacts.removeAttr('checked');
-                $managegroupmembersSelectAllContacts.removeAttr('checked');
+                $managegroupmembersSelectAllSelectedContacts.prop('checked', false);
+                $managegroupmembersSelectAllContacts.prop('checked', false);
             }
         };
 
@@ -354,15 +354,15 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore'], function($, sakai, _) 
                         'permission': $(item).nextAll('select').val()
                     });
                     delete selectedUsers[selectedId];
-                    $('#' + selectedId + '_chk').removeAttr('checked');
-                    $managegroupmembersSelectAllContacts.removeAttr('checked');
+                    $('#' + selectedId + '_chk').prop('checked', false);
+                    $managegroupmembersSelectAllContacts.prop('checked', false);
                     $(item).parent().next().remove();
                     $(item).parent().remove();
                 });
                 if (sakai_global.group) {
                     sakai.api.Groups.removeUsersFromGroup(sakai_global.group.groupData['sakai:group-id'], usersToDelete, sakai.data.me);
                 }
-                $managegroupmembersSelectAllSelectedContacts.removeAttr('checked');
+                $managegroupmembersSelectAllSelectedContacts.prop('checked', false);
             } else {
                 var errorMsg = sakai.api.i18n.getValueForKey('SELECT_AT_LEAST_ONE_MANAGER', 'managegroupmembers');
                 if (existingGroup && sakai_global.group) {
@@ -405,7 +405,7 @@ require(['jquery', 'sakai/sakai.api.core', 'underscore'], function($, sakai, _) 
         var resetAutosuggest = function(h) {
             sakai.api.Util.AutoSuggest.reset($managegroupmembersMembersAutoSuggestField);
             $('ul',$managegroupmembersSelectedContactsContainer).empty();
-            $(managegroupmembersCheckbox).add($managegroupmembersSelectAllContacts).removeAttr('checked');
+            $(managegroupmembersCheckbox).add($managegroupmembersSelectAllContacts).prop('checked', false);
             h.w.hide();
             if (h.o) {
                 h.o.remove();

--- a/node_modules/oae-core/memberships/js/memberships.js
+++ b/node_modules/oae-core/memberships/js/memberships.js
@@ -31,8 +31,8 @@ define(['jquery', 'oae.core'], function($, oae) {
         };
 
         /**
-         * Initialize a new infinite scroll container that fetches a user's memberships. 
-         * This will detect when a search is happening and will change the endpoint 
+         * Initialize a new infinite scroll container that fetches a user's memberships.
+         * This will detect when a search is happening and will change the endpoint
          * accordingly.
          */
         var getMemberships = function() {
@@ -73,7 +73,7 @@ define(['jquery', 'oae.core'], function($, oae) {
          */
         var setUpAnon = function() {
             if (oae.data.me.anon) {
-                $('.oae-list-options-toggle', $rootel).attr('disabled', 'disabled');
+                $('.oae-list-options-toggle', $rootel).prop('disabled', true);
             }
         };
 
@@ -113,7 +113,7 @@ define(['jquery', 'oae.core'], function($, oae) {
             // Replace the current History.js state to have the query information. This
             // is necessary because a newly loaded page will not contain the data object in its
             // state. Calling the replaceState function will automatically trigger the statechange
-            // event, which will take care of the membership listing. The random number is added to 
+            // event, which will take care of the membership listing. The random number is added to
             // the data object to make sure that the statechange event is triggered after a page reload.
             History.replaceState(newState);
         };

--- a/node_modules/oae-core/participants/js/participants.js
+++ b/node_modules/oae-core/participants/js/participants.js
@@ -32,7 +32,7 @@ define(['jquery', 'oae.core'], function($, oae) {
 
         /**
          * Initialize a new infinite scroll container that fetches the members. This
-         * will detect when a search is happening and will change the endpoint 
+         * will detect when a search is happening and will change the endpoint
          * accordingly.
          */
         var getMembers = function() {
@@ -73,7 +73,7 @@ define(['jquery', 'oae.core'], function($, oae) {
          */
         var setUpAnon = function() {
             if (oae.data.me.anon) {
-                $('.oae-list-options-toggle', $rootel).attr('disabled', 'disabled');
+                $('.oae-list-options-toggle', $rootel).prop('disabled', true);
             }
         };
 
@@ -113,7 +113,7 @@ define(['jquery', 'oae.core'], function($, oae) {
             // Replace the current History.js state to have the query information. This
             // is necessary because a newly loaded page will not contain the data object in its
             // state. Calling the replaceState function will automatically trigger the statechange
-            // event, which will take care of the members listing. The random number is added to 
+            // event, which will take care of the members listing. The random number is added to
             // the data object to make sure that the statechange event is triggered after a page reload.
             History.replaceState(newState);
         };

--- a/node_modules/oae-core/register/js/register.js
+++ b/node_modules/oae-core/register/js/register.js
@@ -194,7 +194,7 @@ define(['jquery', 'underscore', 'oae.core', '//www.google.com/recaptcha/api/js/r
             }
 
             // Disable the register button during creation, so it can't be clicked multiple times
-            $('button, input').attr('disabled', 'disabled');
+            $('button, input').prop('disabled', true);
 
             // Create the user
             var displayName = values.firstName + ' ' + values.lastName;
@@ -211,7 +211,7 @@ define(['jquery', 'underscore', 'oae.core', '//www.google.com/recaptcha/api/js/r
                         showRecaptchaError();
                     }
                     // Unlock the register button again
-                    $('button, input').removeAttr('disabled');
+                    $('button, input').prop('disabled', false);
                 }
             });
         };

--- a/node_modules/oae-core/relatedcontent/javascript/relatedcontent.js
+++ b/node_modules/oae-core/relatedcontent/javascript/relatedcontent.js
@@ -154,7 +154,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
         };
 
         var showMore = function() {
-            $(relatedcontentShowMore).attr('disabled','disabled');
+            $(relatedcontentShowMore).prop('disabled', true);
             page++;
             getRelatedContent();
         };

--- a/node_modules/oae-core/savecontent/javascript/savecontent.js
+++ b/node_modules/oae-core/savecontent/javascript/savecontent.js
@@ -90,7 +90,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
          */
         var toggleSavecontent = function() {
 
-            $savecontent_save.removeAttr('disabled');
+            $savecontent_save.prop('disabled', false);
 
             var savecontentTop = clickedEl.offset().top + clickedEl.height() - 3;
             var savecontentLeft = clickedEl.offset().left + clickedEl.width() / 2 - 122;
@@ -216,7 +216,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
          */
         var saveContent = function(id) {
             if ($('#savecontent_select option:selected', $rootel).data('redirect') !== true) {
-                $savecontent_save.attr('disabled', 'disabled');
+                $savecontent_save.prop('disabled', true);
                 $.each(contentObj.data, function(i, content) {
                     if (sakai.api.Content.Collections.isCollection(content.body)) {
                         sakai.api.Content.Collections.shareCollection(content.body['_path'], id, false, function() {
@@ -262,10 +262,10 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
 
         enableDisableAddButton = function() {
             var dropdownSelection = $('#savecontent_select option:selected', $rootel);
-            if (dropdownSelection.attr('disabled') || !dropdownSelection.val()) {
-                $savecontent_save.attr('disabled', 'disabled');
+            if (dropdownSelection.prop('disabled') || !dropdownSelection.val()) {
+                $savecontent_save.prop('disabled', true);
             } else {
-                $savecontent_save.removeAttr('disabled');
+                $savecontent_save.prop('disabled', false);
             }
         };
 
@@ -299,7 +299,7 @@ require(['jquery', 'sakai/sakai.api.core'], function($, sakai) {
             clickedEl = $(this);
 
             //SAKIII-5514 Fix for disabled buttons in Chrome
-            if (!$(el.target).is(clickedEl) && clickedEl.attr('disabled')) {
+            if (!$(el.target).is(clickedEl) && clickedEl.prop('disabled')) {
                 return false;
             }
             idArr = clickedEl.attr('data-entityid');

--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -60,9 +60,9 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
 
             // Reset controls
             $('#upload-doupload', $rootel).hide();
-            $('#upload-doupload', $rootel).removeAttr('disabled');
+            $('#upload-doupload', $rootel).prop('disabled', false);
             $('#upload-permissions', $rootel).hide();
-            $('#upload-change-permissions', $rootel).removeAttr('disabled');
+            $('#upload-change-permissions', $rootel).prop('disabled', false);
 
             // Reset the progress bar
             $('.progress', $rootel).hide();
@@ -375,9 +375,9 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
                 }
 
                 // Disable editing on upload
-                $('#upload-doupload', $rootel).attr('disabled', 'disabled');
-                $('.upload-trash', $rootel).attr('disabled', 'disabled');
-                $('#upload-change-permissions', $rootel).attr('disabled', 'disabled');
+                $('#upload-doupload', $rootel).prop('disabled', true);
+                $('.upload-trash', $rootel).prop('disabled', true);
+                $('#upload-change-permissions', $rootel).prop('disabled', true);
                 $('.jeditable-field', $rootel).editable('destroy');
                 $('[rel="tooltip"]', $rootel).tooltip('destroy');
 

--- a/node_modules/oae-core/uploadnewversion/js/uploadnewversion.js
+++ b/node_modules/oae-core/uploadnewversion/js/uploadnewversion.js
@@ -75,7 +75,7 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport'], f
 
             if (valid) {
                 selectedFile = file;
-                $('#uploadnewversion-upload', $rootel).removeAttr('disabled');
+                $('#uploadnewversion-upload', $rootel).prop('disabled', false);
             }
         };
 
@@ -110,7 +110,7 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport'], f
          */
         var uploadNewVersion = function() {
             // Disable the upload button
-            $('#uploadnewversion-upload', $rootel).attr('disabled', 'disabled');
+            $('#uploadnewversion-upload', $rootel).prop('disabled', true);
 
             // Hide the file input field
             $('#uploadnewversion-form-input', $rootel).hide();

--- a/shared/vendor/js/jquery-plugins/jquery.jeditable.oae-edited.js
+++ b/shared/vendor/js/jquery-plugins/jquery.jeditable.oae-edited.js
@@ -22,19 +22,19 @@
 /**
   * Version 1.7.1
   *
-  * ** means there is basic unit tests for this parameter. 
+  * ** means there is basic unit tests for this parameter.
   *
   * @name  Jeditable
   * @type  jQuery
   * @param String  target             (POST) URL or function to send edited content to **
-  * @param Hash    options            additional options 
+  * @param Hash    options            additional options
   * @param String  options[method]    method to use to send edited content (POST or PUT) **
   * @param Function options[callback] Function to run after submitting edited content **
   * @param String  options[name]      POST parameter name of edited content
   * @param String  options[id]        POST parameter name of edited div id
   * @param Hash    options[submitdata] Extra parameters to send when submitting edited content.
   * @param String  options[type]      text, textarea or select (or any 3rd party input type) **
-  * @param Integer options[rows]      number of rows if using textarea ** 
+  * @param Integer options[rows]      number of rows if using textarea **
   * @param Integer options[cols]      number of columns if using textarea **
   * @param Mixed   options[height]    'auto', 'none' or height in pixels **
   * @param Mixed   options[width]     'auto', 'none' or width in pixels **
@@ -53,19 +53,19 @@
   * @param String  options[select]    true or false, when true text is highlighted ??
   * @param String  options[placeholder] Placeholder text or html to insert when element is empty. **
   * @param String  options[onblur]    'cancel', 'submit', 'ignore' or function ??
-  *             
+  *
   * @param Function options[onsubmit] function(settings, original) { ... } called before submit
   * @param Function options[onreset]  function(settings, original) { ... } called before reset
   * @param Function options[onerror]  function(settings, original, xhr) { ... } called on error
-  *             
+  *
   * @param Hash    options[ajaxoptions]  jQuery Ajax options. See docs.jquery.com.
-  *             
+  *
   */
 define(['jquery.jeditable-focus']);
 (function($) {
 
     $.fn.editable = function(target, options) {
-            
+
         if ('disable' == target) {
             $(this).data('disabled.editable', true);
             return;
@@ -81,78 +81,78 @@ define(['jquery.jeditable-focus']);
                 .removeData('event.editable');
             return;
         }
-        
+
         var settings = $.extend({}, $.fn.editable.defaults, {target:target}, options);
-        
+
         /* setup some functions */
         var plugin   = $.editable.types[settings.type].plugin || function() { };
         var submit   = $.editable.types[settings.type].submit || function() { };
-        var buttons  = $.editable.types[settings.type].buttons 
+        var buttons  = $.editable.types[settings.type].buttons
                     || $.editable.types['defaults'].buttons;
-        var content  = $.editable.types[settings.type].content 
+        var content  = $.editable.types[settings.type].content
                     || $.editable.types['defaults'].content;
-        var element  = $.editable.types[settings.type].element 
+        var element  = $.editable.types[settings.type].element
                     || $.editable.types['defaults'].element;
-        var reset    = $.editable.types[settings.type].reset 
+        var reset    = $.editable.types[settings.type].reset
                     || $.editable.types['defaults'].reset;
         var callback = settings.callback || function() { };
-        var onedit   = settings.onedit   || function() { }; 
+        var onedit   = settings.onedit   || function() { };
         var onsubmit = settings.onsubmit || function() { };
         var onreset  = settings.onreset  || function() { };
         var onerror  = settings.onerror  || reset;
-          
+
         /* show tooltip */
         if (settings.tooltip) {
             $(this).attr('title', settings.tooltip);
         }
-        
+
         settings.autowidth  = 'auto' == settings.width;
         settings.autoheight = 'auto' == settings.height;
-        
+
         return this.each(function() {
-                        
+
             /* save this to self because this changes when scope changes */
-            var self = this;  
-                   
+            var self = this;
+
             /* inlined block elements lose their width and height after first edit */
             /* save them for later use as workaround */
             var savedwidth  = $(self).width();
             var savedheight = $(self).height();
-            
+
             /* save so it can be later used by $.editable('destroy') */
             $(this).data('event.editable', settings.event);
-            
+
             /* if element is empty add something clickable (if requested) */
             if (!$.trim($(this).html())) {
                 $(this).html(settings.placeholder);
             }
-            
+
             $(this).bind(settings.event, function(e) {
-                
+
                 /* abort if disabled for this element */
                 if (true === $(this).data('disabled.editable')) {
                     return;
                 }
-                
+
                 /* prevent throwing an exeption if edit field is clicked again */
                 if (self.editing) {
                     return;
                 }
-                
+
                 /* abort if onedit hook returns false */
                 if (false === onedit.apply(this, [settings, self])) {
                    return;
                 }
-                
+
                 /* prevent default action and bubbling */
                 e.preventDefault();
                 e.stopPropagation();
-                
+
                 /* remove tooltip */
                 if (settings.tooltip) {
                     $(self).removeAttr('title');
                 }
-                
+
                 /* figure out how wide and tall we are, saved width and height */
                 /* are workaround for http://dev.jquery.com/ticket/2190 */
                 if (0 == $(self).width()) {
@@ -161,29 +161,29 @@ define(['jquery.jeditable-focus']);
                     settings.height = savedheight;
                 } else {
                     if (settings.width != 'none') {
-                        settings.width = 
+                        settings.width =
                             settings.autowidth ? $(self).width()  : settings.width;
                     }
                     if (settings.height != 'none') {
-                        settings.height = 
+                        settings.height =
                             settings.autoheight ? $(self).height() : settings.height;
                     }
                 }
                 //$(this).css('visibility', '');
-                
+
                 /* remove placeholder text, replace is here because of IE */
-                if ($(this).html().toLowerCase().replace(/(;|")/g, '') == 
+                if ($(this).html().toLowerCase().replace(/(;|")/g, '') ==
                     settings.placeholder.toLowerCase().replace(/(;|")/g, '')) {
                         $(this).html('');
                 }
-                                
+
                 self.editing    = true;
                 self.revert     = $(self).text();
                 $(self).html('');
 
                 /* create the form object */
                 var form = $('<form />');
-                
+
                 /* apply css or style or both */
                 if (settings.cssclass) {
                     if ('inherit' == settings.cssclass) {
@@ -197,7 +197,7 @@ define(['jquery.jeditable-focus']);
                     if ('inherit' == settings.style) {
                         form.attr('style', $(self).attr('style'));
                         /* IE needs the second line or display wont be inherited */
-                        form.css('display', $(self).css('display'));                
+                        form.css('display', $(self).css('display'));
                     } else {
                         form.attr('style', settings.style);
                     }
@@ -208,7 +208,7 @@ define(['jquery.jeditable-focus']);
 
                 /* set input content via POST, GET, given data or existing value */
                 var input_content;
-                
+
                 if (settings.loadurl) {
                     var t = setTimeout(function() {
                         input.disabled = true;
@@ -239,18 +239,18 @@ define(['jquery.jeditable-focus']);
                         input_content = settings.data.apply(self, [self.revert, settings]);
                     }
                 } else {
-                    input_content = self.revert; 
+                    input_content = self.revert;
                 }
                 content.apply(form, [input_content, settings, self]);
 
                 input.attr('name', settings.name);
-        
+
                 /* add buttons to the form */
                 buttons.apply(form, [settings, self]);
-         
+
                 /* add created form to self */
                 $(self).append(form);
-         
+
                 /* attach 3rd party plugin if requested */
                 plugin.apply(form, [settings, self]);
 
@@ -261,7 +261,7 @@ define(['jquery.jeditable-focus']);
                 if (settings.select) {
                     input.select();
                 }
-        
+
                 /* discard changes if pressing esc */
                 input.keydown(function(e) {
                     if (e.keyCode == 27) {
@@ -300,19 +300,19 @@ define(['jquery.jeditable-focus']);
 
                 form.submit(function(e) {
 
-                    if (t) { 
+                    if (t) {
                         clearTimeout(t);
                     }
 
                     /* do no submit */
-                    e.preventDefault(); 
-            
+                    e.preventDefault();
+
                     /* call before submit hook. */
-                    /* if it returns false abort submitting */                    
-                    if (false !== onsubmit.apply(form, [settings, self])) { 
+                    /* if it returns false abort submitting */
+                    if (false !== onsubmit.apply(form, [settings, self])) {
                         /* custom inputs call before submit hook. */
                         /* if it returns false abort submitting */
-                        if (false !== submit.apply(form, [settings, self])) { 
+                        if (false !== submit.apply(form, [settings, self])) {
 
                           /* check if given target is function */
                           if ($.isFunction(settings.target)) {
@@ -320,7 +320,7 @@ define(['jquery.jeditable-focus']);
                               $(self).text(str);
                               self.editing = false;
                               callback.apply(self, [self.innerHTML, settings]);
-                              /* TODO: this is not dry */                              
+                              /* TODO: this is not dry */
                               if (!$.trim($(self).html())) {
                                   $(self).html(settings.placeholder);
                               }
@@ -343,7 +343,7 @@ define(['jquery.jeditable-focus']);
 
                               /* show the saving indicator */
                               $(self).html(settings.indicator);
-                              
+
                               /* defaults for ajaxoptions */
                               var ajaxoptions = {
                                   type    : 'POST',
@@ -364,28 +364,28 @@ define(['jquery.jeditable-focus']);
                                       onerror.apply(form, [settings, self, xhr]);
                                   }
                               };
-                              
+
                               /* override with what is given in settings.ajaxoptions */
-                              $.extend(ajaxoptions, settings.ajaxoptions);   
-                              $.ajax(ajaxoptions);          
-                              
+                              $.extend(ajaxoptions, settings.ajaxoptions);
+                              $.ajax(ajaxoptions);
+
                             }
                         }
                     }
-                    
+
                     /* show tooltip again */
                     $(self).attr('title', settings.tooltip);
-                    
+
                     return false;
                 });
             });
-            
+
             /* privileged methods */
             this.reset = function(form) {
                 /* prevent calling reset twice when blurring */
                 if (this.editing) {
                     /* before reset hook, if it returns false abort reseting */
-                    if (false !== onreset.apply(form, [settings, self])) { 
+                    if (false !== onreset.apply(form, [settings, self])) {
                         $(self).text(self.revert);
                         self.editing   = false;
                         if (!$.trim($(self).html())) {
@@ -393,11 +393,11 @@ define(['jquery.jeditable-focus']);
                         }
                         /* show tooltip again */
                         if (settings.tooltip) {
-                            $(self).attr('title', settings.tooltip);                
+                            $(self).attr('title', settings.tooltip);
                         }
-                    }                    
+                    }
                 }
-            };            
+            };
         });
 
     };
@@ -407,7 +407,7 @@ define(['jquery.jeditable-focus']);
         types: {
             defaults: {
                 element : function(settings, original) {
-                    var input = $('<input type="hidden"></input>');                
+                    var input = $('<input type="hidden"></input>');
                     $(this).append(input);
                     return(input);
                 },
@@ -430,7 +430,7 @@ define(['jquery.jeditable-focus']);
                         /* otherwise use button with given string as text */
                         } else {
                             var submit = $('<button type="submit" />');
-                            submit.html(settings.submit);                            
+                            submit.html(settings.submit);
                         }
                         $(this).append(submit);
                     }
@@ -448,9 +448,9 @@ define(['jquery.jeditable-focus']);
                         $(cancel).click(function(event) {
                             //original.reset();
                             if ($.isFunction($.editable.types[settings.type].reset)) {
-                                var reset = $.editable.types[settings.type].reset;                                                                
+                                var reset = $.editable.types[settings.type].reset;
                             } else {
-                                var reset = $.editable.types['defaults'].reset;                                
+                                var reset = $.editable.types['defaults'].reset;
                             }
                             reset.apply(form, [settings, original]);
                             return false;
@@ -495,7 +495,7 @@ define(['jquery.jeditable-focus']);
                 },
                 content : function(data, settings, original) {
                     /* If it is string assume it is json. */
-                    if (String == data.constructor) {      
+                    if (String == data.constructor) {
                         eval ('var json = ' + data);
                     } else {
                     /* Otherwise assume it is a hash already. */
@@ -507,15 +507,15 @@ define(['jquery.jeditable-focus']);
                         }
                         if ('selected' == key) {
                             continue;
-                        } 
+                        }
                         var option = $('<option />').val(key).append(json[key]);
-                        $('select', this).append(option);    
-                    }                    
-                    /* Loop option again to set selected. IE needed this... */ 
+                        $('select', this).append(option);
+                    }
+                    /* Loop option again to set selected. IE needed this... */
                     $('select', this).children().each(function() {
-                        if ($(this).val() == json['selected'] || 
+                        if ($(this).val() == json['selected'] ||
                             $(this).text() == $.trim(original.revert)) {
-                                $(this).attr('selected', 'selected');
+                                $(this).prop('selected', true);
                         }
                     });
                 }

--- a/ui/js/search.js
+++ b/ui/js/search.js
@@ -37,11 +37,11 @@ require(['jquery','oae.core'], function($, oae) {
 
         // Reset the type checkboxes to make sure that none of them stay checked incorrectly
         // when hitting the back and forward buttons
-        $('#search-refine-type input[type="checkbox"]').removeAttr('checked', 'checked');
+        $('#search-refine-type input[type="checkbox"]').prop('checked', false);
         // Get the current type refinements from the History.js data object and select the corresponding checkboxes
         var types = History.getState().data.types;
         $.each(types, function(index, type) {
-            $('#search-refine-type input[type="checkbox"][data-type="' + type + '"]').attr('checked', 'checked');
+            $('#search-refine-type input[type="checkbox"][data-type="' + type + '"]').prop('checked', true);
         });
 
         // Set up the infinite scroll for the list of search results
@@ -85,7 +85,7 @@ require(['jquery','oae.core'], function($, oae) {
     };
 
     /**
-     * Extract the search query and type refinements from the current URL. 
+     * Extract the search query and type refinements from the current URL.
      * This will only be executed when the page is loaded.
      */
     var initSearch = function() {

--- a/ui/search.html
+++ b/ui/search.html
@@ -11,7 +11,7 @@
         <!-- CORE CSS -->
         <link rel="stylesheet" type="text/css" href="/shared/oae/css/oae.core.css" />
         <link rel="stylesheet" type="text/css" href="/api/ui/skin" />
-        
+
         <!-- PAGE CSS -->
         <link rel="stylesheet" type="text/css" href="/ui/css/oae.search.css" />
 


### PR DESCRIPTION
On the search page, checking a refine by type checkbox doesn't keep it checked correctly. We're first unselecting all checkboxes (in case we're hitting the back button) and then selecting the correct types. Even though it's setting the correct `checked` attribute, the tick is not visible.

This was definitely working at some point, and I can't see any changes on these files since, so my first guess is that jQuery 2.0 is doing something odd here.
