### PR TITLE
Browse button has no focus style

### DIFF
--- a/node_modules/oae-core/changepic/js/changepic.js
+++ b/node_modules/oae-core/changepic/js/changepic.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['jquery', 'oae.core', 'jquery.jcrop', 'jquery.fileupload', 'jquery.iframe-transport'], function($, oae) {
+define(['jquery', 'oae.core', 'jquery.jcrop', 'jquery.fileupload', 'jquery.iframe-transport', 'jquery.button-focus'], function($, oae) {
 
     return function(uid) {
 
@@ -55,6 +55,9 @@ define(['jquery', 'oae.core', 'jquery.jcrop', 'jquery.fileupload', 'jquery.ifram
             oae.api.util.template().render($('#changepic-profile-picture-template', $rootel), {
                 'pictureUrl': contextData.picture.medium
             }, $('#changepic-pic-container', $rootel));
+
+            // Add focus functionality to the browse button
+            $('.changepic-browse', $rootel).addFocus();
 
             // Initialize the fileupload plugin
             setUpUploadPicture();

--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'jquery.jeditable'], function($, oae) {
+define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'jquery.jeditable', 'jquery.button-focus'], function($, oae) {
 
     return function(uid, showSettings) {
 
@@ -466,31 +466,14 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
             $('#upload-change-permissions', $rootel).on('click', function() {
                 showPermissions();
             });
-        };
 
-        /**
-         * Add focus functionality to the browse button because the input field is
-         * skinned into an element (span) that doesn't original support tab/focus navigation 
-         */
-        var addFocus = function() {
-            // Set the tabindex to 0 to support tab navigation
-            $('.upload-browse-button').prop('tabindex', 0);
-            // Add keydown listener for the browse button
-            $('.upload-browse-button').keydown(function(ev) {
-                // If the event is a Space or Return
-                if ((ev.which === 13) || (e.which === 32)) {
-                    // Activate the click event to the upload input to show file dialog
-                    $('#upload-input').click();
-                }            
-            });
-            // Set the tabindex of the input field to -1 to disable tab navigation because it's hidden
-            $('#upload-input').prop('tabindex', -1);
-        }
+            // Add focus functionality to the browse button
+            $('.upload-browse-button', $rootel).addFocus();
+        };
 
         setUpReset();
         setUpUploadModal();
         setUpDelete();
-        addFocus();
 
     };
 });

--- a/shared/oae/api/oae.bootstrap.js
+++ b/shared/oae/api/oae.bootstrap.js
@@ -48,6 +48,7 @@ requirejs.config({
 
         // OAE paths
         'bootstrap.modal': 'oae/js/bootstrap-plugins/bootstrap.modal',
+        'jquery.button-focus': 'oae/js/jquery-plugins/jquery.button-focus',
         'jquery.clip': 'oae/js/jquery-plugins/jquery.clip',
         'jquery.dnd-upload': 'oae/js/jquery-plugins/jquery.dnd-upload',
         'jquery.infinitescroll': 'oae/js/jquery-plugins/jquery.infinitescroll',


### PR DESCRIPTION
The Browse button in the upload widget doesn't have a focus style when tabbing onto it. It can be used using the keyboard only, but you can't tell when it's focussed.
