### PR TITLE
Visibility icon issue in clip

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -109,7 +109,7 @@ a.oae-plain-link:hover {
 i.icon-oae-private,
 i.icon-oae-loggedin,
 i.icon-oae-public {
-    font-size: 100%;
+    font-size: 18px;
     width: 18px;
     height: 18px;
 }
@@ -400,7 +400,7 @@ div.oae-thumbnail.icon-oae-user:before {
 div.oae-thumbnail i[class^="icon-"] {
     position: absolute;
     bottom: -8px;
-    right: -8px;
+    right: -9px;
 }
 
 


### PR DESCRIPTION
Outside of clips (e.g. lists), the visibility icons for thumbnails show in the bottom right corner of the thumbnail, as they should. However, inside of clips (content, groups), the visibility icon is a couple of pixels too far down the bottom, despite using the same CSS. We should try to make sure that they are the same.

![screen shot 2013-05-22 at 08 52 42](https://f.cloud.github.com/assets/109850/547032/bd62499e-c2b5-11e2-9fb1-f6aebe67f446.png)
![screen shot 2013-05-22 at 08 52 54](https://f.cloud.github.com/assets/109850/547033/bd60b9ee-c2b5-11e2-9803-e1bdd756eb22.png)
