### PR TITLE
Mark notifications upon open instead of close

### DIFF
--- a/node_modules/oae-core/notifications/js/notifications.js
+++ b/node_modules/oae-core/notifications/js/notifications.js
@@ -135,6 +135,9 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
                     'onShown': function($currentRootEl) {
                         $rootel = $currentRootEl;
                         getNotifications();
+                        // The notifications need to be marked as read straight away, in case the user
+                        // follows a link in the notifications and doesn't actually end up closing the
+                        // clickover on the current page
                         markAsRead();
                     },
                     'onHidden': removeUnreadCount


### PR DESCRIPTION
In order to avoid that the notifications are not marked as read when following a link in the clickover and not actually closing it, we have to mark the notifications as read when the clickover is loaded.
