### PR TITLE
Interrupting a file upload makes it impossible to upload again

### DIFF
--- a/node_modules/oae-core/upload/css/upload.css
+++ b/node_modules/oae-core/upload/css/upload.css
@@ -22,6 +22,10 @@
     margin-bottom: 0;
 }
 
+#upload-modal form  {
+    margin: 0;
+}
+
 #upload-modal .upload-browse-button input {
     cursor: pointer;
     font-size: 23px;

--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -54,6 +54,9 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
             selectedFiles = [];
             selectedFilesSize = 0;
 
+            // Reset the fileupload form
+            $('form', $rootel)[0].reset();
+
             // Hide all steps
             $('.modal-body > div', $rootel).hide();
 
@@ -287,7 +290,7 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
 
                 // If the context of the page is a group context and files will be shared with the group, we
                 // set a flag that will be used to determine which notification to show upon completion
-                contextData.addedToGroupContext = _.contains(viewers, contextData.id)
+                contextData.addedToGroupContext = _.contains(viewers, contextData.id);
 
                 // Update the members of the selected files
                 $.each(selectedFiles, function(index, file) {

--- a/node_modules/oae-core/upload/upload.html
+++ b/node_modules/oae-core/upload/upload.html
@@ -9,11 +9,13 @@
     </div>
     <div class="modal-body">
         <div id="upload-dropzone" class="well text-center hide">
-            __MSG__DROP_FILES_TO_UPLOAD__ <br/>__MSG__OR__<br/>
-            <span class="btn upload-browse-button">
-                <span>__MSG__BROWSE__</span>
-                <input id="upload-input" type="file" multiple="" name="file">
-            </span>
+            <form>
+                __MSG__DROP_FILES_TO_UPLOAD__ <br/>__MSG__OR__<br/>
+                <span class="btn upload-browse-button">
+                    <span>__MSG__BROWSE__</span>
+                    <input id="upload-input" type="file" multiple="" name="file">
+                </span>
+            </form>
         </div>
         <div id="upload-overview-container" class="hide">
             <ul id="upload-selected-container" class="oae-list oae-list-compact"><!-- --></ul>


### PR DESCRIPTION
Tenant: http://oae.oae-qa0.oaeproject.org

Browser: Chrome 27.0.1453.94 m

Description: I go to upload a file, browse on the desktop to make my selection, cancel it before actually uploading, then try to browse and upload it again, only this time the file doesn't appear to be recognized, and I'm unable to complete the operation.

Reproducible steps:  See video: http://screencast.com/t/K2LXsSJf

Console Error messages: NA
