### PR TITLE
Creating Links

### DIFF
--- a/node_modules/oae-core/createlink/js/createlink.js
+++ b/node_modules/oae-core/createlink/js/createlink.js
@@ -100,10 +100,15 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
             // Remove duplicate links
             links = _.unique(links);
             // Remove invalid links
-            links = _.filter(links, function(link) {
-                return isValidLink(link);
+            var filteredLinks = [];
+            $.each(links, function(i, link) {
+                var filteredLink = isValidLink(link);
+                if (filteredLink) {
+                    filteredLinks.push(filteredLink);
+                }
             });
-            return links;
+
+            return filteredLinks;
         };
 
         /**


### PR DESCRIPTION
Browsers: FF 20.0.1 & Chrome 20

Can the bug be reproduced: All the time

Description:
I logged into the tenant oae.oae-qa0.sakaiproject.org and tried to add links to different websites and it didn't work.

Error:
![b](https://f.cloud.github.com/assets/4062666/573772/889ff582-c7b8-11e2-8e7b-ce2c5d79dd12.png)

Steps to reproduce:
1. Log into your OAE account
2. Create Link

Expected Result: One should be able to see the website 
Actual Result: The website page is not found

Other information:
tenants used: oae.oae-qa0.sakaiproject.org
marist.oae-qa0.oaeproject.org
