### PR TITLE
Show results from other tenants when the tenant is not private.

### DIFF
--- a/ui/js/search.js
+++ b/ui/js/search.js
@@ -48,7 +48,8 @@ require(['jquery','oae.core', 'jquery.history'], function($, oae) {
         infinityScroll = $('.oae-list').infiniteScroll('/api/search/general', {
             'limit': 12,
             'q': query,
-            'resourceTypes': types
+            'resourceTypes': types,
+            'includeExternal': !oae.api.config.getValue('oae-tenants', 'tenantprivacy', 'tenantprivate')
         }, '#search-template', {
             'postRenderer': function(data) {
                 $('#search-total-results').text(data.total);


### PR DESCRIPTION
Adds the `includeExternal` parameter to search.
