### PR TITLE
Tile titles are cut off in Safari

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -737,7 +737,7 @@ div.oae-thumbnail i[class^="icon-"] {
 .oae-tile h3 a {
     font-size: 14px;
     font-weight: bold;
-    line-height: 1.2;
+    line-height: 1.4;
     margin: 0px;
 }
 


### PR DESCRIPTION
I can't see it in any other browsers

![screen shot 2013-06-14 at 16 50 52](https://f.cloud.github.com/assets/109850/656528/6b6db322-d52e-11e2-8ebd-bbadf1129cc4.png)
