### PR TITLE
Content comments not properly displayed after deleting a comment

### DIFF
--- a/node_modules/oae-core/comments/comments.html
+++ b/node_modules/oae-core/comments/comments.html
@@ -33,7 +33,7 @@
             </div>
             <div class="media-body">
                 {if !comment.body}
-                    <h4 class="media-heading"><small>__MSG__THIS_COMMENT_HAS_BEEN_DELETED__</small><h4>
+                    <h4 class="media-heading"><small>__MSG__THIS_COMMENT_HAS_BEEN_DELETED__</small></h4>
                 {else}
                     <div class="pull-right">
                         {if !oae.data.me.anon}


### PR DESCRIPTION
Only seen it happening in IE9 after deleting a couple of comments in a thread.

![screen shot 2013-06-14 at 16 52 14](https://f.cloud.github.com/assets/218391/655093/7fb96ade-d50a-11e2-86d3-d359b03948a3.png)
![screen shot 2013-06-14 at 16 57 26](https://f.cloud.github.com/assets/218391/655119/25efb412-d50b-11e2-8beb-ae8754c687b3.png)
