### PR TITLE
Reversing the discussion thread order in activities

### DIFF
--- a/node_modules/oae-core/activity/js/activity.js
+++ b/node_modules/oae-core/activity/js/activity.js
@@ -51,7 +51,11 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
             // Threadkeys will have the following format, primarily to allow for proper thread ordering:
             //  - Top level comments: <createdTimeStamp>|
             //  - Reply: <parentCreatedTimeStamp>#<createdTimeStamp>|
-            return a['oae:threadKey'].split('#').pop() < b['oae:threadKey'].split('#').pop();
+            if (a['oae:threadKey'].split('#').pop() < b['oae:threadKey'].split('#').pop()) {
+                return 1;
+            } else {
+                return -1;
+            }
         };
 
         /**


### PR DESCRIPTION
See #2861.

We're now putting the most recent comment at the top of the comments shown in the activity. This is more consistent with the behaviour on the content profile page.
