### PR TITLE
Hiding Etherpad iFrame when unloading the page

### DIFF
--- a/node_modules/oae-core/etherpad/css/etherpad.css
+++ b/node_modules/oae-core/etherpad/css/etherpad.css
@@ -17,7 +17,7 @@
     padding: 20px 10px 30px;
 }
 
-#etherpad-container .etherpad-editor {
+#etherpad-container #etherpad-editor {
     border: 0;
     width: 100%;
     min-height: 500px

--- a/node_modules/oae-core/etherpad/etherpad.html
+++ b/node_modules/oae-core/etherpad/etherpad.html
@@ -4,7 +4,7 @@
 <div id="etherpad-container"><!-- --></div>
 
 <div id="etherpad-template"><!--
-    <iframe src="${url}" class="etherpad-editor"></iframe>
+    <iframe src="${url}" id="etherpad-editor"></iframe>
 --></div>
 
 <div id="etherpad-no-content-template"><!--

--- a/node_modules/oae-core/etherpad/js/etherpad.js
+++ b/node_modules/oae-core/etherpad/js/etherpad.js
@@ -63,6 +63,10 @@ define(['jquery', 'oae.core'], function($, oae) {
          * the page unloading before the request is completed.
          */
         var publish = function() {
+            // The Etherpad iFrame is hidden to avoid the 'Reconnecting Pad' message showing up. Rather than using `hide`,
+            // `invisible` is being used to avoid the comments jumping to the top of the page.
+            $('#etherpad-editor').addClass('invisible');
+            // Publish the pad's content
             $.ajax({
                 'url': '/api/content/' + contentObj.id + '/publish',
                 'type': 'POST',


### PR DESCRIPTION
To avoid the `Reconnecting` message popping up
