### PR TITLE
Accessdenied redirect

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -1053,10 +1053,10 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
 
         /**
          * Redirect the current user to the 401 page. This can be used when the current user does not have
-         * permission to see a certain page.
+         * permission to see a certain page. The link to which access was denied is added to the url.
          */
         var accessdenied = function() {
-            window.location = '/accessdenied';
+            window.location = '/accessdenied?url=' + window.location.pathname;
         };
 
         /**


### PR DESCRIPTION
As an anoymous user, I go to a private item that I only have access to once I'm signed in. I'm redirected to the /accessdenied page, from which I can login. Once I login, the access denied page is just refreshed instead of redirecting the user to the requested page.

In order to make this work, the original URL should be encoded into the /accessdenied URL. There should already be something in topnavigation that will pick up on this.
