### PR TITLE
Infinite scroll keeps loading next page even though there isn't any.

### DIFF
--- a/node_modules/oae-core/comments/comments.html
+++ b/node_modules/oae-core/comments/comments.html
@@ -27,7 +27,7 @@
 <div id="comments-comment-template"><!--
     {for comment in results}
         {var commentLevel = comment.level > 2 ? 2 : comment.level}
-        <li class="media comments-level-${commentLevel} {if !comment.body} deleted{/if}" data-id="${comment.created}" data-key="${comment.created}">
+        <li class="media comments-level-${commentLevel} {if !comment.body} deleted{/if}" data-id="${comment.created}" data-key="${comment.threadKey}">
             <div class="comments-thumbnail">
                 ${renderThumbnail(comment.createdBy || 'user')}
             </div>


### PR DESCRIPTION
In IE9, infinite scroll can't give it a rest. In the screencast I'm looking at a collabdoc with a couple of comments at the bottom.

http://screencast.com/t/nxiXIksjpAt
