### PR TITLE
No activity for "Add discussion to library"

### DIFF
--- a/shared/oae/macros/activity.html
+++ b/shared/oae/macros/activity.html
@@ -80,7 +80,7 @@
     {elseif activityType === 'discussion-update-visibility'}
         ${renderDiscussionUpdateVisibilitySummary(activity, actor1, actor1URL, object1, object1URL, object1Tenant)}
     {elseif activityType === 'discussion-add-to-library'}
-        ${renderDiscussionAddToLibrarySummary(activity, actor1, actor1URL, object1, object1URL, object1Tenant)}
+        ${renderDiscussionAddToLibrarySummary(activity, actor1, actor1URL, object1, object1URL, object2, object2URL, objectCount)}
     {elseif activityType === 'group-add-member'}
         ${renderGroupAddMemberSummary(activity, actor1, actor1URL, object1, object1URL, object2, object2URL, objectCount, target1, target1URL)}
     {elseif activityType === 'group-create'}
@@ -541,8 +541,15 @@
  * @param  {String}       object1URL    Profile path for the first object on the activity
  * @param  {String}       object1Tenant Name of the tenant to which the content visibility is limited
 -->
-{macro renderDiscussionAddToLibrarySummary(activity, actor1, actor1URL, object1, object1URL, object1Tenant)}
-    __MSG__ACTIVITY_DISCUSSION_ADD__
+{macro renderDiscussionAddToLibrarySummary(activity, actor1, actor1URL, object1, object1URL, object2, object2URL, objectCount)}
+    {if !objectCount}
+        __MSG__ACTIVITY_DISCUSSION_ADD_LIBRARY__
+    {elseif objectCount === 2}
+        __MSG__ACTIVITY_DISCUSSION_ADD_LIBRARY_2__
+    {else}
+        __MSG__ACTIVITY_DISCUSSION_ADD_LIBRARY_2+__
+    {/if}
+
 {/macro}
 
 <!--

--- a/ui/bundles/default.properties
+++ b/ui/bundles/default.properties
@@ -68,7 +68,9 @@ ACTIVITY_CONTENT_VISIBILITY_LINK_PUBLIC = <a href="${actor1URL}">${actor1}</a> c
 ACTIVITY_DEFAULT_1 = <a href="${actor1URL}">${actor1}</a> performed the action &quot;${verb}&quot;
 ACTIVITY_DEFAULT_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> performed the action &quot;${verb}&quot;
 ACTIVITY_DEFAULT_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCount - 1} others performed the action &quot;${verb}&quot;
-ACTIVITY_DISCUSSION_ADD = <a href="${actor1URL}">${actor1}</a> added &quot;<a href="${object1URL}">${object1}</a>&quot; to their discussions
+ACTIVITY_DISCUSSION_ADD_LIBRARY = <a href="${actor1URL}">${actor1}</a> added &quot;<a href="${object1URL}">${object1}</a>&quot; to their discussions
+ACTIVITY_DISCUSSION_ADD_LIBRARY_2 = <a href="${actor1URL}">${actor1}</a> added &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot; to their discussions
+ACTIVITY_DISCUSSION_ADD_LIBRARY_2+ = <a href="${actor1URL}">${actor1}</a> added &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCount - 1} others to their discussions
 ACTIVITY_DISCUSSION_CREATE_1 = <a href="${actor1URL}">${actor1}</a> started the discussion &quot;<a href="${object1URL}">${object1}</a>&quot;
 ACTIVITY_DISCUSSION_CREATE_2 = <a href="${actor1URL}">${actor1}</a> started the discussions &quot;<a href="${object1URL}">${object1}</a>&quot and &quot;<a href="${object2URL}">${object2}</a>&quot;
 ACTIVITY_DISCUSSION_CREATE_2+ = <a href="${actor1URL}">${actor1}</a> started the discussion &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCount - 1} others


### PR DESCRIPTION
There isn't a button to add a discussion to my library, so I just shared it with myself. When I did the resulting activity said:

Branden Visser performed the action "add"

In my feed. I suppose this probably becomes significantly lower priority if there was an add to library clip, as no one would probably think to try and do this.
