### PR TITLE
Time reflecting incorrectly when made changes to Time Zone in Preferences under My account

### DIFF
--- a/shared/oae/api/oae.api.l10n.js
+++ b/shared/oae/api/oae.api.l10n.js
@@ -136,8 +136,8 @@ define(['exports', 'jquery', 'underscore', 'oae.api.config', 'globalize'], funct
     };
 
     /**
-     * Function that will take a date and convert it into a localized time ago string, based on the current
-     * user's locale.
+     * Function that will take a date and convert it into a localized time ago string.
+     * The user's locale does not come into play in this since we're expressing how long ago something happened.
      *
      * @param  {Date|Number}    date        Javascript date object or milliseconds since epoch that needs to be converted into a time ago string
      * @return {String}                     Converted localized time ago string
@@ -147,8 +147,17 @@ define(['exports', 'jquery', 'underscore', 'oae.api.config', 'globalize'], funct
         if (!date) {
             throw new Error('A date must be provided');
         }
-        // Make sure that we are working with a valid date adjusted to the user's timezone
-        date = parseDate(date);
+        // If a value with milliseconds since epoch has been provided, we convert it to a date.
+        // All non-date values passed into this function are expressed in UTC and by passing them into
+        // `new Date` they will be automatically converted to the user's browser timezone.
+        if (_.isNumber(date)) {
+            date = new Date(date);
+        } else if (_.isString(date)) {
+            date = new Date(parseInt(date, 10));
+        }
+
+        // The timeago plugin uses the browsers timezone by relying on `new Date()` to get
+        // the current time. It can then simply compare the current time and the date we pass in.
         return $.timeago(date);
     };
 


### PR DESCRIPTION
Browser: Chrome 20.0.1132.57 m

Can the bug be reproduced: All the time

Description: I logged in, clicked on My account, changed the Time zone from GMT UTC to GMT Eastern Time (US & Canada). Although the changed time was reflecting correctly in chat conversations, but then when I or group members post comments in "My library", "My discussions" or "My groups", the time appears incorrectly. 

Steps to reproduce: 
1. Log in as a new user
2. Click on your user name that will appear on the top left hand side of the page
3. Click on "My account"
4. Change the Time Zone from default GMT UTC to GMT Eastern Time (US & Canada).
5. Click on "Save"
6. Click on "My discussion" to start a new discussion
7. Post a comment

Expected Result: The time should appear as per GMT Eastern Time (US & Canada).
Actual Result: The time appears as per GMT UTC.
![time zone_comments](https://f.cloud.github.com/assets/4551054/579188/a42dd4f4-c86c-11e2-80e1-ade559275818.png)
![time zone_chat](https://f.cloud.github.com/assets/4551054/579189/a81ef3f4-c86c-11e2-8a87-53b5f4624eac.png)
