### PR TITLE
Browser Back Button Breaks Etherpad Document

### DIFF
--- a/node_modules/oae-core/etherpad/css/etherpad.css
+++ b/node_modules/oae-core/etherpad/css/etherpad.css
@@ -15,10 +15,17 @@
 
 #etherpad-container {
     padding: 20px 10px 30px;
+
+    /**
+     * We need to apply a min height to the container that will hold the iframe.
+     * This is so when we remove the iframe from the DOM on page unloads we avoid the comments
+     * jumping to the top of the page.
+     */
+    min-height: 500px;
 }
 
 #etherpad-container #etherpad-editor {
     border: 0;
     width: 100%;
-    min-height: 500px
+    min-height: 500px;
 }

--- a/node_modules/oae-core/etherpad/js/etherpad.js
+++ b/node_modules/oae-core/etherpad/js/etherpad.js
@@ -63,9 +63,12 @@ define(['jquery', 'oae.core'], function($, oae) {
          * the page unloading before the request is completed.
          */
         var publish = function() {
-            // The Etherpad iFrame is hidden to avoid the 'Reconnecting Pad' message showing up. Rather than using `hide`,
-            // `invisible` is being used to avoid the comments jumping to the top of the page.
-            $('#etherpad-editor', $rootel).addClass('invisible');
+            // The Etherpad iFrame is removed to avoid the 'Reconnecting Pad' message showing up.
+            // Rather than hiding the iframe, we need to remove it from the DOM, as the back button
+            // would otherwise break in IE10. We currently have no real knowledge as to why this is
+            // necessary, only that it seems to work.
+            $('#etherpad-editor', $rootel).remove();
+
             // Publish the pad's content
             $.ajax({
                 'url': '/api/content/' + contentObj.id + '/publish',


### PR DESCRIPTION
_This issue is intermittent and I was only able to replicate it in IE 10_
Browser: IE 10
OS: Win 7 SP1 64-bit

Issue: When typing on an etherpad document if a user clicks the Home button and then uses the browsers Back button to return to the etherpad document it will show broken text. 

Please see screenshot for details on broken text.

![browserbackbutton](https://f.cloud.github.com/assets/4571236/655216/59e14d60-d50d-11e2-90bf-fcd85c48b702.jpg)
