### PR TITLE
Race condition in requirejs when loading pages

### DIFF
--- a/shared/oae/errors/accessdenied.html
+++ b/shared/oae/errors/accessdenied.html
@@ -47,7 +47,11 @@
         <!-- DEPENDENCIES -->
         <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
         <!-- PAGE JS -->
-        <script>require(['/shared/oae/errors/js/accessdenied.js']);</script>
+        <script>
+            require(['oae.bootstrap'], function() {
+                require(['/shared/oae/errors/js/accessdenied.js']);
+            });
+        </script>
 
     </body>
 </html>

--- a/shared/oae/errors/notfound.html
+++ b/shared/oae/errors/notfound.html
@@ -42,7 +42,11 @@
         <!-- DEPENDENCIES -->
         <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
         <!-- PAGE JS -->
-        <script>require(['/shared/oae/errors/js/notfound.js']);</script>
+        <script>
+            require(['oae.bootstrap'], function() {
+                require(['/shared/oae/errors/js/notfound.js']);
+            });
+        </script>
 
     </body>
 </html>

--- a/ui/content.html
+++ b/ui/content.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE HTML>
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
@@ -103,7 +104,11 @@
         <!-- DEPENDENCIES -->
         <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
         <!-- PAGE JS -->
-        <script>require(['/ui/js/content.js']);</script>
+        <script>
+            require(['oae.bootstrap'], function() {
+                require(['/ui/js/content.js']);
+            });
+        </script>
 
     </body>
 </html>

--- a/ui/discussion.html
+++ b/ui/discussion.html
@@ -105,7 +105,11 @@
         <!-- DEPENDENCIES -->
         <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
         <!-- PAGE JS -->
-        <script>require(['/ui/js/discussion.js']);</script>
+        <script>
+            require(['oae.bootstrap'], function() {
+                require(['/ui/js/discussion.js']);
+            });
+        </script>
 
     </body>
 </html>

--- a/ui/group.html
+++ b/ui/group.html
@@ -120,7 +120,11 @@
         <!-- DEPENDENCIES -->
         <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
         <!-- PAGE JS -->
-        <script>require(['/ui/js/group.js']);</script>
+        <script>
+            require(['oae.bootstrap'], function() {
+                require(['/ui/js/group.js']);
+            });
+        </script>
 
     </body>
 </html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -72,7 +72,10 @@
         <!-- DEPENDENCIES -->
         <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
         <!-- PAGE JS -->
-        <script>require(['/ui/js/index.js']);</script>
-
+        <script>
+            require(['oae.bootstrap'], function() {
+                require(['/ui/js/index.js']);
+            });
+        </script>
     </body>
 </html>

--- a/ui/me.html
+++ b/ui/me.html
@@ -104,7 +104,11 @@
         <!-- DEPENDENCIES -->
         <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
         <!-- PAGE JS -->
-        <script>require(['/ui/js/me.js']);</script>
+        <script>
+            require(['oae.bootstrap'], function() {
+                require(['/ui/js/me.js']);
+            });
+        </script>
 
     </body>
 </html>

--- a/ui/search.html
+++ b/ui/search.html
@@ -114,7 +114,11 @@
         <!-- DEPENDENCIES -->
         <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
         <!-- PAGE JS -->
-        <script>require(['/ui/js/search.js']);</script>
+        <script>
+            require(['oae.bootstrap'], function() {
+                require(['/ui/js/search.js']);
+            });
+        </script>
 
     </body>
 </html>

--- a/ui/user.html
+++ b/ui/user.html
@@ -55,7 +55,11 @@
         <!-- DEPENDENCIES -->
         <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
         <!-- PAGE JS -->
-        <script>require(['/ui/js/user.js']);</script>
+        <script>
+            require(['oae.bootstrap'], function() {
+                require(['/ui/js/user.js']);
+            });
+        </script>
 
     </body>
 </html>


### PR DESCRIPTION
I've found that the bootstrap paths sometimes aren't properly loaded at the time that it tries to load the oae.core libraries, resulting in trying to access a bunch of jquery plugins inside /shared/oae/api/*

The actual issue doesn't make a whole lot of sense to me, aside from a potential bug in require.js due to a race condition. The assumption made is that the second require on most of the pages (e.g., `require('/ui/js/index.js') -> oae.core -> *`)is causing a race with the data-main `oae.bootstrap -> oae.core -> *` and require.js gets confused about using the requirejs.config(...) path values to resolve the resources.

Testing shows that wrapping the require in the page as such:

`require(['oae.bootstrap'], function() { require('/ui/js/index.js'); });` should allow oae.bootstrap enough time to do it's thing, therefore avoiding such a race.
