### PR TITLE
Safari race conditions

### DIFF
--- a/shared/oae/api/oae.bootstrap.js
+++ b/shared/oae/api/oae.bootstrap.js
@@ -86,6 +86,17 @@ requirejs.config({
 });
 
 /*!
- * Load all of the dependencies and core OAE APIs
+ * Load all of the dependencies, core OAE APIs, and the page-specific javascript file (if specified)
  */
-require(['oae.core']);
+require(['oae.core'], function() {
+    // Find a script that has specified both the data-main (which loaded this bootstrap script) and a data-loadmodule attribute. The
+    // data-loadmodule attribute tells us which script they wish to load *after* the core APIs have been properly bootstrapped.
+    var $mainScript = $('script[data-main][data-loadmodule]');
+    if ($mainScript.length) {
+        var loadModule = $mainScript.attr('data-loadmodule');
+        if (loadModule) {
+            // Require the module they specified in the data-loadmodule attribute
+            require([loadModule]);
+        }
+    }
+});

--- a/shared/oae/errors/accessdenied.html
+++ b/shared/oae/errors/accessdenied.html
@@ -45,9 +45,7 @@
         <div data-widget="footer"><!-- --></div>
 
         <!-- DEPENDENCIES -->
-        <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
-        <!-- PAGE JS -->
-        <script data-requiremodule="oae.bootstrap">require(['/shared/oae/errors/js/accessdenied.js']);</script>
+        <script data-main="/shared/oae/api/oae.bootstrap.js" data-loadmodule="/shared/oae/errors/js/accessdenied.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
 
     </body>
 </html>

--- a/shared/oae/errors/notfound.html
+++ b/shared/oae/errors/notfound.html
@@ -40,9 +40,7 @@
         <div data-widget="footer"><!-- --></div>
 
         <!-- DEPENDENCIES -->
-        <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
-        <!-- PAGE JS -->
-        <script data-requiremodule="oae.bootstrap">require(['/shared/oae/errors/js/notfound.js']);</script>
+        <script data-main="/shared/oae/api/oae.bootstrap.js" data-loadmodule="/shared/oae/errors/js/notfound.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
 
     </body>
 </html>

--- a/ui/content.html
+++ b/ui/content.html
@@ -101,9 +101,7 @@
         <div data-widget="footer"><!-- --></div>
 
         <!-- DEPENDENCIES -->
-        <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
-        <!-- PAGE JS -->
-        <script data-requiremodule="oae.bootstrap">require(['/ui/js/content.js']);</script>
+        <script data-main="/shared/oae/api/oae.bootstrap.js" data-loadmodule="/ui/js/content.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
 
     </body>
 </html>

--- a/ui/discussion.html
+++ b/ui/discussion.html
@@ -103,9 +103,7 @@
         <div data-widget="footer"><!-- --></div>
 
         <!-- DEPENDENCIES -->
-        <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
-        <!-- PAGE JS -->
-        <script data-requiremodule="oae.bootstrap">require(['/ui/js/discussion.js']);</script>
+        <script data-main="/shared/oae/api/oae.bootstrap.js" data-loadmodule="/ui/js/discussion.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
 
     </body>
 </html>

--- a/ui/group.html
+++ b/ui/group.html
@@ -131,9 +131,7 @@
         <div data-widget="footer"><!-- --></div>
 
         <!-- DEPENDENCIES -->
-        <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
-        <!-- PAGE JS -->
-        <script data-requiremodule="oae.bootstrap">require(['/ui/js/group.js']);</script>
+        <script data-main="/shared/oae/api/oae.bootstrap.js" data-loadmodule="/ui/js/group.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
 
     </body>
 </html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -70,9 +70,7 @@
         <div data-widget="footer"><!-- --></div>
 
         <!-- DEPENDENCIES -->
-        <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
-        <!-- PAGE JS -->
-        <script data-requiremodule="oae.bootstrap">require(['/ui/js/index.js']);</script>
+        <script data-main="/shared/oae/api/oae.bootstrap.js" data-loadmodule="/ui/js/index.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
 
     </body>
 </html>

--- a/ui/me.html
+++ b/ui/me.html
@@ -102,9 +102,7 @@
         <div data-widget="footer"><!-- --></div>
 
         <!-- DEPENDENCIES -->
-        <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
-        <!-- PAGE JS -->
-        <script data-requiremodule="oae.bootstrap">require(['/ui/js/me.js']);</script>
+        <script data-main="/shared/oae/api/oae.bootstrap.js" data-loadmodule="/ui/js/me.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
 
     </body>
 </html>

--- a/ui/search.html
+++ b/ui/search.html
@@ -112,9 +112,7 @@
         <div data-widget="footer"><!-- --></div>
 
         <!-- DEPENDENCIES -->
-        <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
-        <!-- PAGE JS -->
-        <script data-requiremodule="oae.bootstrap">require(['/ui/js/search.js']);</script>
+        <script data-main="/shared/oae/api/oae.bootstrap.js" data-loadmodule="/ui/js/search.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
 
     </body>
 </html>

--- a/ui/user.html
+++ b/ui/user.html
@@ -53,9 +53,7 @@
         <div data-widget="footer"><!-- --></div>
 
         <!-- DEPENDENCIES -->
-        <script data-main="/shared/oae/api/oae.bootstrap.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
-        <!-- PAGE JS -->
-        <script data-requiremodule="oae.bootstrap">require(['/ui/js/user.js']);</script>
+        <script data-main="/shared/oae/api/oae.bootstrap.js" data-loadmodule="/ui/js/user.js" src="/shared/vendor/js/requirejs/require-jquery.js"></script>
 
     </body>
 </html>


### PR DESCRIPTION
The bugbash showed intermittent failures in Safari because of require.js race conditions:

```
Failed to load resource: the server responded with a status of 404 (Not Found)
require-jquery.3f5c3fe4.js:1Error: Script error
http://requirejs.org/docs/errors.html#scripterror
https://oae.oae-qa0.oaeproject.org/shared/oae/api/oae.core.jsFailed to load resource: the server responded with a status of 404 (Not Found)
require-jquery.3f5c3fe4.js:1Error: Script error
http://requirejs.org/docs/errors.html#scripterror
```
