### PR TITLE
Showing members instead of group in add to group activity

### DIFF
--- a/node_modules/oae-core/activity/activity.html
+++ b/node_modules/oae-core/activity/activity.html
@@ -40,7 +40,7 @@
     {macro renderPreview(activity)}
         <div class="activity-preview-container clearfix">
             {var previewObj = activity.target || activity.object}
-            {if previewObj['oae:id'] === oae.data.me.id}
+            {if previewObj['oae:id'] === oae.data.me.id || activity['oae:activityType'] === 'group-add-member'}
                 {var previewObj = activity.object}
             {elseif activity['oae:activityType'] === 'group-join'}
                 {var previewObj = activity.actor}


### PR DESCRIPTION
The Add members to group activity should show the members that have been added to the group instead of the group, unless you've been added to the group yourself.

See #3006
