### PR TITLE
Allow for oEmbed to be used on HTTPS

### DIFF
--- a/node_modules/oae-core/linkpreview/js/linkpreview.js
+++ b/node_modules/oae-core/linkpreview/js/linkpreview.js
@@ -64,7 +64,7 @@ define(['jquery', 'oae.core', 'jquery.oembed'], function($, oae) {
             });
 
             // Img.ly
-            $.fn.updateOEmbedProvider('img.ly', 'photo', ['img\\.ly/.+'],'http://img.ly/show/large/$1', {
+            $.fn.updateOEmbedProvider('img.ly', 'photo', ['img\\.ly/.+'],'//img.ly/show/large/$1', {
                 'embedtag': {tag: 'img'}
             });
 
@@ -90,7 +90,7 @@ define(['jquery', 'oae.core', 'jquery.oembed'], function($, oae) {
                             }
                             embed.append(oae.api.util.template().render($('#linkpreview-image-template', $rootel), {
                                 'img': results['og:image'],
-                                'link': widgetData
+                                'linkProfile': widgetData
                             }));
                         }
                         return embed;
@@ -110,7 +110,7 @@ define(['jquery', 'oae.core', 'jquery.oembed'], function($, oae) {
                 oae.api.util.template().render($('#linkpreview-default-template', $rootel), {'linkProfile': widgetData}, $('#linkpreview-container'), $rootel);
             // Embed the link as an iframe
             } else {
-                oae.api.util.template().render($('#linkpreview-iframe-template', $rootel), {'linkProfile': widgetData}, $('#linkpreview-container'), $rootel);
+                oae.api.util.template().render($('#linkpreview-iframe-template', $rootel), {'link': widgetData.link}, $('#linkpreview-container'), $rootel);
             }
         };
 

--- a/node_modules/oae-core/linkpreview/linkpreview.html
+++ b/node_modules/oae-core/linkpreview/linkpreview.html
@@ -27,7 +27,7 @@
 
 <!-- IFRAME EMBEDDING -->
 <div id="linkpreview-iframe-template"><!--
-    <iframe src="${linkProfile.link}"></iframe>
+    <iframe src="${link}"></iframe>
 --></div>
 
 <!-- IMAGE EMBEDDING -->

--- a/shared/vendor/js/jquery-plugins/jquery.oembed.js
+++ b/shared/vendor/js/jquery-plugins/jquery.oembed.js
@@ -178,7 +178,7 @@
             + " and " + (/html/.test(from) ? 'xpath' : 'itemPath') + "='" + (embedProvider.yql.xpath || '/')+"'" ;
         if(from=='html') query += " and compat='html5'";
         var ajaxopts = $.extend({
-          url: "http://query.yahooapis.com/v1/public/yql",
+          url: "//query.yahooapis.com/v1/public/yql",
           dataType: 'jsonp',
           data: {
             q: query,
@@ -533,16 +533,16 @@
 
     new $.fn.oembed.OEmbedProvider("embedr", "video", ["embedr\\.com/playlist/.+"],"http://embedr.com/swf/slider/$1/425/520/default/false/std?",
       {templateRegex:/.*playlist\/([^\/]+).*/, embedtag : {width:425,height: 520}}),
-    new $.fn.oembed.OEmbedProvider("blip", "video", ["blip\\.tv/.+"], "http://blip.tv/oembed/"),
+    new $.fn.oembed.OEmbedProvider("blip", "video", ["blip\\.tv/.+"], "//blip.tv/oembed/"),
     new $.fn.oembed.OEmbedProvider("minoto-video", "video", ["http://api.minoto-video.com/publishers/.+/videos/.+","http://dashboard.minoto-video.com/main/video/details/.+","http://embed.minoto-video.com/.+"], "http://api.minoto-video.com/services/oembed.json",{useYQL:'json'}),
     new $.fn.oembed.OEmbedProvider("animoto", "video", ["animoto.com/play/.+"], "http://animoto.com/services/oembed"),
-    new $.fn.oembed.OEmbedProvider("hulu", "video", ["hulu\\.com/watch/.*"], "http://www.hulu.com/api/oembed.json"),
+    new $.fn.oembed.OEmbedProvider("hulu", "video", ["hulu\\.com/watch/.*"], "//www.hulu.com/api/oembed.json"),
     new $.fn.oembed.OEmbedProvider("ustream", "video", ["ustream\\.tv/recorded/.*"], "http://www.ustream.tv/oembed",{useYQL:'json'}),
     new $.fn.oembed.OEmbedProvider("videojug", "video", ["videojug\\.com/(film|payer|interview).*"], "http://www.videojug.com/oembed.json",{useYQL:'json'}),
     new $.fn.oembed.OEmbedProvider("sapo", "video", ["videos\\.sapo\\.pt/.*"], "http://videos.sapo.pt/oembed",{useYQL:'json'}),
     new $.fn.oembed.OEmbedProvider("vodpod", "video", ["vodpod.com/watch/.*"], "http://vodpod.com/oembed.js",{useYQL:'json'}),
 	new $.fn.oembed.OEmbedProvider("vimeo", "video", ["www\.vimeo\.com\/groups\/.*\/videos\/.*", "www\.vimeo\.com\/.*", "vimeo\.com\/groups\/.*\/videos\/.*", "vimeo\.com\/.*"], "//vimeo.com/api/oembed.json"),
-	new $.fn.oembed.OEmbedProvider("dailymotion", "video", ["dailymotion\\.com/.+"],'http://www.dailymotion.com/services/oembed'),
+	new $.fn.oembed.OEmbedProvider("dailymotion", "video", ["dailymotion\\.com/.+"],'//www.dailymotion.com/services/oembed'),
     new $.fn.oembed.OEmbedProvider("5min", "video", ["www\\.5min\\.com/.+"], 'http://api.5min.com/oembed.xml',{useYQL:'xml'}),
     new $.fn.oembed.OEmbedProvider("National Film Board of Canada", "video", ["nfb\\.ca/film/.+"],'http://www.nfb.ca/remote/services/oembed/',{useYQL:'json'}),
     new $.fn.oembed.OEmbedProvider("qik", "video", ["qik\\.com/\\w+"], 'http://qik.com/api/oembed.json',{useYQL:'json'}),
@@ -563,7 +563,7 @@
     new $.fn.oembed.OEmbedProvider("shoudio", "rich", ["shoudio.com/.+","shoud.io/.+"], "http://shoudio.com/api/oembed"),
     new $.fn.oembed.OEmbedProvider("mixcloud", "rich", ["mixcloud.com/.+"],'http://www.mixcloud.com/oembed/',{useYQL:'json'}),
     new $.fn.oembed.OEmbedProvider("rdio.com", "rich", ["rd.io/.+","rdio.com"], "http://www.rdio.com/api/oembed/"),
-    new $.fn.oembed.OEmbedProvider("Soundcloud", "rich", ["soundcloud.com/.+","snd.sc/.+"], "http://soundcloud.com/oembed",{format:'js'}),
+    new $.fn.oembed.OEmbedProvider("Soundcloud", "rich", ["soundcloud.com/.+","snd.sc/.+"], "//soundcloud.com/oembed",{format:'js'}),
     new $.fn.oembed.OEmbedProvider("bandcamp", "rich", ["bandcamp\\.com/album/.+"], null,
 		{yql:{xpath:"//meta[contains(@content, \\'EmbeddedPlayer\\')]", from:'html'
 		  , datareturn:function(results){
@@ -573,7 +573,7 @@
 		}),
 
      //Photo
-		new $.fn.oembed.OEmbedProvider("deviantart", "photo", ["deviantart.com/.+","fav.me/.+","deviantart.com/.+"], "http://backend.deviantart.com/oembed",{format:'jsonp'}),
+		new $.fn.oembed.OEmbedProvider("deviantart", "photo", ["deviantart.com/.+","fav.me/.+","deviantart.com/.+"], "//backend.deviantart.com/oembed",{format:'jsonp'}),
 		new $.fn.oembed.OEmbedProvider("skitch", "photo", ["skitch.com/.+"], null,
     {yql:{xpath:"json", from:'json'
           , url: function(externalurl){return 'http://skitch.com/oembed/?format=json&url='+externalurl}
@@ -581,9 +581,9 @@
         }
     }),
 		new $.fn.oembed.OEmbedProvider("mobypicture", "photo", ["mobypicture.com/user/.+/view/.+","moby.to/.+"], "http://api.mobypicture.com/oEmbed"),
-		new $.fn.oembed.OEmbedProvider("flickr", "photo", ["flickr\\.com/photos/.+"], "http://flickr.com/services/oembed",{callbackparameter:'jsoncallback'}),
+		new $.fn.oembed.OEmbedProvider("flickr", "photo", ["flickr\\.com/photos/.+"], "//www.flickr.com/services/oembed",{callbackparameter:'jsoncallback'}),
 		new $.fn.oembed.OEmbedProvider("photobucket", "photo", ["photobucket\\.com/(albums|groups)/.+"], "http://photobucket.com/oembed/"),
-		new $.fn.oembed.OEmbedProvider("instagram", "photo", ["instagr\\.?am(\\.com)?/.+"], "http://api.instagram.com/oembed"),
+		new $.fn.oembed.OEmbedProvider("instagram", "photo", ["instagr\\.?am(\\.com)?/.+"], "//api.instagram.com/oembed"),
 		//new $.fn.oembed.OEmbedProvider("yfrog", "photo", ["yfrog\\.(com|ru|com\\.tr|it|fr|co\\.il|co\\.uk|com\\.pl|pl|eu|us)/.+"], "http://www.yfrog.com/api/oembed",{useYQL:"json"}),
 		new $.fn.oembed.OEmbedProvider("SmugMug", "photo", ["smugmug.com/[-.\\w@]+/.+"], "http://api.smugmug.com/services/oembed/"),
 
@@ -600,7 +600,7 @@
     new $.fn.oembed.OEmbedProvider("circuitlab", "photo", ["circuitlab.com/circuit/.+"],"https://www.circuitlab.com/circuit/$1/screenshot/540x405/",
       {templateRegex:/.*circuit\/([^\/]+).*/ , embedtag : {tag:'img'},nocache:1}),
     new $.fn.oembed.OEmbedProvider("23hq", "photo", ["23hq.com/[-.\\w@]+/photo/.+"],"http://www.23hq.com/23/oembed",{useYQL:"json"}),
-    new $.fn.oembed.OEmbedProvider("img.ly", "photo", ["img\\.ly/.+"],"http://img.ly/show/thumb/$1",
+    new $.fn.oembed.OEmbedProvider("img.ly", "photo", ["img\\.ly/.+"],"//img.ly/show/thumb/$1",
       {templateRegex:/.*ly\/([^\/]+).*/ , embedtag : {tag:'img'},nocache:1
       }),
     new $.fn.oembed.OEmbedProvider("twitgoo.com", "photo", ["twitgoo\\.com/.+"],"http://twitgoo.com/show/thumb/$1",
@@ -634,7 +634,7 @@
         flashvars : "lang=en_US&amp;embedId=pt-embed-$1-693&amp;treeId=$1&amp;pearlId=$2&amp;treeTitle=Diagrams%2FVisualization&amp;site=www.pearltrees.com%2FF"}
       }),
 
-    new $.fn.oembed.OEmbedProvider("prezi", "rich", ["prezi.com/.*"],"http://prezi.com/bin/preziloader.swf?",
+    new $.fn.oembed.OEmbedProvider("prezi", "rich", ["prezi.com/.*"],"//prezi.com/bin/preziloader.swf?",
       {templateRegex:/.*com\/([^\/]+)\/.*/,embedtag : {width:550,height: 400,
         flashvars : "prezi_id=$1&amp;lock_to_path=0&amp;color=ffffff&amp;autoplay=no&amp;autohide_ctrls=0"
         }
@@ -781,7 +781,7 @@
        embedtag : {tag: 'iframe', width:'120px',height: '240px'}
       }),
 
-    new $.fn.oembed.OEmbedProvider("slideshare", "rich", ["slideshare\.net"], "http://www.slideshare.net/api/oembed/2",{format:'jsonp'}),
+    new $.fn.oembed.OEmbedProvider("slideshare", "rich", ["slideshare\.net"], "//www.slideshare.net/api/oembed/2",{format:'jsonp'}),
     new $.fn.oembed.OEmbedProvider("roomsharejp", "rich", ["roomshare\\.jp/(en/)?post/.*"], "http://roomshare.jp/oembed.json"),
 
     new $.fn.oembed.OEmbedProvider("lanyard", "rich", ["lanyrd.com/\\d+/.+"], null,


### PR DESCRIPTION
When using oEmbed on an https page, security conscious browsers such as Chrome won't load some of the http jsonp and swf content.

```
[blocked] The page at https://mydomain.org/mypage ran insecure content from http://flickr.com/services/oembed?format=json&url=http%3A//www.flickr.com/p…et-72157633424719011&jsoncallback=jQuery20006060085988137871_1372157077449.
```

In this PR, the providers we support have been made protocol agnostic and I've tested this on both http and https:
- blip.tv
- dailymotion
- deviantart
- flickr
- ifixit.com
- img.ly
- instagram
- pastebin.com
- pinterest
- scribd
- slideshare
- soundcloud
- speakerdeck
- ted.com
- twitgoo
- twitpic
- vimeo
- youtube

A PR has also been submitted to jQuery.oembed at https://github.com/starfishmod/jquery-oembed-all/pull/87
