### PR TITLE
Removing application/octet-stream as Word document

### DIFF
--- a/shared/oae/api/oae.api.content.js
+++ b/shared/oae/api/oae.api.content.js
@@ -565,8 +565,7 @@ define(['exports', 'jquery', 'underscore', 'oae.api.i18n'], function(exports, $,
                 'application/doc',
                 'application/msword',
                 'application/vnd.openxmlformats-officedocument.word*',
-                'application/vnd.oasis.opendocument.text',
-                'application/octet-stream'
+                'application/vnd.oasis.opendocument.text'
             ]
         }
     };


### PR DESCRIPTION
To avoid Exe files showing as Word files.

See #3022
