### PR TITLE
Fixed vertical alignment of default icons

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -386,6 +386,7 @@ div.oae-thumbnail img {
 }
 
 div.oae-thumbnail:before {
+    display: inline-block;
     font-size: 20px;
     padding-top: 50%;
     margin-top: -11px;


### PR DESCRIPTION
Caused by FontAwesome upgrade.

See #3025
