### PR TITLE
Add absolute path to make sure that hashing happens correctly

### DIFF
--- a/shared/vendor/js/jquery-plugins/jcrop/jquery.Jcrop.css
+++ b/shared/vendor/js/jquery-plugins/jcrop/jquery.Jcrop.css
@@ -15,7 +15,7 @@
 /* Selection Border */
 .jcrop-vline,
 .jcrop-hline {
-  background: #ffffff url("Jcrop.gif");
+  background: #ffffff url("/shared/vendor/js/jquery-plugins/jcrop/Jcrop.gif");
   font-size: 0;
   position: absolute;
 }


### PR DESCRIPTION
This is the same approach that we've used for other files in /shared/vendor as well (e.g. 3rd party login buttons)

See #3023
