### PR TITLE
Renaming a link on creation needs unfocus

### DIFF
--- a/node_modules/oae-core/createlink/js/createlink.js
+++ b/node_modules/oae-core/createlink/js/createlink.js
@@ -139,6 +139,10 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
             value = $.trim(value);
             var prevValue = this.revert;
             var $listItem = $(this).parents('li.oae-list-item');
+
+            // Re-enable the link creation button
+            $('#createlink-create', $rootel).prop('disabled', false);
+
             // If no name has been entered, we fall back to the previous value
             if (!value) {
                 return prevValue;
@@ -225,6 +229,11 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
             $('.jeditable-field', $rootel).editable(editableSubmitted, {
                 'onblur': 'submit',
                 'select' : true
+            });
+
+            // Disable the submit button when a jEditable field is being edited.
+            $('.jeditable-field', $rootel).on('click.editable', function() {
+                $('#createlink-create', $rootel).prop('disabled', true);
             });
 
             // Apply jQuery Tooltip to the link title field to show that the fields are editable

--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -130,6 +130,10 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
             value = $.trim(value);
             var prevValue = this.revert;
             var $listItem = $(this).parents('li.oae-list-item');
+
+            // Re-enable the upload button
+            $('#upload-upload', $rootel).prop('disabled', false);
+
             // If no name has been entered, we fall back to the previous value
             if (!value) {
                 return prevValue;
@@ -243,6 +247,11 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
             $('.jeditable-field', $rootel).editable(editableSubmitted, {
                 'onblur': 'submit',
                 'select' : true
+            });
+
+            // Disable the submit button when a jEditable field is being edited.
+            $('.jeditable-field', $rootel).on('click.editable', function() {
+                $('#upload-upload', $rootel).prop('disabled', true);
             });
 
             // Apply jQuery Tooltip to the file title field to show that the fields are editable


### PR DESCRIPTION
Browser: IE10
OS: Windows 8

Steps to reproduce:

1/ Click create link
2/ Enter a URL (ex: www.youtube.com)
3/ Click Next
4/ Click the URL so you can rename it (ex: YouTube)
5/ Click the next button _without_ losing focus on the text field
6/ The displayName is still the URL rather than the updated one
