### PR TITLE
Disable Nginx proxy_read_timeout for file uploads

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -296,6 +296,71 @@ http {
             proxy_pass http://tenantworkers;
         }
 
+        location /api/content/create {
+            expires -1;
+            proxy_read_timeout 300;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location ~* /api/content/([^\/]+)/messages {
+            expires -1;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location ~* /api/content/([^\/]+)/newversion {
+            expires -1;
+            proxy_read_timeout 300;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location /api/discussion/create {
+            expires -1;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location ~* /api/discussion/([^\/]+)/messages {
+            expires -1;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location /api/group/create {
+            expires -1;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location ~* /api/group/([^\/]+)/picture {
+            expires -1;
+            proxy_read_timeout 60;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location /api/user/create {
+            expires -1;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location /api/user/import {
+            expires -1;
+            proxy_read_timeout 300;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location ~* /api/user/([^\/]+)/picture {
+            expires -1;
+            proxy_read_timeout 60;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
         # Explicitly don't cache any other API requests
         location /api/ {
             expires -1;


### PR DESCRIPTION
Details:
1. Removed the /mobile stuff. That stuff isn't complete yet I don't think
2. Consolidated some of the proxy and gzip stuff into the `http { }` block. It doesn't need to be copied in every single location
3. Set the default proxy_read_timeout to 5 seconds
4. Set the content create proxy_read_timeout to 5min
5. Disabled proxy_next_upstream on timeout errors for discussion, content and groups, as it could retry N amount of times if the operation simply takes longer. This is dangerous and could accidentally create lots of new items
6. Set etherpad proxy_read_timeout back up to the default 1min to avoid frequent reconnects of idle websocket connections

Ideally I could specify in nginx "Do not jump to the next upstream on timeouts for all POST requests", but unfortunately this is not possible. We also cannot tune the proxy_read_timeout based on http method either. Hopefully someday nginx can provide that functionality.
