### PR TITLE
Cropping outside of the image is still possible

### DIFF
--- a/node_modules/oae-core/changepic/js/changepic.js
+++ b/node_modules/oae-core/changepic/js/changepic.js
@@ -161,7 +161,7 @@ define(['jquery', 'oae.core', 'jquery.jcrop', 'jquery.fileupload', 'jquery.ifram
 
             cropData.x = Math.floor(crd.x * widthScale);
             cropData.y = Math.floor(crd.y * heightScale);
-            cropData.width = Math.floor(crd.w * widthScale);
+            cropData.width = Math.floor(crd.w * widthScale) - 1;
         };
 
         /**


### PR DESCRIPTION
Browser: Chrome
OS: Mac OS X

Steps:
1/ Select an area
2/ Move it around and drag it as low as possible
3/ Make it as big as possible
4/ Possibly move it around
