### PR TITLE
Icons not clickable in IE9

### DIFF
--- a/shared/oae/css/oae.skin.less
+++ b/shared/oae/css/oae.skin.less
@@ -704,6 +704,10 @@ div.oae-thumbnail {
     .background-gradient-two(@thumbnail-gradient1-color, @thumbnail-gradient2-color, 47%, 74%);
 }
 
+/* IE9 and IE10 need a background color on the link to be able to click the awesomefont icon */
+div.oae-thumbnail a {
+    background: rgba(0, 0, 0, 0.01);
+}
 
 /*********************************
  ** @section  Visibility toggle **


### PR DESCRIPTION
In the tile lists a tile with a font-awesome icon in the center cannot be clicked directly on the icon, the surrounding button does work though. I've only seen this in IE9.
