### PR TITLE
Fetch etherpadHtml directly from revision rather than using results from revisions feed

### DIFF
--- a/node_modules/oae-core/revisions/js/revisions.js
+++ b/node_modules/oae-core/revisions/js/revisions.js
@@ -37,7 +37,7 @@ define(['jquery', 'oae.core'], function($, oae) {
          *
          * @return {Object}    The revision data object of the list item that was clicked
          */
-        var getClickedRevision = function(ev) {
+        var getClickedRevision = function(ev, callback) {
             var $listItem = $(ev.target);
             if (!$listItem.hasClass('well')) {
                 $listItem = $($(ev.target).parents('li'));
@@ -45,14 +45,23 @@ define(['jquery', 'oae.core'], function($, oae) {
 
             var revisionId = $listItem.attr('data-revisionid');
 
-            // Return the clicked version object
-            return {
-                'etherpadHtml': etherpadHtml[revisionId],
+            var result = {
                 'mediumUrl': $listItem.attr('data-mediumurl'),
                 'resourceType': contentProfile.resourceType,
                 'resourceSubType': $listItem.attr('data-resourcesubtype'),
                 'revisionId': revisionId
             };
+
+            if (etherpadHtml[revisionId]) {
+                result.etherpadHtml = etherpadHtml[revisionId];
+                callback(result);
+            } else {
+                oae.api.content.getRevision(contentProfile.id, revisionId, function(err, revision) {
+                    etherpadHtml[revisionId] = revision.etherpadHtml;
+                    result.etherpadHtml = revision.etherpadHtml;
+                    callback(result);
+                });
+            }
         };
 
         /**
@@ -61,16 +70,16 @@ define(['jquery', 'oae.core'], function($, oae) {
          * @param  {Object}    ev    Click event object
          */
         var renderPreview = function(ev) {
-            var clickedRevision = getClickedRevision(ev);
+            getClickedRevision(ev, function(clickedRevision) {
+                // Add the selected class to the list item
+                $('.oae-list li', $rootel).removeClass('selected');
+                $(ev.currentTarget).addClass('selected');
 
-            // Add the selected class to the list item
-            $('.oae-list li', $rootel).removeClass('selected');
-            $(ev.currentTarget).addClass('selected');
-
-            // Render the preview for the selected version
-            oae.api.util.template().render($('#revisions-preview-template', $rootel), {
-                'revision': clickedRevision
-            }, $('#revisions-preview', $rootel));
+                // Render the preview for the selected version
+                oae.api.util.template().render($('#revisions-preview-template', $rootel), {
+                    'revision': clickedRevision
+                }, $('#revisions-preview', $rootel));
+            });
         };
 
         /**
@@ -80,33 +89,33 @@ define(['jquery', 'oae.core'], function($, oae) {
          */
         var restoreRevision = function(ev) {
             // Caches the revision data object that needs to be restored
-            var clickedRevision = getClickedRevision(ev);
+            getClickedRevision(ev, function(clickedRevision) {
+                // Restore the revision of the content
+                oae.api.content.restoreRevision(contentProfile.id, clickedRevision.revisionId, function(err, data) {
+                    if (!err) {
+                        // Hide the modal
+                        $('#revisions-modal', $rootel).modal('hide');
 
-            // Restore the revision of the content
-            oae.api.content.restoreRevision(contentProfile.id, clickedRevision.revisionId, function(err, data) {
-                if (!err) {
-                    // Hide the modal
-                    $('#revisions-modal', $rootel).modal('hide');
+                        // Show a success notification
+                        oae.api.util.notification(
+                            oae.api.i18n.translate('__MSG__REVISION_RESTORED__', 'revisions'),
+                            oae.api.i18n.translate('__MSG__REVISION_RESTORE_SUCCESS__', 'revisions')
+                        );
 
-                    // Show a success notification
-                    oae.api.util.notification(
-                        oae.api.i18n.translate('__MSG__REVISION_RESTORED__', 'revisions'),
-                        oae.api.i18n.translate('__MSG__REVISION_RESTORE_SUCCESS__', 'revisions')
-                    );
-
-                    // Fetch the updated content profile
-                    oae.api.content.getContent(contentProfile.id, function(err, updatedContentProfile) {
-                        // Refresh the content profile
-                        $(document).trigger('oae.revisions.done', [data, updatedContentProfile]);
-                    });
-                } else {
-                    // Show a failure notification
-                    oae.api.util.notification(
-                        oae.api.i18n.translate('__MSG__REVISION_NOT_RESTORED__', 'revisions'),
-                        oae.api.i18n.translate('__MSG__REVISION_RESTORE_FAIL__', 'revisions'),
-                        'error'
-                    );
-                }
+                        // Fetch the updated content profile
+                        oae.api.content.getContent(contentProfile.id, function(err, updatedContentProfile) {
+                            // Refresh the content profile
+                            $(document).trigger('oae.revisions.done', [data, updatedContentProfile]);
+                        });
+                    } else {
+                        // Show a failure notification
+                        oae.api.util.notification(
+                            oae.api.i18n.translate('__MSG__REVISION_NOT_RESTORED__', 'revisions'),
+                            oae.api.i18n.translate('__MSG__REVISION_RESTORE_FAIL__', 'revisions'),
+                            'error'
+                        );
+                    }
+                });
             });
         };
 
@@ -127,16 +136,6 @@ define(['jquery', 'oae.core'], function($, oae) {
                 'limit': 8
             }, '#revisions-list-template', {
                 'postProcessor': function(data) {
-                    // Collabdoc revision previews show the full revision content. To do that, the etherpad html
-                    // is cached for all revisions when they are loaded so it can be accessed for the previews
-                    if (contentProfile.resourceSubType === 'collabdoc') {
-                        $.each(data, function(index, revision) {
-                            if (!oae.api.util.isBlank(revision.etherpadHtml)) {
-                                etherpadHtml[revision.revisionId] = revision.etherpadHtml;
-                            }
-                        });
-                    }
-
                     return {
                         'results': data,
                         'resourceSubType': contentProfile.resourceSubType

--- a/shared/oae/api/oae.api.content.js
+++ b/shared/oae/api/oae.api.content.js
@@ -41,6 +41,35 @@ define(['exports', 'jquery', 'underscore', 'oae.api.i18n'], function(exports, $,
     };
 
     /**
+     * Get a specific revision
+     *
+     * @param  {String}       contentId           Content id of the content item we're trying to retrieve
+     * @param  {String}       revisionId          Revision id of the revision we're trying to retrieve
+     * @param  {Function}     callback            Standard callback method
+     * @param  {Object}       callback.err        Error object containing error code and error message
+     * @param  {Content}      callback.content    Content object representing the retrieved content
+     * @throws {Error}                            Error thrown when no content id has been provided
+     */
+    var getRevision = exports.getRevision = function(contentId, revisionId, callback) {
+        if (!contentId) {
+            throw new Error('A valid content id should be provided');
+        }
+        if (!revisionId) {
+            throw new Error('A valid revision id should be provided');
+        }
+
+        $.ajax({
+            'url': '/api/content/' + contentId + '/revisions/' + revisionId,
+            'success': function(data) {
+                callback(null, data);
+            },
+            'error': function(jqXHR, textStatus) {
+                callback({'code': jqXHR.status, 'msg': jqXHR.statusText});
+            }
+        });
+    };
+
+    /**
      * Create a new link.
      *
      * @param  {String}         displayName         Display title for the created content item


### PR DESCRIPTION
As of https://github.com/oaeproject/Hilary/pull/554 , the etherpadHtml does not come out of the revisions feed. Instead it should be fetched lazily when the user clicks/focusses on the revision in the revision pane.

Assigned to @stuartf
