### PR TITLE
Create template for "Restored Revision" activity

### DIFF
--- a/shared/oae/macros/activity.html
+++ b/shared/oae/macros/activity.html
@@ -61,6 +61,8 @@
         ${renderContentCommentSummary(activity, actor1, actor1URL, actor2, actor2URL, actorCount, target1, target1URL)}
     {elseif activityType === 'content-create'}
         ${renderContentCreateSummary(activity, actor1, actor1URL, object1, object1URL, object2, object2URL, objectCount)}
+    {elseif activityType === 'content-restored-revision'}
+        ${renderContentRestoredRevision(activity, actor1, actor1URL, object1, object1URL, object2, object2URL, objectCount)}
     {elseif activityType === 'content-revision'}
         ${renderContentRevisionSummary(activity, actor1, actor1URL, actor2, actor2URL, actorCount, object1, object1URL)}
     {elseif activityType === 'content-share'}
@@ -212,6 +214,32 @@
         __MSG__ACTIVITY_CONTENT_CREATE_2__
     {else}
         __MSG__ACTIVITY_CONTENT_CREATE_2+__
+    {/if}
+{/macro}
+
+<!--
+ * Render the end-user friendly, internationalized summary of a content restored revision activity.
+ *
+ * @param  {Activity}     activity      Standard activity object as specified by the activitystrea.ms specification, representing the content revision restoration activity, for which to generate the activity summary
+ * @param  {String}       actor1        Display name of the first actor on the activity
+ * @param  {String}       actor1URL     Profile path for the first actor on the activity
+ * @param  {String}       object1       Display name of the first object on the activity
+ * @param  {String}       object1URL    Profile path for the first object on the activity
+ * @param  {String}       object2       Display name of the second object on the activity
+ * @param  {String}       object2URL    Profile path for the second object on the activity
+ * @param  {Number}       objectCount   The total number of different objects on the activity
+-->
+{macro renderContentRestoredRevision(activity, actor1, actor1URL, object1, object1URL, object2, object2URL, objectCount)}
+    {if !objectCount}
+        {if activity.object['oae:resourceSubType'] === 'collabdoc'}
+            __MSG__ACTIVITY_CONTENT_RESTORED_COLLABDOC__
+        {elseif activity.object['oae:resourceSubType'] === 'file'}
+            __MSG__ACTIVITY_CONTENT_RESTORED_FILE__
+        {/if}
+    {elseif objectCount === 2}
+        __MSG__ACTIVITY_CONTENT_RESTORED_2__
+    {else}
+        __MSG__ACTIVITY_CONTENT_RESTORED_2+__
     {/if}
 {/macro}
 

--- a/ui/bundles/default.properties
+++ b/ui/bundles/default.properties
@@ -22,6 +22,10 @@ ACTIVITY_CONTENT_CREATE_FILE = <a href="${actor1URL}">${actor1}</a> uploaded &qu
 ACTIVITY_CONTENT_CREATE_LINK = <a href="${actor1URL}">${actor1}</a> added the link &quot;<a href="${object1URL}">${object1}</a>&quot;
 ACTIVITY_CONTENT_CREATE_2 = <a href="${actor1URL}">${actor1}</a> created &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot;
 ACTIVITY_CONTENT_CREATE_2+ = <a href="${actor1URL}">${actor1}</a> created &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCount - 1} others
+ACTIVITY_CONTENT_RESTORED_COLLABDOC = <a href="${actor1URL}">${actor1}</a> restored an older version of the document &quot;<a href="${object1URL}">${object1}</a>&quot;
+ACTIVITY_CONTENT_RESTORED_FILE = <a href="${actor1URL}">${actor1}</a> restored an older version of &quot;<a href="${object1URL}">${object1}</a>&quot;
+ACTIVITY_CONTENT_RESTORED_2 = <a href="${actor1URL}">${actor1}</a> restored an older version of  &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot;
+ACTIVITY_CONTENT_RESTORED_2+ = <a href="${actor1URL}">${actor1}</a> restored an older version of  &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCount - 1} others
 ACTIVITY_CONTENT_REVISION_COLLABDOC_1 = <a href="${actor1URL}">${actor1}</a> edited the document &quot;<a href="${object1URL}">${object1}</a>&quot;
 ACTIVITY_CONTENT_REVISION_COLLABDOC_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> edited the document &quot;<a href="${object1URL}">${object1}</a>&quot;
 ACTIVITY_CONTENT_REVISION_COLLABDOC_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCount - 1} others edited the document &quot;<a href="${object1URL}">${object1}</a>&quot;


### PR DESCRIPTION
A "Restored Revision" activity was created as part of https://github.com/oaeproject/Hilary/pull/583

There should now be a custom template to go along with it.
