### PR TITLE
Large list options visual issues

### DIFF
--- a/node_modules/oae-core/creategroup/creategroup.html
+++ b/node_modules/oae-core/creategroup/creategroup.html
@@ -32,7 +32,7 @@
             <div class="oae-large-options well pull-left text-center {if visibility === 'private'} checked{/if}">
                 <input type="radio" id="oae-visibility-private" value="private" name="oae-visibility-group" class="pull-left" {if visibility === 'private'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-oae-private large text-center"></i>
-                <span>__MSG__PARTICIPANTS_ONLY__</span>
+                <span class="oae-threedots">__MSG__PARTICIPANTS_ONLY__</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>__MSG__GROUP_PRIVATE_DESCRIPTION__</small>
@@ -41,7 +41,7 @@
             <div class="oae-large-options well pull-left text-center {if visibility === 'loggedin'} checked{/if}">
                 <input type="radio" id="oae-visibility-loggedin" value="loggedin" name="oae-visibility-group" class="pull-left" {if visibility === 'loggedin'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-oae-loggedin large text-center"></i>
-                <span>${tenant}</span>
+                <span class="oae-threedots">${tenant}</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>__MSG__GROUP_LOGGEDIN_DESCRIPTION__</small>
@@ -50,7 +50,7 @@
             <div class="oae-large-options well pull-left text-center {if visibility === 'public'} checked{/if}">
                 <input type="radio" id="oae-visibility-public" value="public" name="oae-visibility-group" class="pull-left" {if visibility === 'public'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-oae-public large text-center"></i>
-                <span>__MSG__PUBLIC__</span>
+                <span class="oae-threedots">__MSG__PUBLIC__</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>__MSG__GROUP_PUBLIC_DESCRIPTION__</small>

--- a/node_modules/oae-core/editgroup/editgroup.html
+++ b/node_modules/oae-core/editgroup/editgroup.html
@@ -41,7 +41,7 @@
             <div class="oae-large-options well pull-left text-center {if joinable === 'no'} checked{/if}">
                 <input type="radio" id="oae-joinable-no" value="no" name="oae-joinable-group" class="pull-left" {if joinable === 'no'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-ban-circle large text-center {if joinable === 'no'} selected{/if}"></i>
-                <span>__MSG__ONLY_MANAGERS_CAN_ADD_MEMBERS__</span>
+                <span class="oae-threedots">__MSG__ONLY_MANAGERS_CAN_ADD_MEMBERS__</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>__MSG__GROUP_JOINABLE_MANAGERS_ADD_DESCRIPTION__</small>
@@ -50,7 +50,7 @@
             <div class="oae-large-options well pull-left text-center {if joinable === 'yes'} checked{/if}">
                 <input type="radio" id="oae-joinable-yes" value="yes" name="oae-joinable-group" class="pull-left" {if joinable === 'yes'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-star large text-center {if joinable === 'yes'} selected{/if}"></i>
-                <span>__MSG__ANYONE_CAN_JOIN__</span>
+                <span class="oae-threedots">__MSG__ANYONE_CAN_JOIN__</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>__MSG__GROUP_JOINABLE_ANYONE_DESCRIPTION__</small>

--- a/node_modules/oae-core/editprofile/editprofile.html
+++ b/node_modules/oae-core/editprofile/editprofile.html
@@ -36,7 +36,7 @@
             <div class="oae-large-options well pull-left text-center {if oae.data.me.visibility === 'private'} checked{/if}">
                 <input type="radio" id="oae-visibility-private" value="private" name="oae-visibility-group" class="pull-left" {if oae.data.me.visibility === 'private'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-oae-private large text-center"></i>
-                <span>__MSG__PRIVATE__</span>
+                <span class="oae-threedots">__MSG__PRIVATE__</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>__MSG__PROFILE_PRIVATE_DESCRIPTION__</small>
@@ -45,7 +45,7 @@
             <div class="oae-large-options well pull-left text-center {if oae.data.me.visibility === 'loggedin'} checked{/if}">
                 <input type="radio" id="oae-visibility-loggedin" value="loggedin" name="oae-visibility-group" class="pull-left" {if oae.data.me.visibility === 'loggedin'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-oae-loggedin large text-center"></i>
-                <span>${tenant}</span>
+                <span class="oae-threedots">${tenant}</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>__MSG__PROFILE_LOGGEDIN_DESCRIPTION__</small>
@@ -54,7 +54,7 @@
             <div class="oae-large-options well pull-left text-center {if oae.data.me.visibility === 'public'} checked{/if}">
                 <input type="radio" id="oae-visibility-public" value="public" name="oae-visibility-group" class="pull-left" {if oae.data.me.visibility === 'public'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-oae-public large text-center"></i>
-                <span>__MSG__PUBLIC__</span>
+                <span class="oae-threedots">__MSG__PUBLIC__</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>__MSG__PROFILE_PUBLIC_DESCRIPTION__</small>

--- a/node_modules/oae-core/manageaccess/manageaccess.html
+++ b/node_modules/oae-core/manageaccess/manageaccess.html
@@ -83,7 +83,7 @@
             <div class="oae-large-options well pull-left text-center {if visibility === 'private'} checked{/if}">
                 <input type="radio" id="oae-visibility-private" value="private" name="oae-visibility-group" class="pull-left" {if visibility === 'private'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-oae-private large text-center"></i>
-                <span>${messages.private}</span>
+                <span class="oae-threedots">${messages.private}</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>${messages.privateDescription}</small>
@@ -92,7 +92,7 @@
             <div class="oae-large-options well pull-left text-center {if visibility === 'loggedin'} checked{/if}">
                 <input type="radio" id="oae-visibility-loggedin" value="loggedin" name="oae-visibility-group" class="pull-left" {if visibility === 'loggedin'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-oae-loggedin large text-center"></i>
-                <span>${messages.loggedin}</span>
+                <span class="oae-threedots">${messages.loggedin}</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>${messages.loggedinDescription}</small>
@@ -101,7 +101,7 @@
             <div class="oae-large-options well pull-left text-center {if visibility === 'public'} checked{/if}">
                 <input type="radio" id="oae-visibility-public" value="public" name="oae-visibility-group" class="pull-left" {if visibility === 'public'} checked="checked"{/if} tabindex="0"/>
                 <i class="icon-oae-public large text-center"></i>
-                <span>${messages.public}</span>
+                <span class="oae-threedots">${messages.public}</span>
             </div>
             <i class="icon-ok hide"></i>
             <small>${messages.publicDescription}</small>

--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -192,7 +192,7 @@ i[class^="icon-"].large:before {
  *              <div class="oae-large-options well pull-left text-center checked">
  *                  <input type="radio" id="oae-visibility-private" value="private" name="oae-visibility-group" class="pull-left" checked="checked"/>
  *                  <i class="icon-oae-private large text-center"></i>
- *                  <span>__MSG__PRIVATE__</span>
+ *                  <span class="oae-threedots">__MSG__PRIVATE__</span>
  *              </div>
  *              <i class="icon-ok hide"></i>
  *              <small>__MSG__GROUP_PRIVATE_DESCRIPTION__</small>
@@ -201,7 +201,7 @@ i[class^="icon-"].large:before {
  *              <div class="oae-large-options well pull-left text-center">
  *                  <input type="radio" id="oae-visibility-loggedin" value="loggedin" name="oae-visibility-group" class="pull-left"/>
  *                  <i class="icon-oae-loggedin large text-center"></i>
- *                  <span>Cambridge University</span>
+ *                  <span class="oae-threedots">Cambridge University</span>
  *              </div>
  *              <i class="icon-ok hide"></i>
  *              <small>__MSG__GROUP_LOGGEDIN_DESCRIPTION__</small>
@@ -210,7 +210,7 @@ i[class^="icon-"].large:before {
  *              <div class="oae-large-options well pull-left text-center">
  *                  <input type="radio" id="oae-visibility-public" value="public" name="oae-visibility-group" class="pull-left"/>
  *                  <i class="icon-oae-public large text-center"></i>
- *                  <span>__MSG__PUBLIC__</span>
+ *                  <span class="oae-threedots">__MSG__PUBLIC__</span>
  *              </div>
  *              <i class="icon-ok hide"></i>
  *              <small>__MSG__GROUP_PUBLIC_DESCRIPTION__</small>
@@ -241,6 +241,7 @@ i[class^="icon-"].large:before {
 }
 
 .oae-large-options-container .oae-large-options input {
+    margin: 24px;
     position: absolute;
     z-index: -1; /* Adding a z-index of -1 hides the element from the view but still allows for focus of the element */
 }


### PR DESCRIPTION
The large list options have a number of visual issues:
- When using a transparent color as the background color for the selected large list option, the radio button appears. Perhaps it might be worth thinking about a different accessibility approach for this?
- When using a long tenant name, the text overflows the available space

![screen shot 2013-07-29 at 12 20 04](https://f.cloud.github.com/assets/109850/884637/5e7dcf50-f9bc-11e2-8795-d9a5dbac1b63.png)
