### PR TITLE
Refresh all profile pictures when changing picture

### DIFF
--- a/node_modules/oae-core/changepic/js/changepic.js
+++ b/node_modules/oae-core/changepic/js/changepic.js
@@ -198,7 +198,7 @@ define(['jquery', 'oae.core', 'jquery.jcrop', 'jquery.fileupload', 'jquery.ifram
 
         /**
          * Crop the profile picture, which will return the context's updated profile upon
-         * completion. Sends out an `oae.changepic.finished` event and
+         * completion. Sends out an `oae-update-picture` event and
          * closes the modal when done. While the data is sent to the server a spinning
          * animation is indicating that cropping is in progress.
          */
@@ -228,7 +228,7 @@ define(['jquery', 'oae.core', 'jquery.jcrop', 'jquery.fileupload', 'jquery.ifram
                     data.picture.small += '&' + oae.api.util.generateId();
                     data.picture.medium += '&' + oae.api.util.generateId();
                     data.picture.large += '&' + oae.api.util.generateId();
-                    $(document).trigger('oae.changepic.finished', data);
+                    $(document).trigger('oae-update-picture', data);
 
                     // Unlock the modal
                     $('#changepic-modal', $rootel).modal('unlock');

--- a/shared/oae/api/oae.bootstrap.js
+++ b/shared/oae/api/oae.bootstrap.js
@@ -57,6 +57,7 @@ requirejs.config({
         'jquery.infinitescroll': 'oae/js/jquery-plugins/jquery.infinitescroll',
         'jquery.jeditable-focus': 'oae/js/jquery-plugins/jquery.jeditable-focus',
         'jquery.list-options': 'oae/js/jquery-plugins/jquery.list-options',
+        'jquery.update-picture': 'oae/js/jquery-plugins/jquery.update-picture',
 
         // OAE API modules
         'oae.api': 'oae/api/oae.api',

--- a/shared/oae/api/oae.core.js
+++ b/shared/oae/api/oae.core.js
@@ -55,6 +55,7 @@ define([
         'jquery.dnd-upload',
         'jquery.infinitescroll',
         'jquery.list-options',
+        'jquery.update-picture',
 
         /*!
          * Third-party dependencies.

--- a/shared/oae/js/jquery-plugins/jquery.update-picture.js
+++ b/shared/oae/js/jquery-plugins/jquery.update-picture.js
@@ -1,0 +1,34 @@
+/*!
+ * Copyright 2013 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+define(['jquery', 'oae.api.util'], function (jQuery, oaeUtil) {
+    (function($) {
+
+        /**
+         * Catches the `oae-update-picture` event and updates the associated thumbnail images
+         */
+        $(document).on('oae-update-picture', function(ev, data) {
+            // Define the template
+            var $template = $('<div id="thumbnail-template"><!--${renderThumbnail(entityData)}--></div>');
+            // Render the template, passing in the updated data
+            var result = oaeUtil.template().render($template, {
+                'entityData': data
+            });
+            // Replace the thumbnails with the updated html
+            $('.oae-thumbnail[data-id="' + data.id + '"]').replaceWith(result);
+        });
+
+    })(jQuery);
+});

--- a/shared/oae/macros/list.html
+++ b/shared/oae/macros/list.html
@@ -120,7 +120,7 @@
         {var visibility = entityData['oae:visibility']}
     {/if}
 
-    <div class="oae-thumbnail {if largeDefault} oae-thumbnail-large {/if} icon-oae-${resourceSubType} icon-oae-${resourceType}">
+    <div class="oae-thumbnail {if largeDefault} oae-thumbnail-large {/if} icon-oae-${resourceSubType} icon-oae-${resourceType}" data-id="${entityData['oae:id'] || entityData.id}">
         {if profilePath && addLink !== false}<a href="${profilePath}" title="${entityData.displayName|encodeForHTMLAttribute}">{/if}
         {if thumbnailUrl}
             <img src="${thumbnailUrl}" alt="${entityData.displayName|encodeForHTMLAttribute}" />

--- a/ui/js/group.js
+++ b/ui/js/group.js
@@ -191,20 +191,6 @@ require(['jquery', 'oae.core'], function($, oae) {
     };
 
 
-    //////////////////////////
-    // CHANGE GROUP PICTURE //
-    //////////////////////////
-
-    /**
-     * Re-render the group's clip when a new profile picture has been uploaded. The updated
-     * group profile will be passed into the event
-     */
-    $(document).on('oae.changepic.finished', function(ev, data) {
-        groupProfile = data;
-        setUpClip();
-    });
-
-
     ///////////////////
     // MANAGE ACCESS //
     ///////////////////

--- a/ui/js/me.js
+++ b/ui/js/me.js
@@ -141,16 +141,6 @@ require(['jquery','oae.core'], function($, oae) {
     });
     $(document).trigger('oae.context.send', oae.data.me);
 
-    /**
-     * Re-render the me clip when a new profile picture has been uploaded. The updated
-     * me object will be passed into the event
-     */
-    $(document).on('oae.changepic.finished', function(ev, data) {
-        // Add the new picture object onto the me object
-        oae.data.me.picture = data.picture;
-        setUpClip();
-    });
-
 
     //////////////////
     // EDIT PROFILE //


### PR DESCRIPTION
We should mark up profile pictures with a data attribute that allows for all profile pictures on a page for a given to be refreshed on the fly (e.g. when changing your profile picture). This can probably be done in the template macros.
