### PR TITLE
Show group as activity preview when being added to group

### DIFF
--- a/node_modules/oae-core/activity/activity.html
+++ b/node_modules/oae-core/activity/activity.html
@@ -40,7 +40,9 @@
     {macro renderPreview(activity)}
         <div class="activity-preview-container clearfix">
             {var previewObj = activity.target || activity.object}
-            {if previewObj['oae:id'] === oae.data.me.id || activity['oae:activityType'] === 'group-add-member'}
+            {if previewObj['oae:id'] === oae.data.me.id}
+                {var previewObj = activity.object}
+            {elseif activity['oae:activityType'] === 'group-add-member' && activity.object['oae:id'] !== oae.data.me.id}
                 {var previewObj = activity.object}
             {elseif activity['oae:activityType'] === 'group-join'}
                 {var previewObj = activity.actor}


### PR DESCRIPTION
See #3035

When a user is added to a group, his activity will show the group's thumbnail. When a user different than the user that was added looks at that activity, the activity will show the user's thumbnail.
