### PR TITLE
Creating Links Function

### DIFF
--- a/node_modules/oae-core/createlink/createlink.html
+++ b/node_modules/oae-core/createlink/createlink.html
@@ -10,7 +10,7 @@
     <div class="modal-body">
         <div id="createlink-link-dump-container">
             <label for="createlink-link-dump" class="oae-aural-text">__MSG__ENTER_OR_PASTE_LINKS_HERE__</label>
-            <textarea id="createlink-link-dump" placeholder="__MSG__ENTER_OR_PASTE_LINKS_HERE__"></textarea>
+            <textarea id="createlink-link-dump"></textarea>
         </div>
         <div id="createlink-overview-container" class="hide">
             <ul id="createlink-selected-container" class="oae-list oae-list-compact"><!-- --></ul>

--- a/node_modules/oae-core/createlink/js/createlink.js
+++ b/node_modules/oae-core/createlink/js/createlink.js
@@ -429,6 +429,7 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
                 $('#createlink-modal', $rootel).on('shown', function() {
                     // Set focus to the link dump textarea
                     $('#createlink-link-dump', $rootel).focus();
+                    $('#createlink-link-dump', $rootel).prop('placeholder', oae.api.i18n.translate('__MSG__ENTER_OR_PASTE_LINKS_HERE__', 'createlink'));
                 });
             });
 


### PR DESCRIPTION
Browser: IE 10 & Windows 8

Can the bug be reproduced: All the time

Description: There is an error sometimes when creating a link. Sometimes the text "Enter or paste links here (one per line)" deletes so you can start typing and sometimes it stays. I clear the cache every time it happens but that will work sometimes. 

Result 1
![image](https://f.cloud.github.com/assets/4062666/1150391/07b40682-1eea-11e3-8585-fa452032071b.png)

Result 2:
![image](https://f.cloud.github.com/assets/4062666/1150397/1d546464-1eea-11e3-9179-3cff71a1adf6.png)

Steps to reproduce: 
1. Log in
2. Create Link

Expected Result: The text disappears
Actual Result: The text sometimes disappear and sometimes stay
