### PR TITLE
Displayname issue in comments

### DIFF
--- a/node_modules/oae-core/comments/js/comments.js
+++ b/node_modules/oae-core/comments/js/comments.js
@@ -33,7 +33,6 @@ define(['jquery', 'oae.core'], function($, oae) {
          * @param  {Comment}    comment    The Comment object representing the comment/reply that has been made
          */
         var renderComment = function(err, comment) {
-
             // Top level comment
             if (!comment.replyTo) {
                 // Insert the comment at the beginning of the list after the new comment box
@@ -53,7 +52,6 @@ define(['jquery', 'oae.core'], function($, oae) {
                     })
                 );
             }
-            
             setUpValidation();
         };
 


### PR DESCRIPTION
Fixed issue where private users were still rendered as links instead of static text in comments
