### PR TITLE
Recognise links in comments, etc.

### DIFF
--- a/node_modules/oae-core/activity/activity.html
+++ b/node_modules/oae-core/activity/activity.html
@@ -106,7 +106,7 @@
                                         ${oae.api.l10n.timeAgo(comment.published)}
                                     </small>
                                 </h4>
-                                ${oae.api.util.security().encodeForHTML(comment.content).replace(/\n/g, '<br/>')}
+                                ${oae.api.util.security().encodeForHTMLWithLinks(comment.content).replace(/\n/g, '<br/>')}
                             </div>
                         </li>
                     {/for}

--- a/node_modules/oae-core/comments/comments.html
+++ b/node_modules/oae-core/comments/comments.html
@@ -60,7 +60,7 @@
                         {/if}
                         <small>${oae.api.l10n.timeAgo(comment.created)}</small>
                     </h4>
-                    ${oae.api.util.security().encodeForHTMLWithURL(comment.body).replace(/\n/g, '<br/>')}
+                    ${oae.api.util.security().encodeForHTMLWithLinks(comment.body).replace(/\n/g, '<br/>')}
 
                     <div class="media hide comments-reply-container">
                         <div class="comments-thumbnail">

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -36,7 +36,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
      * @param  {String[]}       paths               Array of paths that should be retrieved
      * @param  {Function}       callback            Standard callback function
      * @param  {Object}         callback.err        Error object containing error code and message
-     * @param  {Object}         callback.response   JSON Object where the keys are the paths to the requested files and values are the content of those static files. An element will be null when the static file could not be found.
+     * @param  {Object}         callback.response   JSON Object where the keys are the paths to the requested files and values are the content of those static files. An element will be null when the static file could not be found
      */
     var staticBatch = exports.staticBatch = function(paths, callback) {
         if (!paths || paths.length === 0) {
@@ -126,6 +126,9 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
             },
             'encodeForHTMLAttribute': function(str) {
                 return security().encodeForHTMLAttribute(str);
+            },
+            'encodeForHTMLWithLinks': function(str) {
+                return security().encodeForHTMLWithLinks(str);
             },
             'encodeForURL': function(str) {
                 return security().encodeForURL(str);
@@ -290,9 +293,9 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
      * This function is mostly just a wrapper around jQuery.bootstrap.notify.js and supports all of the options documented
      * at http://nijikokun.github.com/bootstrap-notify/.
      *
-     * @param  {String}     [title]       The notification title.
-     * @param  {String}     message       The notification message that will be shown underneath the title. The message should be sanitized by the caller to allow for HTML inside of the notification.
-     * @param  {String}     [type]        The notification type. The supported types are `success`, `error` and `info`, as defined in http://twitter.github.com/bootstrap/components.html#alerts. By default, the `success` type will be used.
+     * @param  {String}     [title]       The notification title
+     * @param  {String}     message       The notification message that will be shown underneath the title. The message should be sanitized by the caller to allow for HTML inside of the notification
+     * @param  {String}     [type]        The notification type. The supported types are `success`, `error` and `info`, as defined in http://twitter.github.com/bootstrap/components.html#alerts. By default, the `success` type will be used
      * @throws {Error}                    Error thrown when no message has been provided
      */
     var notification = exports.notification = function(title, message, type) {
@@ -415,7 +418,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
          *
          * @param  {Element|String}     $form                           jQuery form element or jQuery selector for that form which we want to validate
          * @param  {Object}             [options]                       JSON object containing options to pass to the to the jquery validate plugin, as defined on http://docs.jquery.com/Plugins/Validation/validate#options
-         * @param  {Object}             [options.methods]               Extension to the jquery validate options, allowing to specify custom validators. The keys should be the validator identifiers. The value should be an object with a method key containing the validator function and a text key containing the validation message.
+         * @param  {Object}             [options.methods]               Extension to the jquery validate options, allowing to specify custom validators. The keys should be the validator identifiers. The value should be an object with a method key containing the validator function and a text key containing the validation message
          */
         var validate = function($form, options) {
             if (!$form) {
@@ -557,10 +560,10 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
      * - options.onHidden: Function that will be executed when the clickover is hidden. This function can be useful to kill components in
      *                     the clickover, like infinite scrolls.
      *
-     * @param  {Element|String}     $element      jQuery element or jQuery selector for that element that represents the element that triggers the clickover. The clickover will be positioned relative to this element.
-     * @param  {Element|String}     $content      jQuery element or jQuery selector for the element that should be used as the content of the clickover.
-     * @param  {Object}             [options]     JSON Object containing options to pass to the BootstrapX clickover component. It supports all of the standard options documented at http://twitter.github.com/bootstrap/javascript.html#popovers and http://www.leecarmichael.com/bootstrapx-clickover/examples.html#.
-     * @return {Element}                          The root element of the generated clickover.
+     * @param  {Element|String}     $element      jQuery element or jQuery selector for that element that represents the element that triggers the clickover. The clickover will be positioned relative to this element
+     * @param  {Element|String}     $content      jQuery element or jQuery selector for the element that should be used as the content of the clickover
+     * @param  {Object}             [options]     JSON Object containing options to pass to the BootstrapX clickover component. It supports all of the standard options documented at http://twitter.github.com/bootstrap/javascript.html#popovers and http://www.leecarmichael.com/bootstrapx-clickover/examples.html#
+     * @return {Element}                          The root element of the generated clickover
      */
     var clickover = exports.clickover = function($trigger, $content, options) {
         if (!$trigger) {
@@ -933,7 +936,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
         /**
          * Retrieve the selected items in an autosuggest field
          *
-         * @param  {Element|String}     $element                            jQuery element or jQuery selector for the container in which the auto suggest was initialized. Note that this will *not* be the same element as the one used to setup the auto suggest.
+         * @param  {Element|String}     $element                            jQuery element or jQuery selector for the container in which the auto suggest was initialized. Note that this will *not* be the same element as the one used to setup the auto suggest
          * @return {Object[]}           selectedItems                       Array of objects representing the selected autosuggest items
          * @return {String}             selectedItems[i].id                 Resource id of the selected item
          * @return {String}             selectedItems[i].displayName        Display name of the selected item
@@ -1016,8 +1019,8 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
          * Sanitizes user input in a manner that makes it safe for the input to be placed
          * inside of an HTML tag.
          *
-         * @param  {String}     [input]         The user input string that should be sanitized. If this is not provided, an empty string will be returned.
-         * @return {String}                     The sanitized user input, ready to be put inside of an HTML tag.
+         * @param  {String}     [input]         The user input string that should be sanitized. If this is not provided, an empty string will be returned
+         * @return {String}                     The sanitized user input, ready to be put inside of an HTML tag
          */
         var encodeForHTML = function(input) {
             if (!input) {
@@ -1031,9 +1034,9 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
          * Sanitizes user input in a manner that it makes safe for the input to be placed
          * inside of an HTML attribute.
          *
-         * @param  {String}     [input]         The user input string that should be sanitized. If this is not provided, an empty string will be returned.
-         * @param  {String}     [attribute]     The name of the HTML attribute to encode for.
-         * @return {String}                     The sanitized user input, ready to be put inside of an HTML attribute.
+         * @param  {String}     [input]         The user input string that should be sanitized. If this is not provided, an empty string will be returned
+         * @param  {String}     [attribute]     The name of the HTML attribute to encode for
+         * @return {String}                     The sanitized user input, ready to be put inside of an HTML attribute
          */
         var encodeForHTMLAttribute = function(input, attribute) {
             if (!input) {
@@ -1047,35 +1050,33 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
         };
 
         /**
-         * Sanitizes user input that contains URL's in a manner 
-         * that it makes safe for the input to be placed inside of an HTML attribute.
+         * Sanitizes user input in a manner that makes it safe for the input to be placed inside of an HTML tag. 
+         * This sanitizer will also recognise URLs inside of the provided input and will convert these into links.
          *
-         * @param  {String}     [input]         The user input string that should be sanitized. If this is not provided, an empty string will be returned.
-         * @return {String}                     The sanitized user input, ready to be put inside of an HTML tag.
+         * @param  {String}     [input]         The user input string that should be sanitized. If this is not provided, an empty string will be returned
+         * @return {String}                     The sanitized user input, ready to be put inside of an HTML tag with all URLs converted to links
          */
-        var encodeForHTMLWithURL = function(input) {
+        var encodeForHTMLWithLinks = function(input) {
             if (!input) {
                 return '';
             } else {
+
                 // First sanitize the user's input
-                var sanitized = $.encoder.encodeForHTML(input);
+                input = encodeForHTML(input);
 
-                // If the input contains links, we will replace them by using regular expressions
-                var replacedText = '';
+                // URLs starting with http://, https://, or ftp://
+                var URLPattern1 = /(\b(https?|ftp):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gim;
+                input = input.replace(URLPattern1, '<a href="$1" target="_blank" title="$1">$1</a>');
 
-                //URLs starting with http://, https://, or ftp://
-                var replacePattern1 = /(\b(https?|ftp):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gim;
-                replacedText = sanitized.replace(replacePattern1, '<a href="$1" target="_blank">$1</a>');
+                // URLs starting with "www." (without // before it, or it'd re-link the ones done above).
+                var URLPattern2 = /(^|[^\/])(www\.[\S]+(\b|$))/gim;
+                input = input.replace(URLPattern2, '$1<a href="http://$2" target="_blank" title="$2">$2</a>');
 
-                //URLs starting with "www." (without // before it, or it'd re-link the ones done above).
-                var replacePattern2 = /(^|[^\/])(www\.[\S]+(\b|$))/gim;
-                replacedText = replacedText.replace(replacePattern2, '$1<a href="http://$2" target="_blank">$2</a>');
+                // Change email addresses to mailto:: links.
+                var URLPattern3 = /(\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,6})/gim;
+                input = input.replace(URLPattern3, '<a href="mailto:$1" title="$1">$1</a>');
 
-                //Change email addresses to mailto:: links.
-                var replacePattern3 = /(\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,6})/gim;
-                replacedText = replacedText.replace(replacePattern3, '<a href="mailto:$1">$1</a>');
-
-                return replacedText;
+                return input;
             }
         };
 
@@ -1083,8 +1084,8 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
          * Sanitizes user input in a manner that it makes safe for the input to be used
          * as a URL fragment
          *
-         * @param  {String}     [input]         The user input string that should be sanitized. If this is not provided, an empty string will be returned.
-         * @return {String}                     The sanitized user input, ready to be used as a URL fragment.
+         * @param  {String}     [input]         The user input string that should be sanitized. If this is not provided, an empty string will be returned
+         * @return {String}                     The sanitized user input, ready to be used as a URL fragment
          */
         var encodeForURL = function(input) {
             if (!input) {
@@ -1097,7 +1098,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
         return {
             'encodeForHTML': encodeForHTML,
             'encodeForHTMLAttribute': encodeForHTMLAttribute,
-            'encodeForHTMLWithURL': encodeForHTMLWithURL,
+            'encodeForHTMLWithLinks': encodeForHTMLWithLinks,
             'encodeForURL': encodeForURL
         };
     };
@@ -1145,7 +1146,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
 
         /**
          * Redirect the current user to the 502 page. This can be used when the user requests a page on a tenant
-         * that is currently not available.
+         * that is currently not available
          */
         var unavailable = function() {
             window.location = '/unavailable';
@@ -1153,7 +1154,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
 
         /**
          * Redirect the current user to the 503 page. This can be used when the user requests a page on a tenant
-         * that is currently undergoing maintenance.
+         * that is currently undergoing maintenance
          */
         var maintenance = function() {
             window.location = '/maintenance';
@@ -1171,7 +1172,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
 
     /**
      * Function that can be called once a specific page has finished checking for access by the content user, to avoid flickering when
-     * the user doesn't have access. This function will then show the page and set the page title.
+     * the user doesn't have access. This function will then show the page and set the page title
      */
     var showPage = exports.showPage = function() {
         $('body').show();

--- a/ui/js/discussion.js
+++ b/ui/js/discussion.js
@@ -94,7 +94,7 @@ require(['jquery','oae.core'], function($, oae) {
      */
     var setUpTopic = function() {
         if (discussionProfile.description) {
-            var topic = oae.api.util.security().encodeForHTML(discussionProfile.description).replace(/\n/g, '<br/>');
+            var topic = oae.api.util.security().encodeForHTMLWithLinks(discussionProfile.description).replace(/\n/g, '<br/>');
             $('#discussion-topic').html(topic);
             $('#discussion-topic-container').show();
         }


### PR DESCRIPTION
Links that are entered in comments, activities, etc. should be recognised and rendered as links. The best way to do this might be as a TrimPath modifier, although I'm not sure if TrimPath modifiers can be chained.

Examples of TrimPath modifiers can be found in the oae.api.util.js file:

```
'encodeForHTML': function(str) {
  return security().encodeForHTML(str);
},
'encodeForHTMLAttribute': function(str) {
  return security().encodeForHTMLAttribute(str);
},
'encodeForURL': function(str) {
  return security().encodeForURL(str);
}
```
