### PR TITLE
Youtube videos not playing on https

### DIFF
--- a/shared/vendor/js/jquery-plugins/jquery.oembed.js
+++ b/shared/vendor/js/jquery-plugins/jquery.oembed.js
@@ -491,7 +491,7 @@
     $.fn.oembed.providers = [
 
     //Video
-    new $.fn.oembed.OEmbedProvider("youtube", "video", ["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+","youtube.com/embed"], 'http://www.youtube.com/embed/$1?wmode=transparent', {
+    new $.fn.oembed.OEmbedProvider("youtube", "video", ["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+","youtube.com/embed"], '//www.youtube.com/embed/$1?wmode=transparent', {
         templateRegex: /.*(?:v\=|be\/|embed\/)([\w\-]+)&?.*/,embedtag: {tag: 'iframe',width: '425',height: '349'}
     }),
 


### PR DESCRIPTION
Youtube videos are not playing when OAE is using https. For example, when adding http://www.youtube.com/watch?v=0XqEiVXWcI8 as a video to https://oae.oae-qa0.oaeproject.org, the video does not display.

```
Blocked loading mixed active content "http://www.youtube.com/embed/TkV822e3bvo?wmode=transparent&jqoemcache=oW814"
```
