### PR TITLE
Branding image bug

### DIFF
--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -476,7 +476,7 @@ ul.as-list li.as-result-item.active {
 .oae-main-content.oae-branding-container {
     background-position: top center;
     background-repeat: no-repeat;
-    background-size: 100%;
+    background-size: cover;
 }
 
 /* MAIN CONTENT DIV */


### PR DESCRIPTION
On small screens, the branding image was not always covering all of the available space, causing the background color to come through at the bottom. This fix makes sure that the branding image fills all available space.

![screen shot 2013-10-10 at 17 45 37](https://f.cloud.github.com/assets/109850/1308257/6bda34bc-31cb-11e3-80e0-d5318321d882.png)
