### PR TITLE
Fixed JSHint errors for Google Analytics code

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -341,8 +341,8 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
             // Google Analytics tracking code
             // @see https://developers.google.com/analytics/devguides/
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            (i[r].q=i[r].q||[]).push(arguments);};i[r].l=1*new Date();a=s.createElement(o);
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m);
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
             // Retrieve the Google Analytics application ID


### PR DESCRIPTION
The next version of JSHint will have an ignore feature that will allow you to ignore a number of lines from the JSHint check. However, as that isn't ready yet, I've pushed some semicolon fixes to the GA tracking code.
