### PR TITLE
Don't show current user's picture as preview for notification

### DIFF
--- a/node_modules/oae-core/notifications/notifications.html
+++ b/node_modules/oae-core/notifications/notifications.html
@@ -30,7 +30,7 @@
                 <div class="pull-left">
                     ${renderThumbnail(actor)}
                 </div>
-                {if !previewObj['oae:collection']}
+                {if !previewObj['oae:collection'] && previewObj['oae:id'] !== oae.data.me.id}
                     <div class="pull-right">
                         ${renderThumbnail(previewObj)}
                     </div>


### PR DESCRIPTION
No longer showing the current user's picture as the preview picture for a notification

https://github.com/oaeproject/3akai-ux/issues/3237
