### PR TITLE
Unable to see entire discussion topic. 

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -639,7 +639,7 @@ div.oae-thumbnail i[class^="icon-"] {
     font-weight: 600;
     max-width: 300px;
     min-height: 21px;
-    word-wrap: break-word;
+    word-wrap: nowrap;
 }
 
 .oae-clip .oae-clip-content h1.oae-threedots {


### PR DESCRIPTION
Browsers: Chrome 28, FF 22, & IE 10

Can the bug be reproduced: All the time

Description:
While doing the bug bash in the tenant https://oae.oae-qao.oaeproject.org I encountered a problem with the discussion topic title. If the title is very long, you can't see the entire title, even if you hover over it with your mouse (you only can see the entire title in IE). 

IE:
![image](https://f.cloud.github.com/assets/4062666/1344209/d5619ce8-367d-11e3-8bfd-60a0d2b01ccc.png)

Chrome & FF: 
![image](https://f.cloud.github.com/assets/4062666/1344231/fdc6d662-367d-11e3-923f-01959ff69077.png)

Steps to reproduce:
1. Log into your Marist OAE account
2. Create a long discussion topic
3. Click on discussion topic to see if you can see the topic. 
