### PR TITLE
Fixed type ahead issue

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -886,7 +886,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
                             $thumbnail.append($('<div>')
                                 .css('background-image', 'url("' + originalData.thumbnailUrl + '")')
                                 .attr('role', 'img')
-                                .attr('aria-label', oae.api.Util.encodeForHtmlAttribute(originalData.displayName))
+                                .attr('aria-label', security().encodeForHTMLAttribute(originalData.displayName))
                             );
                         }
                         $elem.prepend($thumbnail);


### PR DESCRIPTION
The following error was seen when adding someone to the typeahead:

```
ReferenceError: Can't find variable: oae
```

https://github.com/oaeproject/3akai-ux/issues/3250
