### PR TITLE
Replace condition with regex in untranslated keys test

### DIFF
--- a/tests/qunit/tests/js/untranslatedkeys.js
+++ b/tests/qunit/tests/js/untranslatedkeys.js
@@ -29,12 +29,18 @@ require(['jquery', 'oae.core', '/tests/qunit/js/util.js'], function($, oae, util
     var checkKeys = function(testData, file, widgetId) {
         if (regex.test(file)) {
             $.each(file.split(/\n/), function(index, line) {
-                // Skip commented lines and this test
-                if (! line.match(/^\s*(\/\/|\*)/)) {
+                // Skip commented lines
+                if (!line.match(/^\s*(\/\/|\*)/)) {
                     regex = new RegExp('__MSG__(.*?)__', 'gm');
                     while (regex.test(line)) {
                         // Get the key from the match
                         var key = RegExp.$1;
+
+                        // (.*?) is the key from the regex that does the
+                        // actual replacement, so ignore it
+                        if ('(.*?)' === key) {
+                            continue;
+                        }
 
                         // Check if the key has been found at least in one of the i18n files
                         var hasI18n = false;


### PR DESCRIPTION
Per comment https://github.com/oaeproject/3akai-ux/pull/3231/files#r7058269 a condition can to be replaced with a regular expression.
