### PR TITLE
Content item checkboxes

### DIFF
--- a/node_modules/oae-core/share/js/share.js
+++ b/node_modules/oae-core/share/js/share.js
@@ -86,6 +86,9 @@ define(['jquery', 'oae.core'], function($, oae) {
                             var notificationBody = oae.api.util.template().render($('#share-notification-body-template', $rootel), data);
                             oae.api.util.notification(notificationTitle, notificationBody, data.err ? 'error': 'success');
 
+                            // Uncheck all the checkboxes
+                            $(".oae-list input[type='checkbox']", '#contentlibrary-widget').attr('checked', false); 
+
                             // Hide the clickover
                             toggleShareClickover();
                         } else {


### PR DESCRIPTION
After sharing files, the checkboxes under the content items should be unchecked. When a user wants to share/delete/... another item, he needs to uncheck the items' checkboxes first.

![screen shot 2013-10-23 at 11 06 04](https://f.cloud.github.com/assets/2194396/1388957/d80c0634-3bca-11e3-8f23-baf514a1357f.png)
