### PR TITLE
Always set acceptedTC to true on user creation when the T&C needs to be accepted

### DIFF
--- a/shared/oae/api/oae.api.user.js
+++ b/shared/oae/api/oae.api.user.js
@@ -63,7 +63,7 @@ define(['exports', 'jquery', 'underscore', 'oae.api.config'], function(exports, 
 
         // If the tenant requires the terms and conditions to be accepted add it on the data object
         if (configAPI.getValue('oae-principals', 'termsAndConditions', 'enabled') === true) {
-            data.acceptedTC = additionalOptions.acceptedTC;
+            data.acceptedTC = true;
         }
 
         // Create the user


### PR DESCRIPTION
The additionalOptions for T&C aren't passed in by the register widget anymore since code review but acceptedTC didn't get set to true in the user API yet.
