### PR TITLE
Invalid CSS in oae.base.css

### DIFF
--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -29,7 +29,7 @@ body {
 /* DEFAULT FONT AND TEXT STYLE */
 
 body, button, input, select, textarea {
-    font-family: 'Open Sans', sans-serif; arial, helvetica, sans-serif;
+    font-family: 'Open Sans', arial, helvetica, sans-serif;
     line-height: 1.5;
 }
 


### PR DESCRIPTION
Checking the QA1 build, `oae.base.css` has the following:

```
body, button, input, select, textarea {
    font-family: 'Open Sans', sans-serif; arial, helvetica, sans-serif;
    line-height: 1.5;
}
```

Note the semi-colon after the first instance of `sans-serif`. It should be a comma. (And presumably the first `sans-serif` shouldn't be present at all since the font is repeated at the end of the list.)
