### PR TITLE
When clicking a private user in the 'followers' tab of a different user I'm directed to the same page

### DIFF
--- a/node_modules/oae-core/network/js/network.js
+++ b/node_modules/oae-core/network/js/network.js
@@ -102,13 +102,6 @@ define(['jquery', 'oae.core', 'jquery.history'], function($, oae) {
                     // is a main list or a search list, as different paging
                     // keys need to be provided for each
                     data.query = query;
-
-                    // Suppress links to user with private profiles
-                    _.each(data.results, function(user) {
-                       if (user.visibility === 'private') {
-                           user.profilePath = false;
-                       }
-                    });
                     return data;
                 },
                 'emptyListProcessor': function() {


### PR DESCRIPTION
A private user's profile cannot be viewed but still I'm presented with a link when looking at a private user following someone else. The link should be taken away when the user is private.

![screen shot 2013-11-20 at 16 21 03](https://f.cloud.github.com/assets/218391/1583600/bd029a88-51ff-11e3-8215-69cb34a5ad8a.png)
