### PR TITLE
Leaving Multiple Groups at Once Can Result in Intermediate State

### DIFF
--- a/node_modules/oae-core/leavegroup/js/leavegroup.js
+++ b/node_modules/oae-core/leavegroup/js/leavegroup.js
@@ -43,8 +43,9 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
             var toDo = groupsToLeave.length;
             var errCount = 0;
 
-            // Lock the modal and disable repeat clicks
+            // Lock the modal
             $('#leavegroup-modal', $rootel).modal('lock');
+            // Disable form elements to prevent repeat clicks
             $('button, input', $rootel).prop('disabled', true);
 
             /**
@@ -127,7 +128,7 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
                     'backdrop': 'static'
                 });
 
-                // (Re-)enable the controls
+                // Enable the form elements
                 $('button, input', $rootel).prop('disabled', false);
 
                 // Request the context information


### PR DESCRIPTION
Try to leave multiple groups at the same time where one of the groups will not permit leaving.

OAE removes you from the groups which it can and presents an error dialog. The dialog presents you with two options, neither of which is accurate and doable:

![screen shot 2013-10-23 at 12 05 29 pm](https://f.cloud.github.com/assets/1731910/1391468/6227e072-3bfd-11e3-892c-6cbaf53d09d2.png)

You cannot leave the group (doing so will just display the same error message)

You cannot cancel the action since you've already been removed from some groups. (Well, you can click cancel, but it doesn't really cancel the action you attempted.)
