### PR TITLE
Show toolbar controls for PDF-type content in full-screen mode

### DIFF
--- a/node_modules/oae-core/documentpreview/bundles/default.properties
+++ b/node_modules/oae-core/documentpreview/bundles/default.properties
@@ -1,3 +1,4 @@
+EXIT_FULL_SCREEN = Exit full screen
 FULL_SCREEN = View full screen
 NEXT_PAGE = Next page
 PAGE_X_OF_Y_MIDDLE = of

--- a/node_modules/oae-core/documentpreview/bundles/nl_NL.properties
+++ b/node_modules/oae-core/documentpreview/bundles/nl_NL.properties
@@ -1,4 +1,5 @@
 #X-Generator: crowdin.net
+EXIT_FULL_SCREEN = Sluit volledig scherm
 FULL_SCREEN=Bekijk op volledig scherm
 NEXT_PAGE=Volgende pagina
 PAGE_X_OF_Y_MIDDLE=van

--- a/node_modules/oae-core/documentpreview/css/documentpreview.css
+++ b/node_modules/oae-core/documentpreview/css/documentpreview.css
@@ -17,6 +17,19 @@
     padding: 20px 65px 30px 50px;
 }
 
+#documentpreview-fullscreen-container {
+    height: 100%;
+    width: 100%;
+}
+
+#documentpreview-fullscreen-container.active {
+    background-color: #FFF;
+}
+
+#documentpreview-fullscreen-container.active .documentpreview-content {
+    max-height: 100%;
+}
+
 #documentpreview-container .documentpreview-toolbar {
     margin-bottom: 0;
     padding: 5px;
@@ -32,7 +45,8 @@
     padding-top: 4px;
 }
 
-#documentpreview-container .documentpreview-toolbar .documentpreview-view-controls .documentpreview-full-screen {
+#documentpreview-container .documentpreview-toolbar .documentpreview-view-controls .documentpreview-full-screen,
+#documentpreview-container .documentpreview-toolbar .documentpreview-view-controls .documentpreview-exit-full-screen {
     margin-left: 30px;
 }
 

--- a/node_modules/oae-core/documentpreview/documentpreview.html
+++ b/node_modules/oae-core/documentpreview/documentpreview.html
@@ -4,37 +4,42 @@
 <!-- CONTENT -->
 <div id="documentpreview-container">
 
-    <!-- TOOLBAR -->
-    <div class="documentpreview-toolbar well well-small clearfix">
-        <span class="documentpreview-view-controls pull-left">
-            <button type="button" class="documentpreview-zoom-in btn btn-link" title="__MSG__ZOOM_IN__">
-                <i class="icon-zoom-in"><span class="oae-aural-text">__MSG__ZOOM_IN__</span></i>
-            </button>
-            <button type="button" class="documentpreview-zoom-out btn btn-link" title="__MSG__ZOOM_OUT__">
-                <i class="icon-zoom-out"><span class="oae-aural-text">__MSG__ZOOM_OUT__</span></i>
-            </button>
-            <button type="button" class="documentpreview-full-screen hide btn btn-link" title="__MSG__FULL_SCREEN__">
-                <i class="icon-fullscreen"><span class="oae-aural-text">__MSG__FULL_SCREEN__</span></i>
-            </button>
-        </span>
+    <div id="documentpreview-fullscreen-container">
+        <!-- TOOLBAR -->
+        <div class="documentpreview-toolbar well well-small clearfix">
+            <span class="documentpreview-view-controls pull-left">
+                <button type="button" class="documentpreview-zoom-in btn btn-link" title="__MSG__ZOOM_IN__">
+                    <i class="icon-zoom-in"><span class="oae-aural-text">__MSG__ZOOM_IN__</span></i>
+                </button>
+                <button type="button" class="documentpreview-zoom-out btn btn-link" title="__MSG__ZOOM_OUT__">
+                    <i class="icon-zoom-out"><span class="oae-aural-text">__MSG__ZOOM_OUT__</span></i>
+                </button>
+                <button type="button" class="documentpreview-full-screen hide btn btn-link" title="__MSG__FULL_SCREEN__">
+                    <i class="icon-fullscreen"><span class="oae-aural-text">__MSG__FULL_SCREEN__</span></i>
+                </button>
+                <button type="button" class="documentpreview-exit-full-screen hide btn btn-link" title="__MSG__EXIT_FULL_SCREEN__">
+                    <i class="icon-remove"><span class="oae-aural-text">__MSG__EXIT_FULL_SCREEN__</span></i>
+                </button>
+            </span>
 
-        <span class="documentpreview-page-controls pull-right">
-            <button type="button" class="documentpreview-page-prev btn btn-link" title="__MSG__PREV_PAGE__">
-                <i class="icon-caret-left"><span class="oae-aural-text">__MSG__PREV_PAGE__</span></i>
-            </button>
-            <span class="documentpreview-page-label documentpreview-toolbar-text">__MSG__PAGE_X_OF_Y_PREFIX__</span>
-            <input class="documentpreview-page-num input-mini text-center" type="text">
-            <span class="documentpreview-toolbar-text">__MSG__PAGE_X_OF_Y_MIDDLE__</span>
-            <span class="documentpreview-page-count documentpreview-toolbar-text"></span>
-            <span class="documentpreview-page-label documentpreview-toolbar-text">__MSG__PAGE_X_OF_Y_SUFFIX__</span>
-            <button type="button" class="documentpreview-page-next btn btn-link" title="__MSG__NEXT_PAGE__">
-                <i class="icon-caret-right"><span class="oae-aural-text">__MSG__NEXT_PAGE__</span></i>
-            </button>
-        </span>
+            <span class="documentpreview-page-controls pull-right">
+                <button type="button" class="documentpreview-page-prev btn btn-link" title="__MSG__PREV_PAGE__">
+                    <i class="icon-caret-left"><span class="oae-aural-text">__MSG__PREV_PAGE__</span></i>
+                </button>
+                <span class="documentpreview-page-label documentpreview-toolbar-text">__MSG__PAGE_X_OF_Y_PREFIX__</span>
+                <input class="documentpreview-page-num input-mini text-center" type="text">
+                <span class="documentpreview-toolbar-text">__MSG__PAGE_X_OF_Y_MIDDLE__</span>
+                <span class="documentpreview-page-count documentpreview-toolbar-text"></span>
+                <span class="documentpreview-page-label documentpreview-toolbar-text">__MSG__PAGE_X_OF_Y_SUFFIX__</span>
+                <button type="button" class="documentpreview-page-next btn btn-link" title="__MSG__NEXT_PAGE__">
+                    <i class="icon-caret-right"><span class="oae-aural-text">__MSG__NEXT_PAGE__</span></i>
+                </button>
+            </span>
+        </div>
+
+        <!-- DOCUMENT PAGES -->
+        <div class="documentpreview-content"><!-- --></div>
     </div>
-
-    <!-- DOCUMENT PAGES -->
-    <div class="documentpreview-content"><!-- --></div>
 </div>
 
 <!-- TEMPLATES -->

--- a/node_modules/oae-core/documentpreview/js/documentpreview.js
+++ b/node_modules/oae-core/documentpreview/js/documentpreview.js
@@ -77,9 +77,11 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
         var $rootel = $('#' + uid);
         var $container = $('#documentpreview-container', $rootel);
         var $content = $('.documentpreview-content', $container);
+        var $fullscreenContainer = $('#documentpreview-fullscreen-container', $container);
         var $zoomIn = $('.documentpreview-zoom-in', $container);
         var $zoomOut = $('.documentpreview-zoom-out', $container);
         var $fullScreen = $('.documentpreview-full-screen', $container);
+        var $deactivateFullscreen = $('.documentpreview-exit-full-screen', $container);
         var $prevPage = $('.documentpreview-page-prev', $container);
         var $pageNumber = $('.documentpreview-page-num', $container);
         var $totalPages = $('.documentpreview-page-count', $container);
@@ -127,6 +129,9 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
          * @param  {Object}  $el  jQuery-wrapped element to render in full screen
          */
         var activateFullscreen = function($el) {
+            $fullScreen.hide();
+            $deactivateFullscreen.show();
+
             var htmlEl = $el[0];
             if (htmlEl.requestFullscreen) {
                 htmlEl.requestFullscreen();
@@ -134,6 +139,31 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
                 htmlEl.mozRequestFullScreen();
             } else if (htmlEl.webkitRequestFullscreen) {
                 htmlEl.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+            }
+        };
+
+        /**
+         * Deactivate the full screen mode
+         */
+        var deactivateFullscreen = function() {
+            if (document.cancelFullScreen) {
+                document.cancelFullScreen();
+            } else if (document.mozCancelFullScreen) {
+                document.mozCancelFullScreen();
+            } else if (document.webkitCancelFullScreen) {
+                document.webkitCancelFullScreen();
+            }
+        };
+
+        /**
+         * Handle changes to the full screen state
+         */
+        var fullScreenChanged = function() {
+            var isFullScreen = document.fullScreen || document.mozFullScreen || document.webkitIsFullScreen;
+            if (!isFullScreen) {
+                $fullScreen.show();
+                $deactivateFullscreen.hide();
+                $fullscreenContainer.removeClass('active');
             }
         };
 
@@ -291,8 +321,15 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
         });
 
         $fullScreen.on('click', function() {
-            activateFullscreen($content);
+            activateFullscreen($fullscreenContainer);
+            $fullscreenContainer.addClass('active');
         });
+
+        $deactivateFullscreen.on('click', function() {
+            deactivateFullscreen();
+        });
+
+        $(document).on('fullscreenchange webkitfullscreenchange mozfullscreenchange', fullScreenChanged);
 
         $prevPage.on('click', function() {
             if (state.pageNumber > 1) {


### PR DESCRIPTION
It'd be useful if the full-screen mode for PDFs could include the toolbar with the zoom and paging buttons
