### PR TITLE
Appears TravisCI fails due to Cassandra not being able to start.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ before_install:
   - cd ../3akai-ux
 
 services:
-  - cassandra
   - elasticsearch
   - rabbitmq
   - redis-server


### PR DESCRIPTION
TravisCI Cassandra failures. Followed @mrvisser fix for https://github.com/oaeproject/Hilary/pull/713
