### PR TITLE
Documentviewer fixes

### DIFF
--- a/node_modules/oae-core/documentpreview/js/documentpreview.js
+++ b/node_modules/oae-core/documentpreview/js/documentpreview.js
@@ -166,14 +166,14 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
                 }
 
                 // In case the requested page hasn't been reached yet, the next page is loaded
-                if (lastPageLoaded <= pageNumber) {
+                if (lastPageLoaded < pageNumber) {
                     loadPage(pages[lastPageLoaded], loadNextPage);
                 } else {
                     // If the requested page has been loaded,
                     // we make sure that there is a container worth of pages below the requested page to make sure that the loading of new pages that
                     // could occur after scrolling to the requested page doesn't interfere with the scroll position set when scrolling to the requested page.
                     var requestedPage = pages[pageNumber - 1];
-                    var spaceBelowRequestedPage = $content.prop('scrollHeight') - requestedPage.$el.position().top + requestedPage.height;
+                    var spaceBelowRequestedPage = $content.prop('scrollHeight') - requestedPage.$el.position().top - $content.height();
                     if (lastPageLoaded < widgetData.previews.pageCount && spaceBelowRequestedPage < $content.height()) {
                         loadPage(pages[lastPageLoaded], loadNextPage);
                     } else {


### PR DESCRIPTION
This PR incorporates
- #3349: Document preview error when jumping to end of document
- #3351: Document preview jumps to wrong page
- #3352: Document preview inappropriately submits form on single page document
