### PR TITLE
Support dedicated "share" feed with autosuggest

### DIFF
--- a/node_modules/oae-core/manageaccess/js/manageaccess.js
+++ b/node_modules/oae-core/manageaccess/js/manageaccess.js
@@ -201,7 +201,8 @@ define(['jquery', 'oae.core', 'jquery.autosuggest'], function($, oae) {
          */
         var setUpAutoSuggest = function() {
             oae.api.util.autoSuggest().setup($('#manageaccess-share-autosuggest', $rootel), {
-                'selectionChanged': autoSuggestChanged
+                'selectionChanged': autoSuggestChanged,
+                'url': '/api/search/share'
             }, null, function() {
                 // Focus on the autosuggest field once it has been set up
                 focusAutoSuggest();

--- a/node_modules/oae-core/setpermissions/js/setpermissions.js
+++ b/node_modules/oae-core/setpermissions/js/setpermissions.js
@@ -120,7 +120,8 @@ define(['jquery', 'oae.core'], function($, oae) {
 
             // Initialize the autoSuggest field
             oae.api.util.autoSuggest().setup($('#setpermissions-share', $rootel), {
-                'preFill': preFillData
+                'preFill': preFillData,
+                'url': '/api/search/share'
             }, null, callback);
         };
 

--- a/node_modules/oae-core/share/js/share.js
+++ b/node_modules/oae-core/share/js/share.js
@@ -134,7 +134,8 @@ define(['jquery', 'oae.core'], function($, oae) {
             // Initialize the autoSuggest field
             oae.api.util.autoSuggest().setup($('#share-autosuggest', $rootel), {
                 'ghosts': ghosts,
-                'selectionChanged': autoSuggestChanged
+                'selectionChanged': autoSuggestChanged,
+                'url': '/api/search/share'
             }, null, function() {
                 // Focus on the autosuggest field once it has been set up
                 oae.api.util.autoSuggest().focus($rootel);


### PR DESCRIPTION
Supports this new search type: https://github.com/oaeproject/Hilary/pull/568

So that users aren't given private joinable groups in auto-suggest share / add member results that violate privacy boundaries.
