### PR TITLE
Clicking Share - Notifications - share results in an uninitialized share window

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -632,7 +632,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
         // Cache the `onShown` callback if it has been provided, so the clickover's
         // root element can be passed into the `onShown` callback.
         if (options.onShown) {
-            showCallback = options.onShown;
+            var showCallback = options.onShown;
             options.onShown = function() {
                 showCallback(this.$tip);
             };


### PR DESCRIPTION
Browser: Chrome
OS: 10

Steps to reproduce
1. Go to a piece of content
2. Click the share clip
3. Click your notifications icon
4. Click the share clip again.

Result
![Bad share](http://cl.ly/image/2d2Q2f412y3T/Screen%20Shot%202013-08-20%20at%2016.26.59.png)
