### PR TITLE
Clickover color scheme makes Cancel button (nearly) invisible on hover

### DIFF
--- a/shared/oae/css/oae.skin.less
+++ b/shared/oae/css/oae.skin.less
@@ -907,6 +907,13 @@ div.oae-thumbnail {
     color: @clip-primary-hover-color;
 }
 
+.oae-clip button.btn-link:hover,
+.oae-clip button.btn-link:focus,
+.oae-clip button.btn-link:hover i,
+.oae-clip button.btn-link:focus i {
+    color: @link-hover-color;
+}
+
 .oae-clip ul li button:hover {
     background-color: @clip-primary-gradient2-color;
 }
@@ -952,6 +959,13 @@ div.oae-thumbnail {
 .oae-clip.oae-clip-secondary button:hover i,
 .oae-clip.oae-clip-secondary button:focus i {
     color: @clip-secondary-hover-color;
+}
+
+.oae-clip.oae-clip-secondary button.btn-link:hover,
+.oae-clip.oae-clip-secondary button.btn-link:focus,
+.oae-clip.oae-clip-secondary button.btn-link:hover i,
+.oae-clip.oae-clip-secondary button.btn-link:focus i {
+    color: @link-hover-color;
 }
 
 .oae-clip.oae-clip-secondary ul li button:hover {


### PR DESCRIPTION
After clicking on the Share clip, the Cancel button is essentially illegible on hover. (It's white text on light gray background.) (It's there in the screen shot below, but very hard to see.)

![screen shot 2013-12-17 at 8 38 48 am](https://f.cloud.github.com/assets/1731910/1764111/04de8a2a-6721-11e3-81a6-895a03b99c07.png)
