### PR TITLE
Backspace key in share container causes item to appear selected

### DIFF
--- a/shared/oae/css/oae.skin.less
+++ b/shared/oae/css/oae.skin.less
@@ -680,6 +680,11 @@ ul.as-selections li.as-selection-item.blur a.as-close {
 /* Ghost item hover border color */
 @as-item-ghost-hover-border-color: #BBB;
 
+/*
+ * The autosuggest plugin will add `selected` class if user backspaces over
+ * a ghost item. Suppress those styles unless the item really is selected.
+ */
+
 ul.as-selections li.as-selection-item.as-ghost-item,
 ul.as-selections li.as-selection-item.as-ghost-item.selected:not(.as-ghost-selected) {
     .background-gradient-two(@as-item-ghost-gradient1-color, @as-item-ghost-gradient2-color);


### PR DESCRIPTION
Safari 7.0.1 in OS X 10.9.1
- Open Share clip.

![screen shot 2013-12-19 at 12 53 25 pm](https://f.cloud.github.com/assets/1731910/1784709/125ee73c-68d7-11e3-8c6f-1a4a2e1f6c33.png)
- Press the backspace/delete key and the first sharing tag (e.g. My library) appears selected.

![screen shot 2013-12-19 at 12 54 16 pm](https://f.cloud.github.com/assets/1731910/1784719/3bab5e40-68d7-11e3-8e87-ca7d1b787c7a.png)

Presumably, backspacing should not select the tag. If that behavior is expected, however, then the user should be able to click the share button. That is not possible because (as the above screenshot indicates), although the tag appears selected, the button remains disabled.

Note: The backspace key results in the `selected` class being added to the `<li class="as-selection-item as-ghost-item">` element. Correctly selecting the tag results in the `as-ghost-selected` tag being added.
