### PR TITLE
Sort the modules alphabetically in the admin UI's configuration view

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -256,21 +256,21 @@
 
         <div id="admin-modules-template"><!--
             <div class="admin-container-striped">
-                {for module in schema}
+                {for item in schema}
                     <div class="admin-module-configuration-container">
-                        <button type="button" title="Edit the ${module.title|encodeForHTMLAttribute}" class="admin-module-configuration-toggle-button btn">
+                        <button type="button" title="Edit the ${item.module.title|encodeForHTMLAttribute}" class="admin-module-configuration-toggle-button btn">
                             <i class="icon-pencil"></i>
-                            ${module.title|encodeForHTML}
+                            ${item.module.title|encodeForHTML}
                         </button>
                         <div class="admin-module-configuration-container" style="display:none;">
-                            <form class="form-horizontal admin-module-configuration-form" data-module="${module_index}">
-                                {for option in module}
+                            <form class="form-horizontal admin-module-configuration-form" data-module="${item.moduleName}">
+                                {for option in item.module}
                                     {if option && option_index !== "title"}
                                         <h4>${option.name|encodeForHTML}</h4>
                                         {for element in option.elements}
                                             {var tenantCanOverride = oae.data.me.isGlobalAdmin || option.tenantOverride !== false}
-                                            {var configPath = module_index + '/' + option_index + '/' + element_index}
-                                            {var configValue = configuration[module_index][option_index][element_index]}
+                                            {var configPath = item.moduleName + '/' + option_index + '/' + element_index}
+                                            {var configValue = configuration[item.moduleName][option_index][element_index]}
                                             {if element.type === "boolean"}
                                                 <div class="control-group">
                                                     <input type="checkbox" id="${configPath|encodeForHTMLAttribute}" name="${configPath|encodeForHTMLAttribute}" {if configValue}checked="checked"{/if} class="admin-module-config-checkbox" {if !tenantCanOverride} disabled="disabled"{/if}/>
@@ -290,7 +290,7 @@
                                                         <div class="controls">
                                                             <select class="admin-internationalizabletext-language-picker" id="${configPath|encodeForHTMLAttribute}">
                                                                 <option value="default">Default</option>
-                                                                {for language in schema['oae-principals'].user.elements.defaultLanguage.list}
+                                                                {for language in languages}
                                                                     <option value="${language.value|encodeForHTMLAttribute}">${language.name|encodeForHTML}</option>
                                                                 {/for}
                                                             </select>
@@ -305,7 +305,7 @@
                                                         </div>
                                                     </div>
 
-                                                    {for language in schema['oae-principals'].user.elements.defaultLanguage.list}
+                                                    {for language in languages}
                                                         {var i18nValue = configValue[language.value] ? configValue[language.value].toString() : ''}
                                                         <div data-id="${language.value}" class="control-group hide">
                                                             <label for="${configPath|encodeForHTMLAttribute}/${language.value}" class="control-label">${language.name} - ${element.description|encodeForHTML} {if !tenantCanOverride} <span class="text-warning">(Tenant override disabled)</span>{/if}</label>

--- a/admin/js/admin.config.js
+++ b/admin/js/admin.config.js
@@ -42,10 +42,28 @@ define(['exports', 'jquery', 'underscore', 'oae.core', '/admin/js/admin.skin.js'
      * Render the available configuration modules and their configured values
      */
     var renderModules = function() {
+        var schema = [];
+
+        // Convert the configuration schema to an array as we can't sort a dictionary
+        _.each(configurationSchema, function(module, moduleName) {
+            schema.push({'module': module, 'moduleName': moduleName});
+        });
+
+        // Sort the array based on the module title.
+        schema = schema.sort(function(a, b) {
+            if (a.module.title > b.module.title) {
+                return 1;
+            }
+            if (a.module.title < b.module.title) {
+                return -1;
+            }
+            return 0;
+        });
         oae.api.util.template().render($('#admin-modules-template'), {
-            'schema': configurationSchema,
+            'schema': schema,
             'configuration': configuration,
-            'context': currentContext
+            'context': currentContext,
+            'languages': configurationSchema['oae-principals'].user.elements.defaultLanguage.list
         }, $('#admin-modules-container'));
     };
 


### PR DESCRIPTION
I kept being annoyed by the fact that our module list wasn't sorted..
