### PR TITLE
Styles from pdf2htmlEX may overwrite OAE styles

### DIFF
--- a/node_modules/oae-core/documentpreview/documentpreview.html
+++ b/node_modules/oae-core/documentpreview/documentpreview.html
@@ -40,7 +40,7 @@
 
 <!-- TEMPLATES -->
 <div id="documentpreview-content-page-template"><!--
-    <div class="documentpreview-content-page" data-page-number="${pageNumber}">
+    <div class="documentpreview-content-page ${contentId}-${revisionId}-pdf2html" data-page-number="${pageNumber}">
         <div class="documentpreview-content-page-loading text-center">
             <i class="icon-spinner icon-spin"><span class="oae-aural-text">__MSG__LOADING__</span></i>
         </div>

--- a/node_modules/oae-core/documentpreview/js/documentpreview.js
+++ b/node_modules/oae-core/documentpreview/js/documentpreview.js
@@ -86,7 +86,9 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
 
             // Add the page container, containing a loading indicator
             $content.append(oae.api.util.template().render($('#documentpreview-content-page-template', $rootel), {
-                'pageNumber': page.pageNumber
+                'pageNumber': page.pageNumber,
+                'contentId': widgetData.id.replace(/:/g, '-'),
+                'revisionId': widgetData.latestRevisionId.replace(/:/g, '-')
             }));
 
             // Cache a reference to the page element
@@ -492,7 +494,7 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
         var loadStyleSheets = function() {
             // The stylesheets are loaded before the pages are loaded to avoid display issues
             // when any of the pages are be loaded before the stylesheets are loaded
-            LazyLoad.css([constructDocumentPreviewURL('base.css'), constructDocumentPreviewURL('fancy.css'), constructDocumentPreviewURL('lines.css')], function() {
+            LazyLoad.css([constructDocumentPreviewURL('combined.css')], function() {
                 // Load the first page
                 loadPage(pages[0]);
             });


### PR DESCRIPTION
The pdf2htmlEX processor generates style sheets that are incorporated into document preview web pages. The rules in those style sheets may conflict with rules specified by OAE. Issue #3345 revealed one such conflict, but others are possible, for example, `base.css` includes the following rules, any of which could conceivably conflict with an OAE style:

```
#sidebar {
    width: 250px;
}

.loading-indicator {
    width: 64px;
    height: 64px;
}

span {
    vertical-align: baseline;
    display: inline-block;
}
```

And since we have no control over the pdf2htmlEX implementation, others may be added in the future.

To protect OAE styles, we might want to consider scoping the pdf2htmlEX styles so that they only apply to document previews.
