### PR TITLE
Share popover behind youtube video

### DIFF
--- a/node_modules/oae-core/share/js/share.js
+++ b/node_modules/oae-core/share/js/share.js
@@ -190,6 +190,9 @@ define(['jquery', 'oae.core'], function($, oae) {
                     'onShown': function($currentRootEl) {
                         $rootel = $currentRootEl;
                         getContext();
+                        // Workaround a Chrome bug where it sometimes forgets
+                        // to update z-index by forcing a repaint
+                        $rootel[0].style.webkitTransform = 'scale(1)';
                     }
                 });
             });


### PR DESCRIPTION
When it's active, the popover correctly displays in front of the youtube video. However, when inactive, it displays behind the youtube video.

![screen shot 2014-01-21 at 00 13 04](https://f.cloud.github.com/assets/109850/1959507/d0e4176e-8230-11e3-84fc-a82eae3b8344.png)
