### PR TITLE
Changes in nginx.conf to get etherpad working 

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -377,13 +377,6 @@ http {
             proxy_pass http://tenantworkers;
         }
 
-        # Explicitly don't cache any other API requests
-        location /api/ {
-            expires -1;
-            proxy_pass http://tenantworkers;
-        }
-
-
         ########################
         ## PUSH NOTIFICATIONS ##
         ########################
@@ -399,6 +392,12 @@ http {
             proxy_read_timeout 3600;
         }
 
+
+        # Explicitly don't cache any other API requests
+        location /api/ {
+            expires -1;
+            proxy_pass http://tenantworkers;
+        }
 
         ####################
         ## FILE DOWNLOADS ##


### PR DESCRIPTION
There are a couple of issues with the nginx.conf file that causes some client side network errors. 
