### PR TITLE
Get new signature for content previews when adding new previews when the old one is expired

### DIFF
--- a/node_modules/oae-core/documentpreview/js/documentpreview.js
+++ b/node_modules/oae-core/documentpreview/js/documentpreview.js
@@ -70,9 +70,11 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
          * @param  {Function}       [callback]          Standard callback function
          * @param  {Object}         [callback.err]      Error object containing error code and error message
          */
-        var loadPage = function(page, callback) {
+        var loadPage = function(page, callback, _isRetryAttempt) {
             // Set a default callback function in case no callback function has been provided
             callback = callback || function() {};
+            // Indicates whether or not we attempted to load this page previously
+            _isRetryAttempt = _isRetryAttempt || false;
 
             // Don't reload the page if it has already been loaded
             if (page.$el) {
@@ -118,7 +120,26 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
                     callback();
                 },
                 'error': function(jqXHR, textStatus) {
-                    callback({'code': jqXHR.status, 'msg': jqXHR.responseText});
+                    // If the user has been reading a document for a while, it's possible that the signature expired
+                    // If we could not load the page due to a 401 (access denied) and it's the first time we tried loading this
+                    // particular page, we refresh the signature and try again
+                    if (jqXHR.status === 401 && !_isRetryAttempt) {
+                        return refreshSignature(function(err) {
+                            if (err) {
+                                return callback(err);
+                            }
+
+                            // Remove the loading indicator and delete the cached reference to it
+                            page.$el.remove();
+                            delete page.$el;
+
+                            // Try loading the page again
+                            return loadPage(page, callback, true);
+                        });
+                    }
+
+                    // For all other error responses, we pass the error back up the call stack
+                    return callback({'code': jqXHR.status, 'msg': jqXHR.responseText});
                 }
             });
         };
@@ -199,6 +220,22 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
                    '?signature=' + widgetData.signature.signature +
                    '&expires=' + widgetData.signature.expires +
                    '&lastmodified=' + widgetData.signature.lastModified;
+        };
+
+        /**
+         * Refreshes the signature.
+         *
+         * @param  {Function}   callback    Standard callback function
+         */
+        var refreshSignature = function(callback) {
+            oae.api.content.getContent(widgetData.id, function(err, content) {
+                if (err) {
+                    return callback(err);
+                }
+
+                widgetData = content;
+                return callback();
+            });
         };
 
 


### PR DESCRIPTION
If you keep the page open for a long time (ex: reading a set of slides) the signature will expire and new pages won't be loaded.

The signature object contains an `expires` field that can be checked whether or not the signature has expired. If it has, we will need to refetch the content profile to get a signature.
