### PR TITLE
In content profile – full screen mode toolbar arrow icon needs to change...

### DIFF
--- a/node_modules/oae-core/documentpreview/js/documentpreview.js
+++ b/node_modules/oae-core/documentpreview/js/documentpreview.js
@@ -58,7 +58,6 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
         var $pageNumber = $('.documentpreview-page-num', $rootel);
         var $nextPage = $('.documentpreview-page-next', $rootel);
 
-
         ////////////////////////////////
         // Page loading and rendering //
         ////////////////////////////////
@@ -466,6 +465,8 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
          */
         var fullScreenChanged = function() {
             $widget.toggleClass('documentpreview-widget-fullscreen');
+            // Change the icon of the fullscreen button according to the view's state
+            $fullScreen.find('i').toggleClass('icon-resize-small').toggleClass('icon-fullscreen');
         };
 
         /**


### PR DESCRIPTION
... to indicate the action now has changed (to exit full screen)

![screen shot 2014-01-20 at 18 08 53](https://f.cloud.github.com/assets/1489257/1956866/ee150fbe-81fe-11e3-896d-d73623a2a93f.png)

When in full screen can we change the icon to this one?
![screen shot 2014-01-20 at 18 18 29](https://f.cloud.github.com/assets/1489257/1956890/4b499088-81ff-11e3-82b9-b6f8ebd1ce05.png)
