### PR TITLE
Main content container box shadow position too low for white branded skins

### DIFF
--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -507,9 +507,9 @@ ul.as-list li.as-result-item.active {
     -webkit-border-radius: 5px;
        -moz-border-radius: 5px;
             border-radius: 5px;
-    -webkit-box-shadow: 0 2px 4px #DBDBDB;
-       -moz-box-shadow: 0 2px 4px #DBDBDB;
-            box-shadow: 0 2px 4px #DBDBDB;
+    -webkit-box-shadow: 0 0 4px #DBDBDB;
+       -moz-box-shadow: 0 0 4px #DBDBDB;
+            box-shadow: 0 0 4px #DBDBDB;
     padding: 10px;
     min-height: 450px;
     clear: both;


### PR DESCRIPTION
Can change the main content container box shadow:
    .oae-main-content

To:
    -webkit-box-shadow: 0 0 4px #DBDBDB;
    -moz-box-shadow: 0 0 4px #DBDBDB; 
    box-shadow: 0 2px 0 #DBDBDB; 

Before:
![screen shot 2014-01-29 at 11 44 29](https://f.cloud.github.com/assets/1489257/2029044/e6d77e92-88db-11e3-843d-14b94e9a7df0.png)

With change:
![screen shot 2014-01-29 at 11 48 04](https://f.cloud.github.com/assets/1489257/2029047/ef3a8a02-88db-11e3-85c8-fea22624b11f.png)
