### PR TITLE
Remove selected state styling for left hand navigation item hover background color

### DIFF
--- a/shared/oae/css/oae.skin.less
+++ b/shared/oae/css/oae.skin.less
@@ -542,7 +542,9 @@ ul.as-selections.as-selections-focus {
 .nav > li.active > a,
 .nav > li.active > a:hover,
 .nav > li.active > a:focus,
-.nav > li.active i {
+.nav > li.active > a i,
+.nav > li.active > a:hover i,
+.nav > li.active > a:focus i {
     color: @lhnav-item-text-selected-color;
     background-color: @lhnav-item-background-selected-color;
 }


### PR DESCRIPTION
Setting a color for:
Left hand navigation item hover background color

Results in the icon having a background color:
![screen shot 2014-01-29 at 12 23 49](https://f.cloud.github.com/assets/1489257/2029270/a9d3da7c-88e0-11e3-9408-224c59b23554.png)

(disregard translation pop-up)

Suggest removing hover bg styling from the selected/active state
