### PR TITLE
Group profile picture disappears when adding member

### DIFF
--- a/ui/js/group.js
+++ b/ui/js/group.js
@@ -274,6 +274,18 @@ require(['jquery', 'oae.core'], function($, oae) {
     });
 
 
+    ////////////////////
+    // CHANGE PICTURE //
+    ////////////////////
+
+    /**
+     * Cache the updated group profile after the profile picture has changed
+     */
+    $(document).on('oae.changepic.update', function(ev, data) {
+        groupProfile = data;
+    });
+
+
     ////////////////
     // JOIN GROUP //
     ////////////////


### PR DESCRIPTION
This problem happens when taking the following steps:
1. Create a group
2. Give it a profile picture
3. Add a user to the group
4. The profile picture in the clip is reset

After refreshing the page, the profile picture is present
