### PR TITLE
Revision history functional regressions

### DIFF
--- a/node_modules/oae-core/revisions/css/revisions.css
+++ b/node_modules/oae-core/revisions/css/revisions.css
@@ -68,8 +68,12 @@
     -webkit-box-shadow: none;
        -moz-box-shadow: none;
             box-shadow: none;
-    margin: 0 10px 0 0;
+    margin: 0 10px 12px 0;
     padding: 3px 10px 0;
+}
+
+#revisions-modal #revisions-list-container .oae-list .well:last-child {
+    margin: 0 10px 0 0;
 }
 
 #revisions-modal #revisions-list-container .oae-list .well:hover,
@@ -119,5 +123,11 @@
 
     #revisions-modal #revisions-preview #revisions-image-container {
         line-height: 350px;
+    }
+}
+
+@media (max-width: 320px) {
+    #revisions-modal #revisions-list-container .oae-list .well.selected .revisions-list-actions span {
+        display: none;
     }
 }

--- a/node_modules/oae-core/revisions/revisions.html
+++ b/node_modules/oae-core/revisions/revisions.html
@@ -61,12 +61,12 @@
             </div>
             <span>${revision.createdBy.displayName|encodeForHTML}</span>
             <div class="revisions-list-actions hide">
-                <button type="button" class="revisions-list-actions-restore btn btn-sm">
-                    <i class="icon-undo"></i> __MSG__RESTORE__
+                <button type="button" class="revisions-list-actions-restore btn btn-sm" title="__MSG__RESTORE__">
+                    <i class="icon-undo"></i> <span>__MSG__RESTORE__</span>
                 </button>
                 {if resourceSubType === 'file'}
-                    <a href="/api/content/${revision.contentId}/download/${revision.revisionId}" class="revisions-list-actions-download btn btn-sm">
-                        <i class="icon-download"></i> __MSG__DOWNLOAD__
+                    <a href="/api/content/${revision.contentId}/download/${revision.revisionId}" class="revisions-list-actions-download btn btn-sm" title="__MSG__DOWNLOAD__">
+                        <i class="icon-download"></i> <span>__MSG__DOWNLOAD__</span>
                     </a>
                 {/if}
             </div>


### PR DESCRIPTION
- Added margin to the list items
- Hide the text on the restore/download buttons on small screens

![image](https://f.cloud.github.com/assets/102265/2032076/2f72390c-890a-11e3-9b31-57c24e72e6e4.png)
