### PR TITLE
Flickering when preview processor finishes processing image

### DIFF
--- a/node_modules/oae-core/uploadnewversion/js/uploadnewversion.js
+++ b/node_modules/oae-core/uploadnewversion/js/uploadnewversion.js
@@ -158,7 +158,7 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport'], f
                         'error'
                     );
                 } else {
-                    $(document).trigger('oae.content.update', updatedContent);
+                    $(document).trigger('oae.uploadnewversion.done', updatedContent);
                     // If we need an iframe for the upload, progress will probably not be supported
                     if (!useIframeTransport) {
                         updateProgress(100);

--- a/ui/js/content.js
+++ b/ui/js/content.js
@@ -220,12 +220,18 @@ require(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
      *
      * @param  {Object}         ev                      jQuery event object
      * @param  {Content}        updatedContent          Content profile of the updated content item
+     * @param  {Boolean}        [refreshPreview]        `true` to force the content preview to refresh
      */
-    var refreshContentProfile = function(ev, updatedContent) {
+    var refreshContentProfile = function(ev, updatedContent, refreshPreview) {
         // Cache the content profile data
         contentProfile = updatedContent;
-        // Refresh the content profile elements
-        refreshContentPreview();
+        // Only refresh the content preview when it's not an image as
+        // images are previewed without having to be processed first
+        // or if refreshing the preview is forced
+        if (contentProfile.mime.substring(0, 6) !== 'image/' || refreshPreview) {
+            refreshContentPreview();
+        }
+        // Refresh the content clips
         setUpClips();
     };
 
@@ -233,6 +239,12 @@ require(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
     // a new version has been uploaded or the preview has finished generating.
     $(document).on('oae.content.update', refreshContentProfile);
 
+    $(document).on('oae.content.newversion', function(ev, updatedContent) {
+        // Cache the content profile data
+        contentProfile = updatedContent;
+        // Refresh the content preview
+        refreshContentPreview();
+    });
 
     ///////////////////
     // MANAGE ACCESS //
@@ -330,7 +342,18 @@ require(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
     $(document).on('oae.revisions.done', function(ev, restoredRevision, updatedContentProfile) {
         contentProfile = updatedContentProfile;
         // Refresh the content profile elements
-        refreshContentProfile(ev, updatedContentProfile);
+        refreshContentProfile(ev, updatedContentProfile, true);
+    });
+
+
+    ////////////////////////
+    // UPLOAD NEW VERSION //
+    ////////////////////////
+
+    $(document).on('oae.uploadnewversion.done', function(ev, updatedContentProfile) {
+        contentProfile = updatedContentProfile;
+        // Refresh the content profile elements
+        refreshContentProfile(ev, updatedContentProfile, true);
     });
 
 


### PR DESCRIPTION
When looking at an image content profile page for which preview processing hasn't finished yet, we will show the image as is. However, when preview processing finishes, the page receives a push notification for this and will try to refresh the preview. However, as the image is already there, this results in the image appearing to flicker.

When looking at an image, we can just ignore the preview processor finished push notification.
