### PR TITLE
Allow global and tenant Google Analytics tracking

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -379,8 +379,8 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
      */
     var googleAnalytics = function() {
         // Get the Google Analytics configuration
-        var globalEnabled = configAPI.getValue('oae-google-analytics', 'google-analytics', 'enabled');
-        var globalId = globalEnabled && configAPI.getValue('oae-google-analytics', 'google-analytics', 'id');
+        var globalEnabled = configAPI.getValue('oae-google-analytics', 'google-analytics', 'globalEnabled');
+        var globalId = globalEnabled && configAPI.getValue('oae-google-analytics', 'google-analytics', 'globalId');
         var tenantEnabled = configAPI.getValue('oae-google-analytics', 'google-analytics', 'tenantEnabled');
         var tenantId = tenantEnabled && configAPI.getValue('oae-google-analytics', 'google-analytics', 'tenantId');
 


### PR DESCRIPTION
We now have a number of tenants that have changed the GA tracking id for their tenant to that their institutional one, which means that we lose all tracking information from those tenants.

We should extend our GA support to allow for the following things:
- Have a tracking id config value that can be set and seen by global administrators only. This can be used to track users across all tenants.
- Have a second tracking id config value that can be set and seen by tenant administrators as well. This can be used to provide tenant-specific tracking.

According to @bp323, Google Analytics should allow us to use 2 tracking ids.

This ticket will require some Hilary work as well.
