### PR TITLE
Top navigation alignment issue

### DIFF
--- a/node_modules/oae-core/topnavigation/css/topnavigation.css
+++ b/node_modules/oae-core/topnavigation/css/topnavigation.css
@@ -38,7 +38,7 @@
 }
 
 #topnavigation-loginlogout-container #topnavigation-signout {
-    padding: 23px 0;
+    padding: 23px 12px 23px 0;
 }
 
 /** SEARCH **/


### PR DESCRIPTION
![screen shot 2014-02-17 at 12 59 17](https://f.cloud.github.com/assets/109850/2185343/65606e94-97d3-11e3-9840-42f34183daef.png)

The right of the `Sign Out` button is aligned with the right hand side of the content div. However, there should be the same amount of margin there as we can see on the left hand side with the `Home` icon.
