### PR TITLE
Share shown when content can be shared

### DIFF
--- a/ui/js/content.js
+++ b/ui/js/content.js
@@ -37,17 +37,19 @@ require(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
                 'icon': 'icon-comments',
                 'title': oae.api.i18n.translate('__MSG__COMMENT__'),
                 'class': 'comments-focus-new-comment'
-            },
-            {
-                'icon': 'icon-share',
-                'title': oae.api.i18n.translate('__MSG__SHARE__'),
-                'class': 'oae-trigger-share',
-                'data': {
-                    'data-id': contentProfile.id,
-                    'data-resourcetype': contentProfile.resourceType,
-                    'data-resourcesubtype': contentProfile.resourceSubType
-                }
             });
+            if (contentProfile.canShare) {
+                lhNavActions.push({
+                    'icon': 'icon-share',
+                    'title': oae.api.i18n.translate('__MSG__SHARE__'),
+                    'class': 'oae-trigger-share',
+                    'data': {
+                        'data-id': contentProfile.id,
+                        'data-resourcetype': contentProfile.resourceType,
+                        'data-resourcesubtype': contentProfile.resourceSubType
+                    }
+                });
+            }
         }
 
         var lhNavPages = [{


### PR DESCRIPTION
Share is shown in the collapsible left hand navigation when the content item can't be shared by the current user. The share clip is correctly hidden though.
