### PR TITLE
(TravisCI) Update release script to push release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -13,7 +13,7 @@ var ReleaseUtil = require('oae-release-tools').ReleaseUtil;
 //////////////////////
 
 var argv = require('optimist')
-    .usage('Usage: $0 [-s] [-p] -v <release version>')
+    .usage('Usage: $0 [-s] [-p] -r <remote repository> -v <release version>')
 
     .alias('h', 'help')
     .describe('h', 'Show this help information')
@@ -23,6 +23,10 @@ var argv = require('optimist')
 
     .alias('p', 'package')
     .describe('p', 'Generate a package tarball (tar.gz) of the tag')
+
+    .alias('r', 'remote')
+    .describe('r', 'The remote repository to push the release commits into (e.g., origin)')
+    .demand('r')
 
     .alias('v', 'version')
     .describe('v', 'Which version to release (e.g., 0.4.1)')
@@ -41,12 +45,13 @@ if (argv.h) {
 // PERFORM RELEASE //
 /////////////////////
 
-var version = argv.v;
 var packageJsonPath = path.resolve('package.json');
 var packageDest = 'dist';
+var remoteName = argv.r;
+var version = argv.v;
 
 // Ensure everything is OK to do a release
-ReleaseUtil.validateRelease(3);
+ReleaseUtil.validateRelease(remoteName, 3);
 
 // If they specified to package after the tag, verify everything is OK to package before doing anything
 if (argv.p) {
@@ -57,7 +62,7 @@ if (argv.p) {
 var packageJson = CoreUtil.loadPackageJson(packageJsonPath, '3akai-ux', 4);
 
 // Ensure our target version is a valid jump from where we are
-ReleaseUtil.validateTargetVersion(packageJson, argv.v, 5);
+ReleaseUtil.validateTargetVersion(packageJson, argv.v, remoteName, 5);
 
 // Optionally, run the tests right now
 if (!argv.s) {
@@ -70,7 +75,7 @@ if (!argv.s) {
 ReleaseUtil.bumpPackageJsonVersion(packageJsonPath, packageJson.version, argv.v, 7);
 
 // Commit the version change and tag the release
-ReleaseUtil.gitCommitVersionAndTag(argv.v, 8);
+ReleaseUtil.gitCommitVersionAndTag(argv.v, remoteName, 8);
 
 // Optionally package up the release on the tag
 if (argv.p || argv.u) {
@@ -85,17 +90,4 @@ if (argv.p || argv.u) {
     CoreUtil.exec(packageCmd, 'Error distributing the release', 9, true);
 }
 
-CoreUtil.logSuccess('Successfully released 3akai-ux '.text + argv.v.white + ' in your local repository'.text);
-CoreUtil.logInfo(' ');
-CoreUtil.logInfo('Next you will have to do the following:');
-CoreUtil.logInfo(' ');
-CoreUtil.logInfo('    1. Analyze the commits in your local repository and verify they are what you want. Look at the diffs between the 2 commits');
-CoreUtil.logInfo('       to ensure they are only bumping the version.');
-CoreUtil.logInfo('            * Use "git log" and "git diff" to analyze the commit');
-CoreUtil.logInfo('            * Use "git tag" to verify that the tag '.text + argv.v.white + ' was indeed created'.text);
-CoreUtil.logInfo(' ');
-CoreUtil.logInfo('    2. If everything is OK, push the commits to the https://github.com/oaeproject/3akai-ux repository with "git push".');
-CoreUtil.logInfo(' ');
-CoreUtil.logInfo('    3. Once pushed, also push the tag you created with: "git push <remote> ' + argv.v + '"');
-CoreUtil.logInfo(' ');
-CoreUtil.logSuccess('Complete!');
+CoreUtil.logSuccess('Successfully released 3akai-ux '.text + argv.v.white + ' to the remote repository '.text + remoteName.white);


### PR DESCRIPTION
More details of this issue in the description of https://github.com/oaeproject/Hilary/pull/807

In short, in order to convince TravisCI to build the proper commit, the commit must be in a push of its own. These changes use the new feature of the `oae-release-tools` which safely pushes the commits and tags into a specified remote repository.
