### PR TITLE
Select picture button should wrap

### DIFF
--- a/node_modules/oae-core/changepic/css/changepic.css
+++ b/node_modules/oae-core/changepic/css/changepic.css
@@ -75,8 +75,10 @@
 
 #changepic-modal .changepic-browse {
     margin-bottom: 20px;
+    max-width: 180px;
     overflow: hidden;
     position: relative;
+    white-space: normal;
 }
 
 #changepic-modal .changepic-browse input[type="file"] {


### PR DESCRIPTION
When the button becomes larger than the container above it, the text should wrap to the next line (and the text should be centered).

![screen shot 2014-02-25 at 17 48 32](https://f.cloud.github.com/assets/109850/2260774/97f204e4-9e45-11e3-9ea2-c50fd50bbfcd.png)
