### PR TITLE
Errors when adding users to documents/discussions with keyboard

### DIFF
--- a/node_modules/oae-core/createlink/createlink.html
+++ b/node_modules/oae-core/createlink/createlink.html
@@ -22,8 +22,8 @@
                     </div>
                 </div>
                 <!-- setpermissions needs to be in a form -->
-                <form id="setpermissions-form" role="form">
-                    <div id="createlink-permissions-container" class="hide"><!-- --></div>
+                <form id="createlink-permissions-form" role="form" class="hide">
+                    <div id="createlink-permissions-container"><!-- --></div>
                 </form>
             </div>
             <div class="modal-footer">

--- a/node_modules/oae-core/createlink/js/createlink.js
+++ b/node_modules/oae-core/createlink/js/createlink.js
@@ -195,7 +195,7 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
             $('#createlink-modal .modal-body > div:visible', $rootel).hide();
             $('#createlink-modal .modal-content > .modal-footer', $rootel).hide();
             // Show the permissions container
-            $('#createlink-modal .modal-body form > div#createlink-permissions-container', $rootel).show();
+            $('#createlink-modal .modal-body > form#createlink-permissions-form', $rootel).show();
             $('#createlink-create', $rootel).hide();
         };
 
@@ -204,7 +204,7 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
          */
         var showOverview = function() {
             // Hide all containers
-            $('#createlink-modal .modal-body > div:visible', $rootel).hide();
+            $('#createlink-modal .modal-body > div:visible,form', $rootel).hide();
             $('#createlink-next', $rootel).hide();
             // Show the overview container
             $('#createlink-modal .modal-content > .modal-footer', $rootel).show();

--- a/node_modules/oae-core/setpermissions/js/setpermissions.js
+++ b/node_modules/oae-core/setpermissions/js/setpermissions.js
@@ -134,7 +134,7 @@ define(['jquery', 'oae.core'], function($, oae) {
             // Render the setpermissions template
             oae.api.util.template().render('#setpermissions-template', widgetData, '#setpermissions-container');
 
-            $('#setpermissions-form', $rootel).on('submit', savePermissionsChange);
+            $('#setpermissions-savepermissions', $rootel).on('click', savePermissionsChange);
             $('#setpermissions-cancelpermissions', $rootel).on('click', cancelPermissionsChange);
 
             // Trigger and bind an event that will ask for the page context

--- a/node_modules/oae-core/setpermissions/setpermissions.html
+++ b/node_modules/oae-core/setpermissions/setpermissions.html
@@ -32,7 +32,7 @@
 
     <div id="setpermissions-footer" class="modal-footer">
         <button type="button" id="setpermissions-cancelpermissions" class="btn btn-link pull-left">__MSG__CANCEL__</button>
-        <button type="submit" id="setpermissions-savepermissions" class="btn btn-primary pull-right">__MSG__UPDATE__</button>
+        <button type="button" id="setpermissions-savepermissions" class="btn btn-primary pull-right">__MSG__UPDATE__</button>
     </div>
 --></div>
 

--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -215,7 +215,7 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
             $('#upload-modal .modal-body > div', $rootel).hide();
             $('#upload-modal .modal-content > .modal-footer', $rootel).hide();
             // Show the permissions container
-            $('#upload-modal .modal-body form > div#upload-permissions-container', $rootel).show();
+            $('#upload-modal .modal-body > form#upload-permissions-form', $rootel).show();
             $('#upload-upload', $rootel).hide();
         };
 
@@ -224,7 +224,7 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
          */
         var showOverview = function() {
             // Hide all containers
-            $('#upload-modal .modal-body > div', $rootel).hide();
+            $('#upload-modal .modal-body > div,form', $rootel).hide();
             // Show the overview container
             $('#upload-modal .modal-content > .modal-footer', $rootel).show();
             $('#upload-modal .modal-body > div#upload-overview-container', $rootel).show();

--- a/node_modules/oae-core/upload/upload.html
+++ b/node_modules/oae-core/upload/upload.html
@@ -28,8 +28,8 @@
                     </div>
                 </div>
                 <!-- setpermissions needs to be wrapped in a form -->
-                <form id="setpermissions-form" role="form">
-                    <div id="upload-permissions-container" class="text-left hide"><!-- --></div>
+                <form id="upload-permissions-form" role="form" class="hide">
+                    <div id="upload-permissions-container" class="text-left"><!-- --></div>
                 </form>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
- Go to either the Create Document or Create Discussion widget
- Click Change
- Start entering a name in the typeahead
- Use the keyboard to go down and select a user (enter key)

We are brought back to the previous modal screen straight away, the user is not added to the list and JS errors are present in the console.

![screen shot 2014-02-25 at 17 58 42](https://f.cloud.github.com/assets/109850/2260856/7fbd6a0c-9e46-11e3-9992-e2fcdbc07943.png)

![screen shot 2014-02-25 at 17 55 46](https://f.cloud.github.com/assets/109850/2260842/62693d14-9e46-11e3-90d1-ab930d42537c.png)
