### PR TITLE
Browser title is incorrect

### DIFF
--- a/node_modules/oae-core/lhnavigation/js/lhnavigation.js
+++ b/node_modules/oae-core/lhnavigation/js/lhnavigation.js
@@ -36,6 +36,9 @@ define(['jquery', 'oae.core', 'jquery.history'], function($, oae) {
             // Mark the selected page as active in the left hand navigation
             $('.oae-lhnavigation ul li[data-id="' + selectedPage.id + '"]', $rootel).addClass('active');
 
+            // Set the browser title
+            oae.api.util.setBrowserTitle(selectedPage.title);
+
             // Hide the current open page
             $('.oae-page > div', $rootel).hide();
 


### PR DESCRIPTION
Because of the left hand navigation, the browser title is now incorrectly set to `Content` for content item or `Discussion` for discussions.

The browser title should be the following when the lhnav is used:
- Me: `Open Academic Environment - My ...`
- User: `Open Academic Environment - First name Last name - Library`
- Group: `Open Academic Environment - Group title - Library`
- Content item: `Open Academic Environment - Content title`
- Discussion: `Open Academic Environment - Discussion title`
