### PR TITLE
Details and compact view list action buttons alignment

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -1457,6 +1457,7 @@ ul.oae-list > li:first-child .oae-listitem {
 
 .oae-list-actions ul {
     margin: 0;
+    padding: 0;
 }
 
 .oae-list-actions ul > li {


### PR DESCRIPTION
The list action buttons in details and compact view are too far to the right. They should be aligned to the left of the widget.

![screen shot 2014-03-05 at 14 21 24](https://f.cloud.github.com/assets/109850/2333832/97ea7698-a471-11e3-8f3a-be284bb31061.png)
