### PR TITLE
Activity summary issue

### DIFF
--- a/shared/oae/api/oae.api.push.js
+++ b/shared/oae/api/oae.api.push.js
@@ -302,8 +302,14 @@ define(['exports', 'jquery', 'underscore', 'oae.api.util', 'sockjs'], function(e
         aggregates[resourceId] = aggregates[resourceId] || {};
         aggregates[resourceId][streamType] = aggregates[resourceId][streamType] || {};
 
-        // Only aggregate activities of the same activity type (e.g. `content-create`)
         var activityType = newMessage.activity['oae:activityType'];
+
+        // Only aggregate activities if there are rules defined for that type
+        if (!AGGREGATION_RULES[activityType]) {
+            return callback(newMessage);
+        }
+
+        // Only aggregate activities of the same activity type (e.g. `content-create`)
         aggregates[resourceId][streamType][activityType] = aggregates[resourceId][streamType][activityType] || {};
 
         // Generate the aggregation key used to determine which activities should be aggregated


### PR DESCRIPTION
The push notification created by changing the visibility of 2 content items doesn't have a description. When refreshing the page, this is not an issue, as the activities are not aggregated.

![screen shot 2014-01-29 at 19 27 42](https://f.cloud.github.com/assets/109850/2033364/c6ac0d32-891b-11e3-93bc-b0c71479e62e.png)
