### PR TITLE
Top navigation issues

### DIFF
--- a/node_modules/oae-core/topnavigation/css/topnavigation.css
+++ b/node_modules/oae-core/topnavigation/css/topnavigation.css
@@ -14,9 +14,47 @@
  */
 
 #topnavigation-container {
-    line-height: 5;
-    margin-bottom: 5px;
+    margin: 5px 0;
 }
+
+/* Setup and alignment of three main topnav areas */
+
+#topnavigation-controls {
+    display: table;
+    width: 100%;
+}
+
+#topnavigation-center,
+#topnavigation-left,
+#topnavigation-right {
+    display: table-cell;
+    vertical-align: middle;
+}
+
+#topnavigation-left,
+#topnavigation-right {
+    width: 41.6666667%;
+}
+
+#topnavigation-center {
+    text-align: center;
+    width: 16.6666667%
+}
+
+#topnavigation-left {
+    padding-left: 15px;
+}
+
+#topnavigation-right {
+    padding-right: 15px;
+    text-align: right;
+}
+
+#topnavigation-center .oae-institutional-logo,
+#topnavigation-center .oae-institutional-logo-small {
+    margin: 0;
+}
+
 
 /** MENU ITEMS **/
 
@@ -33,30 +71,38 @@
 }
 
 #topnavigation-loginlogout-container {
+    display: inline;
     max-width: 100px;
-    padding: 0 0 0 34px;
+    padding: 0 0 0 10px;
 }
 
 #topnavigation-loginlogout-container #topnavigation-signout {
     padding: 23px 0;
 }
 
+#topnavigation-loginlogout-container ul.topnavigation-menu-buttons {
+    display: inline-block;
+}
+
 /** SEARCH **/
 
 #topnavigation-search-form {
-    margin-top: 18px;
+    display: inline-block;
+}
+
+#topnavigation-search-form .form-group {
+    margin: 0;
 }
 
 #topnavigation-search-form #topnavigation-search-query {
-    display: inline;
-    padding-right: 30px;
+    position: relative; /* Shift underneath search button */
+    right: -30px;
+    width: auto;
 }
 
 #topnavigation-search-form #topnavigation-search-icon {
-    margin-left: -27px;
-    margin-top: 7px;
-    padding: 0px;
     opacity: 0.6;
+    padding: 0 10px 0 0;
 }
 
 /* On smaller resolutions the search box is hidden and the margin on the search icon needs to be changed */
@@ -131,6 +177,10 @@
 }
 
 @media (min-width: 992px) {
+    #topnavigation-search-form #topnavigation-search-query {
+        display: inline !important; /* Need to override bootstrap's visible-sm */
+    }
+
     .topnavigation-signin-dropdown-double {
         width: 500px;
     }

--- a/node_modules/oae-core/topnavigation/topnavigation.html
+++ b/node_modules/oae-core/topnavigation/topnavigation.html
@@ -8,12 +8,12 @@
     <div id="topnavigation-scroll-to-top_container">
         <button id="topnavigation-scroll-to-top" class="oae-link-button hide" title="__MSG__SCROLL_TO_TOP__" accesskey="s"></button>
     </div>
-    <!-- NAVIGATION -->
-    <div class="row">
-        <!-- LEFT MENU -->
-        <div id="topnavigation-left" class="col-xs-5"><!-- --></div>
+    <!-- NAVIGATION CONTROLS -->
+    <div id="topnavigation-controls">
+        <!-- LEFT CONTROLS -->
+        <div id="topnavigation-left"><!-- --></div>
         <!-- LOGO -->
-        <div id="topnavigation-center" class="col-xs-2 text-center">
+        <div id="topnavigation-center">
             <a href="/" class="oae-institutional-logo hidden-xs visible-sm" title="__MSG__OAE__">
                 <span class="oae-aural-text">__MSG__OAE__</span>
             </a>
@@ -21,21 +21,20 @@
                 <span class="oae-aural-text">__MSG__OAE__</span>
             </a>
         </div>
-        <!-- RIGHT MENU -->
-        <div id="topnavigation-right" class="col-xs-5">
-            <div id="topnavigation-loginlogout-container" class="pull-right"><!-- --></div>
+        <!-- RIGHT CONTROLS -->
+        <div id="topnavigation-right">
             <!-- SEARCH -->
-            <div class="col-md-8 pull-right">
-                <form id="topnavigation-search-form" class="form-horizontal navbar-search" role="search" aria-label="__MSG__TOPNAV_SEARCH_ARIA_LABEL__">
-                    <div class="form-group">
-                        <label for="topnavigation-search-query" class="control-label oae-aural-text">__MSG__SEARCH__</label>
-                        <input type="text" id="topnavigation-search-query" class="hidden-xs hidden-sm search-query form-control pull-left" title="__MSG__SEARCH_FOR_CONTENT_PEOPLE_GROUPS__"/>
-                        <button type="submit" id="topnavigation-search-icon" class="btn btn-link pull-left">
-                            <i class="icon-search"><span class="oae-aural-text">__MSG__SEARCH__</span></i>
-                        </button>
-                    </div>
-                </form>
-            </div>
+            <form id="topnavigation-search-form" class="form-horizontal navbar-search" role="search" aria-label="__MSG__TOPNAV_SEARCH_ARIA_LABEL__">
+                <div class="form-group">
+                    <label for="topnavigation-search-query" class="control-label oae-aural-text">__MSG__SEARCH__</label>
+                    <input type="text" id="topnavigation-search-query" class="hidden-xs hidden-sm search-query form-control" title="__MSG__SEARCH_FOR_CONTENT_PEOPLE_GROUPS__"/>
+                    <button type="submit" id="topnavigation-search-icon" class="btn btn-link">
+                        <i class="icon-search"><span class="oae-aural-text">__MSG__SEARCH__</span></i>
+                    </button>
+                </div>
+            </form>
+            <!-- LOGIN/LOGOUT -->
+            <div id="topnavigation-loginlogout-container"><!-- --></div>
         </div>
     </div>
 </div>
@@ -62,7 +61,7 @@
                            oae.api.config.getValue('oae-authentication', 'cas', 'enabled') ||
                            oae.api.config.getValue('oae-authentication', 'shibboleth', 'enabled')}
 
-    <ul class="pull-right list-inline topnavigation-menu-buttons">
+    <ul class="list-inline topnavigation-menu-buttons">
         <li class="dropdown">
             <button type="button" id="topnavigation-signin" class="btn btn-link dropdown-toggle" data-toggle="dropdown">__MSG__SIGN_IN__</button>
 
@@ -123,8 +122,8 @@
                                     <input id="topnavigation-signin-password" name="topnavigation-signin-password" type="password" class="form-control required" maxlength="255">
                                 </div>
                                 <div id="topnavigation-login-actions">
-                                    <button id="topnavigation-signin-button" class="btn btn-primary pull-right" type="submit">__MSG__SIGN_IN__</button>
-                                    <span id="topnavigation-signin-signing-in" class="hide" class="pull-right">__MSG__SIGNING_IN__...</span>
+                                    <button id="topnavigation-signin-button" class="btn btn-primary" type="submit">__MSG__SIGN_IN__</button>
+                                    <span id="topnavigation-signin-signing-in" class="hide">__MSG__SIGNING_IN__...</span>
                                     {if oae.api.config.getValue("oae-authentication", "local", "allowAccountCreation")}
                                         <span>__MSG__NO_ACCOUNT_YET__
                                             <button id="topnavigation-signin-signup" type="button" class="btn btn-link oae-trigger-register">__MSG__SIGN_UP__</button>
@@ -163,7 +162,7 @@
 --></div>
 
 <div id="topnavigation-right-loggedin-template"><!--
-    <button type="button" id="topnavigation-signout" class="btn btn-link pull-right" title="__MSG__SIGN_OUT__">
+    <button type="button" id="topnavigation-signout" class="btn btn-link" title="__MSG__SIGN_OUT__">
         <i class="icon-signout"><span class="oae-aural-text">__MSG__SIGN_OUT__</span></i>
     </button>
 --></div>


### PR DESCRIPTION
- On small screens, the gap between search and log out is noticeably larger than the gap between home and notifications
- The order of the search and log out buttons is still reversed, causing tab order to be unnatural. We should revert to a structure where the logical order is preserved

![screen shot 2014-03-05 at 13 56 09](https://f.cloud.github.com/assets/109850/2333612/1f35ca48-a46e-11e3-8065-f112bc009cab.png)
