### PR TITLE
Changepic issues

### DIFF
--- a/node_modules/oae-core/changepic/css/changepic.css
+++ b/node_modules/oae-core/changepic/css/changepic.css
@@ -109,10 +109,3 @@
     display: block !important;   /* jCrop sets inline CSS to display: none; which makes the crop area inaccessible for keyboard users */
     opacity: 0;                  /* https://github.com/tapmodo/Jcrop/issues/20 */
 }
-
-/* iPhone resolution */
-@media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
-    #changepic-modal .modal-content {
-        min-width: inherit;
-    }
-}


### PR DESCRIPTION
- On the iPhone, the first state of changepic widget unnecessarily takes up the full width

![screen shot 2014-03-03 at 18 11 21](https://f.cloud.github.com/assets/109850/2334744/f9e55048-a47b-11e3-8e10-114a9c0bd591.png)
- On the iPhone, when cropping the profile picture, the picture overflows the available space

![screen shot 2014-03-05 at 15 35 29](https://f.cloud.github.com/assets/109850/2334737/e9e52786-a47b-11e3-9915-71cfeaa051fe.png)
- On a Desktop device, the widget can be larger than the screen (when screen size is reduced to 400px)
