### PR TITLE
Show all button for activity collections > 3 items

### DIFF
--- a/node_modules/oae-core/activity/activity.html
+++ b/node_modules/oae-core/activity/activity.html
@@ -64,35 +64,23 @@
                 </ul>
             {else}
                 {if previewObj.objectType === 'collection'}
+                    {var previewItems = previewObj['oae:collection']}
                     {var count = previewObj['oae:collection'].length}
-                    {if count <= 3}
-                        {var largePreviews = previewObj['oae:collection'].slice(0, 3)}
-                    {else}
-                        {var largePreviews = previewObj['oae:collection'].slice(0, 2)}
-                        {var smallPreviews = previewObj['oae:collection'].slice(2, 14)}
-                    {/if}
                 {else}
-                    {var largePreviews = [previewObj]}
+                    {var previewItems = [previewObj]}
+                    {var count = 1}
                 {/if}
 
-                <ul class="row oae-list oae-list-grid">
-                    {for largePreview in largePreviews}
-                        ${listItem(largePreview, null, false)}
+                <ul class="row oae-list oae-list-grid{if count > 3} activity-multiple{/if}">
+                    {for item in previewItems}
+                        ${listItem(item, null, false)}
                     {/for}
-                    {if smallPreviews}
-                        <li>
-                            <div class="oae-tile activity-multiple">
-                                {for smallPreview in smallPreviews}
-                                    ${renderThumbnail(smallPreview, false)}
-                                {/for}
-                                {if count > 14}
-                                    {var x = count - 14}
-                                    <div class="oae-tile-metadata">__MSG__AND_X_MORE__</div>
-                                {/if}
-                            </div>
-                        </li>
-                    {/if}
                 </ul>
+                {if count > 3}
+                    <div class="media text-center activity-show-all-container">
+                        <a class="btn btn-link activity-show-all-toggle">__MSG__SHOW_ALL__</a>
+                    </div>
+                {/if}
             {/if}
         </div>
     {/macro}

--- a/node_modules/oae-core/activity/css/activity.css
+++ b/node_modules/oae-core/activity/css/activity.css
@@ -46,25 +46,13 @@
 
 /* Tile with multiple items */
 
-.activity-widget ul.oae-list.oae-list-grid > li .activity-multiple {
-    height: 162px;
-    border: none;
-    -webkit-box-shadow: none;
-       -moz-box-shadow: none;
-            box-shadow: none;
-    width: 162px;
+/* Hide all but the first three activity items */
+.activity-widget ul.oae-list.oae-list-grid.activity-multiple li:nth-child(n+4) {
+    display:none;
 }
 
-.activity-widget ul.oae-list.oae-list-grid > li .activity-multiple div.oae-thumbnail {
-    height: 25px;
-    margin: 3px 0 15px 8px;
-    width: 25px;
-}
-
-.activity-widget ul.oae-list.oae-list-grid > li .activity-multiple div.oae-thumbnail img {
-    height: 25px;
-    min-width: 25px;
-    width: 25px;
+.activity-widget div.activity-preview-container.activity-show-all ul.oae-list.oae-list-grid.activity-multiple li {
+    display:block;
 }
 
 /* Wide tiles */

--- a/node_modules/oae-core/activity/js/activity.js
+++ b/node_modules/oae-core/activity/js/activity.js
@@ -179,6 +179,20 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
         };
 
         /**
+         * Bind an event to the show all link for those activities which have more than 3 thumbnails. When this is clicked,
+         * the other thumbnails will be shown
+         */
+        var postRenderer = function() {
+            $('.activity-show-all-toggle', $rootel).on('click', function() {
+                // Show all the thumbnails in this activity
+                $(this).closest('div.activity-preview-container').addClass('activity-show-all');
+
+                // Remove the "Show all" button
+                $(this).closest('div.activity-show-all-container').hide();
+            });
+        };
+
+        /**
          * Render the list header of the activity feed
          */
         var setUpListHeader = function() {
@@ -233,6 +247,7 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
                 'limit': 10
             }, '#activity-items-template', {
                 'postProcessor': processActivities,
+                'postRenderer': postRenderer,
                 'emptyListProcessor': handleEmptyResultList
             });
         };


### PR DESCRIPTION
This commit introduces a "Show all" button when an activity is a
collection of more than 3 activities. By default, only 3 tiles are
shown. When the user clicks the button, all remaining tiles are
displayed and the "Show all" button is removed.
