### PR TITLE
Clips take up more space than needed on IE9

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -714,8 +714,7 @@ div.oae-thumbnail i[class^="icon-"] {
 
 /* Box sizing tweak needed to workaround IE9 bug in calculating container size */
 .ie-lt10 .oae-clip .oae-clip-content > div > ul li button {
-    -moz-box-sizing: content-box;
-         box-sizing: content-box;
+    box-sizing: content-box;
     min-width: 50px; /* doesn't include padding with content-box */
 }
 


### PR DESCRIPTION
Note that the clips are also overlapping, so some tweaking might be required.

![screen shot 2014-03-07 at 15 22 45](https://f.cloud.github.com/assets/109850/2358430/659b7aa6-a60c-11e3-9919-8e48c2a487ee.png)
