### PR TITLE
Document preview doesn't process UI controls while loading

### DIFF
--- a/node_modules/oae-core/documentpreview/js/documentpreview.js
+++ b/node_modules/oae-core/documentpreview/js/documentpreview.js
@@ -166,6 +166,12 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
             // can take a while in large documents
             $content.addClass('documentpreview-content-preloading');
 
+            // Disable all the controls while we're loading
+            $zoomOut.prop('disabled', true);
+            $zoomIn.prop('disabled', true);
+            $nextPage.prop('disabled', true);
+            $pageNumber.prop('disabled', true);
+
             /**
              * Stop the page loading process when all required pages have
              * been loaded or when an error has occurred during loading
@@ -176,6 +182,9 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
                 $content.removeClass('documentpreview-content-preloading');
                 // Scroll to the requested page
                 scrollToPage(pages[pageNumber - 1]);
+                // Re-enable appropriate toolbar buttons
+                updateToolbar();
+                $pageNumber.prop('disabled', false);
             };
 
             /**


### PR DESCRIPTION
1. View multi-page document (e.g. this [one](https://oae.oae-qa0.oaeproject.org/content/oae/eJsumkTAH))
2. Enter page number (e.g. "12") in input and press enter.
3. While request is being processed, delete "12", input new page number (e.g. "2"), and press enter.
4. The control shows the new page number ("2") but then it is overwritten with the original request ("12") and that page (12, not 2) is loaded for viewing.
