### PR TITLE
Reply icon alignment

### DIFF
--- a/node_modules/oae-core/comments/css/comments.css
+++ b/node_modules/oae-core/comments/css/comments.css
@@ -55,6 +55,11 @@
     margin: 1px 15px 3px 3px;
 }
 
+/* Align top of reply and delete buttons with container */
+.comments-widget .media-body .btn {
+    padding-top: 0;
+}
+
 .comments-widget small {
     font-size: 12px;
 }


### PR DESCRIPTION
The reply icon in comments in not quite aligned with the top line of the comment.

![screen shot 2014-03-19 at 16 06 08](https://f.cloud.github.com/assets/109850/2463097/4139d0ec-af88-11e3-845b-c07dd17ca26b.png)
