### PR TITLE
Notifications loading phase (spinner) doesn't look right

### DIFF
--- a/node_modules/oae-core/notifications/css/notifications.css
+++ b/node_modules/oae-core/notifications/css/notifications.css
@@ -35,6 +35,8 @@
 #notifications-container {
     line-height: 1.5;
     max-height: 254px;
+    min-height: 60px;
+    min-width: 240px;
     overflow: auto;
 }
 


### PR DESCRIPTION
When you click notifications there is a period of time when the spinner is going, and the panel is misaligned
