### PR TITLE
Suggestions for "My Profile" privacy icons

### DIFF
--- a/node_modules/oae-core/creategroup/creategroup.html
+++ b/node_modules/oae-core/creategroup/creategroup.html
@@ -31,7 +31,7 @@
     <h4>__MSG__VISIBILITY__</h4>
 
     <div class="oae-large-options-container row">
-        <div class="col-md-4 text-center">
+        <div class="col-sm-4 text-center">
             <label for="oae-visibility-private" class="{if visibility === 'private'}checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">
@@ -42,7 +42,7 @@
                 <small>__MSG__GROUP_PRIVATE_DESCRIPTION__</small>
             </label>
         </div>
-        <div class="col-md-4 text-center">
+        <div class="col-sm-4 text-center">
             <label for="oae-visibility-loggedin" class="{if visibility === 'loggedin'} checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">
@@ -53,7 +53,7 @@
                 <small>__MSG__GROUP_LOGGEDIN_DESCRIPTION__</small>
             </label>
         </div>
-        <div class="col-md-4 text-center">
+        <div class="col-sm-4 text-center">
             <label for="oae-visibility-public" class="{if visibility === 'public'} checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">

--- a/node_modules/oae-core/creategroup/css/creategroup.css
+++ b/node_modules/oae-core/creategroup/css/creategroup.css
@@ -13,14 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#creategroup-modal .modal-body {
-    padding: 5px 25px 0;
-}
-
-#creategroup-modal .modal-footer {
-    padding: 0 25px 15px 15px;
-}
-
 #creategroup-modal #creategroup-name {
     width: 100%;
 }

--- a/node_modules/oae-core/editgroup/css/editgroup.css
+++ b/node_modules/oae-core/editgroup/css/editgroup.css
@@ -12,7 +12,3 @@
  * or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
-#editgroup-modal .modal-body {
-    padding: 5px 25px 0;
-}

--- a/node_modules/oae-core/editgroup/editgroup.html
+++ b/node_modules/oae-core/editgroup/editgroup.html
@@ -38,7 +38,7 @@
     <h4>__MSG__JOIN_OPTIONS__</h4>
 
     <div class="row oae-large-options-container">
-        <div class="col-md-6 text-center">
+        <div class="col-sm-6 text-center">
             <label for="oae-joinable-no" class="{if joinable === 'no'}checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">
@@ -49,7 +49,7 @@
                 <small>__MSG__GROUP_JOINABLE_MANAGERS_ADD_DESCRIPTION__</small>
             </label>
         </div>
-        <div class="col-md-6 text-center">
+        <div class="col-sm-6 text-center">
             <label for="oae-joinable-yes" class="{if joinable === 'yes'}checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">

--- a/node_modules/oae-core/editprofile/editprofile.html
+++ b/node_modules/oae-core/editprofile/editprofile.html
@@ -32,7 +32,7 @@
     <h4>__MSG__PROFILE_VISIBILITY__</h4>
     {var tenant = oae.api.util.security().encodeForHTML(oae.data.me.tenant.displayName)}
     <div class="oae-large-options-container row">
-        <div class="col-md-4 text-center">
+        <div class="col-sm-4 text-center">
             <label for="oae-visibility-private" class="{if oae.data.me.visibility === 'private'} checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">
@@ -43,7 +43,7 @@
                 <small>__MSG__PROFILE_PRIVATE_DESCRIPTION__</small>
             </label>
         </div>
-        <div class="col-md-4 text-center">
+        <div class="col-sm-4 text-center">
             <label for="oae-visibility-loggedin" class="{if oae.data.me.visibility === 'loggedin'} checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">
@@ -54,7 +54,7 @@
                 <small>__MSG__PROFILE_LOGGEDIN_DESCRIPTION__</small>
             </label>
         </div>
-        <div class="col-md-4 text-center">
+        <div class="col-sm-4 text-center">
             <label for="oae-visibility-public" class="{if oae.data.me.visibility === 'public'} checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">

--- a/node_modules/oae-core/manageaccess/manageaccess.html
+++ b/node_modules/oae-core/manageaccess/manageaccess.html
@@ -84,7 +84,7 @@
 <div id="manageaccess-visibility-template"><!--
     <h4>__MSG__VISIBILITY__</h4>
     <div class="oae-large-options-container row">
-        <div class="col-md-4 text-center">
+        <div class="col-sm-4 text-center">
             <label for="oae-visibility-private" class="{if visibility === 'private'} checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">
@@ -95,7 +95,7 @@
                 <small>${messages.privateDescription}</small>
             </label>
         </div>
-        <div class="col-md-4 text-center">
+        <div class="col-sm-4 text-center">
             <label for="oae-visibility-loggedin" class="{if visibility === 'loggedin'} checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">
@@ -106,7 +106,7 @@
                 <small>${messages.loggedinDescription}</small>
             </label>
         </div>
-        <div class="col-md-4 text-center">
+        <div class="col-sm-4 text-center">
             <label for="oae-visibility-public" class="{if visibility === 'public'} checked{/if}">
                 <i class="icon-ok hide"></i>
                 <div class="oae-large-options well">

--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -214,57 +214,56 @@ i[class^="icon-"].large:before {
  * - `col-md-<x>` defines the width of the column. The sum of all column widths should be 12
  **/
 
+.oae-large-options-container {
+    margin-top: -35px;
+    padding: 0 10px;
+}
+
+.oae-large-options-container > div {
+    padding: 35px 7px 0 7px;
+}
+
 .oae-large-options-container label {
     cursor: pointer;
     display: inline;
-}
-
-.oae-large-options-container label small {
-    display: block;
-    margin: 0 0 35px;
-    position: relative;
-}
-
-.oae-large-options-container label.checked small {
     margin: 0;
-    top: -35px;
 }
 
-.oae-large-options-container .oae-large-options {
+.oae-large-options-container label .oae-large-options {
     -webkit-box-sizing: border-box;
        -moz-box-sizing: border-box;
             box-sizing: border-box;
     height: 150px;
+    margin-bottom: 17px;
     padding-top: 13px;
     width: 100%;
 }
 
 .oae-large-options-container label.checked .oae-large-options {
     border: 8px solid;
+    margin-top: -35px;
     padding-top: 6px;
-    position: relative;
-    top: -35px;
 }
 
-.oae-large-options-container .oae-large-options input {
+.oae-large-options-container label .oae-large-options input {
     position: absolute;
     z-index: -1; /* Adding a z-index of -1 hides the element from the view but still allows for focus of the element */
 }
 
-.oae-large-options-container .oae-large-options i.icon-oae-private:before,
-.oae-large-options-container .oae-large-options i.icon-oae-loggedin:before,
-.oae-large-options-container .oae-large-options i.icon-oae-public:before {
+.oae-large-options-container label .oae-large-options i.icon-oae-private:before,
+.oae-large-options-container label .oae-large-options i.icon-oae-loggedin:before,
+.oae-large-options-container label .oae-large-options i.icon-oae-public:before {
     margin-top: 6px;
 }
 
-.oae-large-options-container .oae-large-options span {
+.oae-large-options-container label .oae-large-options span {
     display: block;
     font-size: 13px;
     font-weight: bold;
     margin-top: 15px;
 }
 
-.oae-large-options-container i.icon-ok {
+.oae-large-options-container label i.icon-ok {
     display: none;
 }
 


### PR DESCRIPTION
1. We change the layout of the privacy icons when the width of the modal hasn't changed at all. This seems unnecessary

![screen shot 2014-03-19 at 12 42 34 pm](https://f.cloud.github.com/assets/102265/2462841/873678f0-af85-11e3-8468-1c51684ab14a.png)
1. Even when we get to (I think) "small" size, the modal size _increases_ as a result of reducing the padding on the page. That is good, but I think we can still leave the layout of those buttons the same since we didn't lose width
2. Rry and keep the width of the privacy squares the same always rather than stretching them to the width of the modal, it looks odd
3. Don't use 3-dots on the header text (i.e., tenant name in the "logged in" privacy box), instead let it wrap

![screen shot 2014-03-19 at 12 40 58 pm](https://f.cloud.github.com/assets/102265/2462835/6a56325c-af85-11e3-8cda-98ffa6ecc636.png)
