### PR TITLE
Global tenant 404 not properly caught

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -83,6 +83,18 @@ http {
             expires max;
         }
 
+        # HTML files under /shared/oae/errors are not hashed and should not be cached
+        location ~* /shared/oae/errors/([^\.]+).html$ {
+            alias <%= nginxConf.UX_HOME %>/shared/oae/errors/$1.html;
+            expires -1;
+        }
+
+        rewrite ^/accessdenied      /shared/oae/errors/accessdenied.html last;
+        rewrite ^/maintenance       /shared/oae/errors/maintenance.html last;
+        rewrite ^/noscript          /shared/oae/errors/noscript.html last;
+        rewrite ^/notfound          /shared/oae/errors/notfound.html last;
+        rewrite ^/unavailable       /shared/oae/errors/unavailable.html last;
+
         rewrite ^/favicon.ico /shared/oae/img/favicon.ico last;
 
 
@@ -106,9 +118,25 @@ http {
         rewrite ^/tenant/(.*)$   /admin/index.html last;
 
 
+        #################
+        ## ERROR PAGES ##
+        #################
+
+        error_page      401     /shared/oae/errors/accessdenied.html;
+        error_page      404     /shared/oae/errors/notfound.html;
+        error_page      502     /shared/oae/errors/unavailable.html;
+        error_page      503     /shared/oae/errors/maintenance.html;
+
+
         #########################
         ## APP SERVER REQUESTS ##
         #########################
+
+        location /ui/ {
+            alias <%= nginxConf.UX_HOME %>/ui/;
+            autoindex off;
+            expires max;
+        }
 
         location /api/ui/skin {
             expires 15m;
@@ -129,6 +157,31 @@ http {
         location /api/ {
             expires -1;
             proxy_pass http://globaladminworkers;
+        }
+
+        ######################
+        ## WIDGET RESOURCES ##
+        ######################
+
+        location /node_modules/ {
+            alias <%= nginxConf.UX_HOME %>/node_modules/;
+            autoindex off;
+            expires max;
+        }
+
+        ########################
+        ## PUSH NOTIFICATIONS ##
+        ########################
+
+        location /api/push/ {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_pass http://tenantworkers;
+            proxy_redirect off;
+            proxy_buffering off;
+            proxy_read_timeout 3600;
         }
     }
 


### PR DESCRIPTION
We should have proper error pages for the global tenant, similar to what we have for the tenants. Assigning to @nicolaasmatthijs as this probably needs some design thinking.
