### PR TITLE
IE10 ghost autosuggest button

### DIFF
--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -500,6 +500,10 @@ ul.as-selections li.as-original input:focus {
     width: 150px;
 }
 
+ul.as-selections li.as-original input::-ms-clear {
+    display: none;
+}
+
 ul.as-selections li.as-selection-item {
     -webkit-border-radius: 3px;
         -moz-border-radius: 3px;


### PR DESCRIPTION
IE10 shows a ghost close button in the autosuggest.

![screen shot 2014-03-24 at 19 58 38](https://f.cloud.github.com/assets/109850/2504552/c7f62bc6-b38e-11e3-9140-31b85c9ec4ae.png)
