### PR TITLE
Manage access visual issues

### DIFF
--- a/node_modules/oae-core/manageaccess/css/manageaccess.css
+++ b/node_modules/oae-core/manageaccess/css/manageaccess.css
@@ -21,8 +21,7 @@
     margin-top: -3px;
 }
 
-#manageaccess-modal #manageaccess-overview-visibility.well,
-#manageaccess-modal #manageaccess-overview-shared.well {
+#manageaccess-modal #manageaccess-overview-visibility.well {
     padding: 10px;
     margin-bottom: 25px;
 }
@@ -34,7 +33,12 @@
 #manageaccess-modal #manageaccess-overview-shared.well {
     height: 240px;
     margin-bottom: 0;
+    padding: 0;
     overflow: auto;
+}
+
+#manageaccess-modal #manageaccess-overview-selected {
+    padding: 10px;
 }
 
 /* List items */
@@ -158,9 +162,8 @@
     #manageaccess-modal #manageaccess-overview-selected > li .oae-listitem-actions > .btn,
     #manageaccess-modal #manageaccess-overview-selected > li .oae-listitem-actions > i {
         float: right;
-        bottom: 45px;
         left: 30px;
-        margin-top: 13px;
+        margin-top: -30px;
         position: relative;
     }
 


### PR DESCRIPTION
When there are more than 4 items in the `manageaccess` widget, Firefox shows too much space below the last one, whilst IE doesn't show any margin below the last one.

FF:

![screen shot 2014-03-24 at 19 18 56](https://f.cloud.github.com/assets/109850/2504266/39a8ba12-b38b-11e3-8a59-884c0a86e762.png)

IE:

![screen shot 2014-03-24 at 19 31 22](https://f.cloud.github.com/assets/109850/2504268/43a46868-b38b-11e3-8bd2-621b12615d3c.png)
