### PR TITLE
Activity summary doesn't wrap properly in activity feed in IE9

### DIFF
--- a/node_modules/oae-core/activity/css/activity.css
+++ b/node_modules/oae-core/activity/css/activity.css
@@ -23,6 +23,11 @@
     padding-left: 50px;
 }
 
+/* IE9 ignores word-wrap on `<a>` tags */
+.ie-lt10 .activity-widget .activity-summary {
+    word-wrap: break-word;
+}
+
 .activity-widget .activity-summary a {
     word-wrap: break-word;
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/102265/2539711/c205dd5e-b5ca-11e3-9e43-50279e2b91b5.png)

It does appear to have wrapped properly in the heading of the comment that was part of the feed, though.
