### PR TITLE
Lhnav regression on content/discussion profile

### DIFF
--- a/ui/css/oae.content.css
+++ b/ui/css/oae.content.css
@@ -20,7 +20,7 @@
     }
 
     .oae-page {
-        padding: 5px 25px 50px !important;
+        margin-left: 25px;
     }
 }
 

--- a/ui/css/oae.discussion.css
+++ b/ui/css/oae.discussion.css
@@ -20,7 +20,7 @@
     }
 
     .oae-page {
-        padding: 5px 25px 50px !important;
+        margin-left: 25px;
     }
 }
 

--- a/ui/search.html
+++ b/ui/search.html
@@ -51,7 +51,7 @@
             <div>
                 <div id="search-content-container" class="row">
                     <div class="oae-lhnavigation">
-                        <ul id="search-refine-type" class="nav nav-list hidden-xs hidden-sm">
+                        <ul id="search-refine-type" class="nav nav-list">
                             <li class="nav-header">__MSG__REFINE_SEARCH_BY_TYPE_COLON__</li>
                             <li>
                                 <label class="checkbox"><input type="checkbox" data-type="user" /><div>__MSG__PEOPLE__</div></label>


### PR DESCRIPTION
On content and discussion profiles, the page content is moved to the left on large screens. When looking at the code, that is expected indeed. The work-around for this can be removed once we drop the left hand navigation on these pages.

![screen shot 2014-03-28 at 10 03 20](https://cloud.githubusercontent.com/assets/109850/2548347/1800c5fc-b661-11e3-8df9-221758e865ae.png)
