### PR TITLE
`Rename` shouldn't have `x` on IE10

### DIFF
--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -304,6 +304,10 @@ select.form-control {
     padding: 0;
 }
 
+.modal .jeditable-field form input::-ms-clear {
+    display: none;
+}
+
 /* Add an IE9 fallback for threedots */
 
 @media (min-width: 550px) {


### PR DESCRIPTION
`Rename` shouldn't have `x` on IE10

![screen shot 2014-03-31 at 16 37 36](https://cloud.githubusercontent.com/assets/109850/2569630/3bc966d4-b8ef-11e3-9bb6-c3246f323d3d.png)
