### PR TITLE
Don't clear comment text box when submitting

### DIFF
--- a/node_modules/oae-core/comments/js/comments.js
+++ b/node_modules/oae-core/comments/js/comments.js
@@ -93,20 +93,23 @@ define(['jquery', 'oae.core', 'jquery.autosize'], function($, oae) {
          */
          var createComment = function(form) {
             var $form = $(form);
+            $form.find('textarea, button').prop('disabled', true);
             var comment = $.trim($('textarea', $form).val());
             // Post the comment and re-render the results
             oae.api.comment.createComment(contextProfile.id, contextProfile.resourceType, comment, null, function(err, comment) {
                 if (!err) {
                     renderComment(comment);
+                    // Reset the form
+                    $form[0].reset();
+                    // Resize the textarea as it is now empty
+                    $('textarea', $form).trigger('autosize.resize');
                 } else {
                     var params = {'type': 'comment'};
                     showErrorNotification(params);
                 }
+                // Enable form controls
+                $form.find('textarea, button').prop('disabled', false);
             });
-            // Reset the form
-            $form[0].reset();
-            // Resize the textarea as it is now empty
-            $('textarea', $form).trigger('autosize.resize');
             // Return false to prevent the default browser behavior
             return false;
         };
@@ -118,20 +121,23 @@ define(['jquery', 'oae.core', 'jquery.autosize'], function($, oae) {
          */
         var createReply = function(form) {
             var $form = $(form);
+            $form.find('textarea, button').prop('disabled', true);
             var replyTo = $form.attr('data-replyTo');
             var comment = $.trim($form.find('textarea').val());
             // Post the comment and re-render the results
             oae.api.comment.createComment(contextProfile.id, contextProfile.resourceType, comment, replyTo, function(err, comment) {
                 if (!err) {
                     renderComment(comment);
+                    // Reset the form
+                    $form[0].reset();
+                    $form.parents('.comments-reply-container').hide();
                 } else {
                     var params = {'type': 'reply'};
                     showErrorNotification(params);
                 }
+                // Enable form controls
+                $form.find('textarea, button').prop('disabled', false);
             });
-            // Reset the form
-            $form[0].reset();
-            $form.parents('.comments-reply-container').hide();
             // Return false to prevent the default browser behavior
             return false;
         };


### PR DESCRIPTION
It's a pretty minor thing, but it'd be nice if we could wait with clearing the text box when submitting a comment until the server has acknowledged the message. Especially on mobile it can be annoying if you lose a comment that you've just laboured over for the last 5 minutes.

The button can probably be disabled on submit (and should be re-enabled on failure/success) to prevent double submitting something
