### PR TITLE
MediaCore preview issues

### DIFF
--- a/node_modules/oae-core/filepreview/css/filepreview.css
+++ b/node_modules/oae-core/filepreview/css/filepreview.css
@@ -69,6 +69,10 @@
     width: 100%;
 }
 
+.mobile #filepreview-container #filepreview-mediacore iframe {
+    width: 340px; /* iOS will need an explicit width for the iframe */
+}
+
 @media (min-width: 780px) {
     #filepreview-container #filepreview-mediacore iframe {
         height: 600px;


### PR DESCRIPTION
The MediaCore preview container overruns the page on iOs
