### PR TITLE
indented markdown loses linebreaks

### DIFF
--- a/node_modules/oae-core/filepreview/css/filepreview.css
+++ b/node_modules/oae-core/filepreview/css/filepreview.css
@@ -97,5 +97,5 @@
 }
 
 #filepreview-container #filepreview-markdown-container pre code {
-    white-space: nowrap;
+    white-space: pre;
 }


### PR DESCRIPTION
![linebreaks](https://cloud.githubusercontent.com/assets/70221/2540283/5f2aa08c-b5d1-11e3-99d2-2f6aaafe075b.png)

An indentation of 4 or more spaces in markdown results in `<pre><code>` around the lines, and is expected to be used for things like inline source code examples and as such should preserve linebreaks.
