### PR TITLE
 Profile picture update issue

### DIFF
--- a/shared/oae/js/jquery-plugins/jquery.update-picture.js
+++ b/shared/oae/js/jquery-plugins/jquery.update-picture.js
@@ -29,16 +29,8 @@ define(['jquery', 'oae.api.util'], function (jQuery, oaeUtil) {
                 'entityData': data
             }))).find('[role="img"]')[0].outerHTML;
 
-            // For each thumbnail in the DOM, render the updated thumbnail image
-            $('.oae-thumbnail[data-id="' + data.id + '"]').each(function(i, picture) {
-                // If the thumbnail to update links to the user's profile, render the image inside of the anchor tag inside of `oae-thumbnail`
-                if ($(picture).has('a').length) {
-                    $($(picture).has('a')).html(thumbnailImage);
-                // If the thumbnail to update doesn't link to the user's profile, render the image directly into `oae-thumbnail`
-                } else {
-                    $(picture).html(thumbnailImage);
-                }
-            });
+            // Updated the thumbnail images in the DOM
+            $('.oae-thumbnail[data-id="' + data.id + '"] [role="img"]').replaceWith(thumbnailImage);
         });
 
     })(jQuery);


### PR DESCRIPTION
When setting a new/updated profile picture, the picture will automatically be updated in the clip. However, the thumbnail is being rendered as a link, and is incorrectly clickable on Webkit.

The same mechanism is used to update all the other profile pictures from the user on the page, and all of those do need the link available.

![screen shot 2014-03-07 at 12 43 07](https://f.cloud.github.com/assets/109850/2356959/40248ef4-a5f6-11e3-95ba-66c718a05945.png)
