### PR TITLE
Update the readme file with a link to the widget wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ By default 3akai-ux uses the Open Sans font family available from Google's Web F
 
 ## Widget development
 
-Documentation on how to create custom OAE widgets and an overview of the available widgets can be found at the [Widget Library](http://oae-widgets.sakaiproject.org/)
+Documentation on how to create custom OAE widgets can be found in the [Widget Wiki](https://github.com/oaeproject/3akai-ux/wiki/Widget-Development-%5BWIP%5D)
 
 ## Functional tests
 


### PR DESCRIPTION
I suggest changing the link to the widget library to a link to the WIP on widget development before we tag bootstrap3
