### PR TITLE
Enable the error pages on the global administrator tenant

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -170,21 +170,6 @@ http {
         error_page      502     /shared/oae/errors/unavailable.html;
         error_page      503     /shared/oae/errors/maintenance.html;
 
-
-        ########################
-        ## PUSH NOTIFICATIONS ##
-        ########################
-
-        location /api/push/ {
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
-            proxy_pass http://tenantworkers;
-            proxy_redirect off;
-            proxy_buffering off;
-            proxy_read_timeout 3600;
-        }
     }
 
 


### PR DESCRIPTION
We should have proper error pages for the global tenant, similar to what we have for the tenants. Assigning to @nicolaasmatthijs as this probably needs some design thinking.
