### PR TITLE
Sign in popover has top border on iPad when it shouldn't

### DIFF
--- a/node_modules/oae-core/topnavigation/css/topnavigation.css
+++ b/node_modules/oae-core/topnavigation/css/topnavigation.css
@@ -144,7 +144,7 @@
     }
 }
 
-@media(max-width: 768px) {
+@media(max-width: 767px) {
     .topnavigation-signin-dropdown-double #topnavigation-signin-internal {
         border-top: 1px dotted #D4D4D4;
         padding-top: 15px;


### PR DESCRIPTION
![img_0015](https://cloud.githubusercontent.com/assets/218391/2581184/a3c9ca0a-b9b5-11e3-8fed-7b5440b5e807.PNG)

I think this is just on the breakpoint where we do some incorrect max-width min-width handling.
