### PR TITLE
Update `x time ago` timings regularly

### DIFF
--- a/node_modules/oae-core/activity/activity.html
+++ b/node_modules/oae-core/activity/activity.html
@@ -30,7 +30,7 @@
             </div>
             <div class="activity-summary">
                 ${renderActivitySummary(activity)}
-                <small class="muted oae-timeago" title="${oae.api.l10n.transformDateTime(activity.published)}"></small>
+                <small class="muted oae-timeago" title="${activity.published}"></small>
             </div>
         </div>
     {/macro}
@@ -93,7 +93,7 @@
                                     {else}
                                         ${comment.author.displayName|encodeForHTML}
                                     {/if}
-                                    <small class="muted oae-timeago" title="${oae.api.l10n.transformDateTime(comment.published)}"></small>
+                                    <small class="muted oae-timeago" title="${comment.published}"></small>
                                 </h4>
                                 ${oae.api.util.security().encodeForHTMLWithLinks(comment.content).replace(/\n/g, '<br/>')}
                             </div>

--- a/node_modules/oae-core/activity/js/activity.js
+++ b/node_modules/oae-core/activity/js/activity.js
@@ -234,13 +234,6 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
         };
 
         /**
-         * Apply jQuery timeago to the comment dates
-         */
-        var applyTimeago = function() {
-            $('.oae-timeago', $rootel).timeago();
-        };
-
-        /**
          * Initialize a new infinite scroll container that fetches the activity stream
          * for the current context.
          */
@@ -257,8 +250,7 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
                 'limit': 10
             }, '#activity-items-template', {
                 'postProcessor': processActivities,
-                'emptyListProcessor': handleEmptyResultList,
-                'postRenderer': applyTimeago
+                'emptyListProcessor': handleEmptyResultList
             });
         };
 

--- a/node_modules/oae-core/comments/comments.html
+++ b/node_modules/oae-core/comments/comments.html
@@ -58,7 +58,7 @@
                         {else}
                             ${comment.createdBy.displayName|encodeForHTML}
                         {/if}
-                        <small class="muted oae-timeago" title="${oae.api.l10n.transformDateTime(comment.created)}"></small>
+                        <small class="muted oae-timeago" title="${comment.created}"></small>
                     </h4>
                     ${oae.api.util.security().encodeForHTMLWithLinks(comment.body).replace(/\n/g, '<br/>')}
 

--- a/node_modules/oae-core/comments/js/comments.js
+++ b/node_modules/oae-core/comments/js/comments.js
@@ -27,13 +27,6 @@ define(['jquery', 'oae.core', 'jquery.autosize'], function($, oae) {
         var infinityScroll = null;
 
         /**
-         * Apply jQuery timeago to the comment dates
-         */
-        var applyTimeago = function() {
-            $('.oae-timeago', $rootel).timeago();
-        };
-
-        /**
          * Show a notification when an error occurs
          *
          * @param  {Object}    params           Parameters to be used in the template
@@ -61,6 +54,8 @@ define(['jquery', 'oae.core', 'jquery.autosize'], function($, oae) {
                         'canManage': contextProfile.isManager
                     })
                 );
+                // Apply timeago to the reply timestamp
+                oae.api.l10n.timeAgo($('#comments-container li:first-child + li', $rootel));
             // Reply on an existing comment
             } else {
                 // Insert the reply after the comment it is a reply to
@@ -70,8 +65,9 @@ define(['jquery', 'oae.core', 'jquery.autosize'], function($, oae) {
                         'canManage': contextProfile.isManager
                     })
                 );
+                // Apply timeago to the reply timestamp
+                oae.api.l10n.timeAgo($('li.media[data-id="' + comment.replyTo + '"] + li', $rootel));
             }
-            applyTimeago();
             setUpValidation();
         };
 
@@ -260,7 +256,6 @@ define(['jquery', 'oae.core', 'jquery.autosize'], function($, oae) {
                     return data;
                 },
                 'postRenderer': function() {
-                    applyTimeago();
                     setUpValidation();
                 }
             });

--- a/shared/oae/api/oae.api.l10n.js
+++ b/shared/oae/api/oae.api.l10n.js
@@ -137,4 +137,31 @@ define(['exports', 'jquery', 'underscore', 'oae.api.config', 'globalize'], funct
         // When a certain number of decimal places is required, we pass in n<Number of decimal places>
         return Globalize.format(number, decimalPlaces !== null ? 'n' + decimalPlaces : 'n');
     };
+
+    /**
+     * Apply timeago to all `oae-timeago` elements inside of the specified container. the function is automatically called
+     * when specifying the output container when rendering a template and when using the infinite scroll plugin. It's expected
+     * that the `title` attribute is set to the date in milliseconds from epoch. This function will take care of converting it
+     * to the right date format for `$.timeago`.
+     *
+     * @param  {String|jQuery}    $container    jQuery object or String selector of the container where the timeago elements are contained in
+     * @throws {Error}                          Error thrown when no container has been provided
+     */
+    var timeAgo = exports.timeAgo = function($container) {
+        if (!$container) {
+            throw new Error('A container must be provided');
+        }
+
+        // Parse the date property in the title
+        $('.oae-timeago', $($container)).each(function(i, el) {
+            // Make sure that we are working with a valid date. The timeago plugin uses the browsers
+            // timezone for time comparisons by relying on `new Date()` to get the current time. This
+            // means that the provided date does not need to be localized to the user's timezone, as
+            // it can then simply compare the current time and the date we pass in.
+            // Apply timeago to every `oae-timeago` element in the container
+            var date = parseDate($(el).prop('title'), false);
+            $(el).prop('title', Globalize.format(date, 'D') + ' ' + Globalize.format(date, 'T'));
+        });
+        $('.oae-timeago').timeago();
+    };
 });

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -306,6 +306,8 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
                 // Make sure that the provided output is a jQuery object
                 $output = $($output);
                 $output.html(renderedHTML);
+                // Apply timeago to the `oae-timeago` elements in the output container
+                require('oae.api.l10n').timeAgo($output);
             } else {
                 return renderedHTML;
             }

--- a/shared/oae/js/jquery-plugins/jquery.infinitescroll.js
+++ b/shared/oae/js/jquery-plugins/jquery.infinitescroll.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n'], function (jQuery, _, oaeUtil, oaeI18n) {
+define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n', 'oae.api.l10n'], function (jQuery, _, oaeUtil, oaeI18n, oaeL10n) {
 (function($) {
 
     /**
@@ -254,6 +254,9 @@ define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n'], function (jQuer
                         }
                     }
                 }
+
+                // Apply timeago to the `oae-timeago` elements in the output container
+                oaeL10n.timeAgo($listContainer);
             }
         };
 


### PR DESCRIPTION
Update `x time ago` timings regularly so timing remain accurate when the page has been open for a long time.

Every 30 or 60 seconds is probably sufficient.
