### PR TITLE
Error with link :

### DIFF
--- a/node_modules/oae-core/linkpreview/js/linkpreview.js
+++ b/node_modules/oae-core/linkpreview/js/linkpreview.js
@@ -102,15 +102,29 @@ define(['jquery', 'oae.core', 'jquery.oembed'], function($, oae) {
         /**
          * In case the current link doesn't match any of the oEmbed providers, we try to embed the link as an iframe.
          * If the preview processor has marked the link as non-embeddable because of cross-domain embedding policies,
-         * we try to show the preview image if available.
+         * we try to show the preview image if available. Also, if the link's protocol is http but the user is accessing
+         * the server over https, we try to convert the link to https to avoid browser security issues/warnings.
          */
         var renderDefaultPreview = function() {
-            // The link does not allow embedding
-            if (widgetData.previews.embeddable === false) {
+            var link = widgetData.link;
+            var embeddable = widgetData.previews.embeddable;
+
+            // If there is a protocol mismatch, make adjustments
+            if ((window.location.protocol === 'https:') && (link.indexOf('http:') === 0)) {
+                // If we can convert to https, do so
+                if (widgetData.previews.httpsAccessible) {
+                    link = link.replace('http:', 'https:');
+                // If we can't convert to https, we can't embed
+                } else {
+                    embeddable = false;
+                }
+            }
+            // We cannot embed the link
+            if (embeddable === false) {
                 oae.api.util.template().render($('#linkpreview-default-template', $rootel), {'linkProfile': widgetData}, $('#linkpreview-container'), $rootel);
             // Embed the link as an iframe
             } else {
-                oae.api.util.template().render($('#linkpreview-iframe-template', $rootel), {'link': widgetData.link}, $('#linkpreview-container'), $rootel);
+                oae.api.util.template().render($('#linkpreview-iframe-template', $rootel), {'link': link}, $('#linkpreview-container'), $rootel);
             }
         };
 


### PR DESCRIPTION
Hi all,
there is an error with the  link creation, so we created a link eg http://cacm.acm.org/magazines/2014/4/173221-who-does-what-in-a-massive-open-online-course/fulltext

and the link is not show in OAE but the consol indicate an error :

best
fred

```
[blocked] The page at 'https://oae.oae-qa0.oaeproject.org/content/oae/l1wMLRVPn' was loaded over HTTPS, but ran insecure content from 'http://cacm.acm.org/magazines/2014/4/173221-who-does-what-in-a-massive-open-online-course/fulltext': this content should also be loaded over HTTPS. require-jquery.3f5c3fe4.js:1
    (anonymous function)require-jquery.3f5c3fe4.js:1
    jQuery.extend.accessrequire-jquery.3f5c3fe4.js:1
    jQuery.fn.extend.htmlrequire-jquery.3f5c3fe4.js:1
    ioae.core.0d39739f.js:1
    alinkpreview.da62259c.js:1
    llinkpreview.da62259c.js:1
    (anonymous function)linkpreview.da62259c.js:1
    boae.core.0d39739f.js:1
    (anonymous function)oae.core.0d39739f.js:1
    r.execCbrequire-jquery.3f5c3fe4.js:1
    n.checkrequire-jquery.3f5c3fe4.js:1
    (anonymous function)require-jquery.3f5c3fe4.js:1
    (anonymous function)require-jquery.3f5c3fe4.js:1
    (anonymous function)require-jquery.3f5c3fe4.js:1
    eachrequire-jquery.3f5c3fe4.js:1
    n.emitrequire-jquery.3f5c3fe4.js:1
    n.checkrequire-jquery.3f5c3fe4.js:1
    (anonymous function)require-jquery.3f5c3fe4.js:1
    (anonymous function)require-jquery.3f5c3fe4.js:1
    (anonymous function)require-jquery.3f5c3fe4.js:1
    eachrequire-jquery.3f5c3fe4.js:1
    n.emitrequire-jquery.3f5c3fe4.js:1
    n.checkrequire-jquery.3f5c3fe4.js:1
    n.enablerequire-jquery.3f5c3fe4.js:1
    n.initrequire-jquery.3f5c3fe4.js:1
    Lrequire-jquery.3f5c3fe4.js:1
    r.completeLoadrequire-jquery.3f5c3fe4.js:1
    r.onScriptLoadrequire-jquery.3f5c3fe4.js:1
```
