### PR TITLE
Authentication button regression

### DIFF
--- a/shared/oae/api/oae.api.authentication.js
+++ b/shared/oae/api/oae.api.authentication.js
@@ -44,7 +44,7 @@ define(['exports', 'jquery', 'oae.api.config'], function(exports, $, configAPI) 
         }
 
         // Google Apps authentication
-        if (configAPI.getValue('oae-authentication', 'facebook', 'enabled') && configAPI.getValue('oae-authentication', 'google', 'hostedDomain')) {
+        if (configAPI.getValue('oae-authentication', 'google', 'enabled') && configAPI.getValue('oae-authentication', 'google', 'hostedDomain')) {
             enabledStrategies['googleApps'] = {'url': '/api/auth/google'};
         }
 


### PR DESCRIPTION
When using the combination of local auth and google apps auth, the Google Apps button doesn't show. This is for example causing people to no longer be able to sign into the RP tenant.
