### PR TITLE
Track JavaScript Errors with Google Analytics

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -454,13 +454,13 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
             ga('send', 'pageview');
 
             // Add event handler to track JavaScript errors
-            window.addEventListener('error', function(evt) {
-                ga('send', 'event', 'JavaScript Error', 'log', evt.message + ' [' + evt.filename + ':  ' + evt.lineno + ']');
+            window.addEventListener('error', function(ev) {
+                ga('send', 'event', 'JavaScript Error', 'log', ev.message + ' [' + ev.filename + ':  ' + ev.lineno + ']');
             });
 
             // Add event handler to track jQuery AJAX errors
-            $(document).ajaxError(function(evt, request, settings, err) {
-                ga('send', 'event', 'Ajax Error', 'log', settings.type + ' ' + settings.url + ' => ' + err);
+            $(document).ajaxError(function(ev, request, settings, err) {
+                ga('send', 'event', 'Ajax Error', 'log', settings.type + ' ' + settings.url + ' => ' + err + ' (' + request.status + ')');
             });
         }
 


### PR DESCRIPTION
Since we have the capability to use Google Analytics, we ought to also use it to track JavaScript errors in the UI. Not as fancy as the purpose-built services such as [errorception](https://errorception.com), but easy to add via GA custom events:

```
// Add event handler to track JavaScript errors
window.addEventListener('error', function(e) {
    ga('send', 'event', 'JavaScript Error', e.message + ' [' + e.filename + ':  ' + e.lineno + ']');
});

// Add event handler to track jQuery AJAX errors
$(document).ajaxError(function(e, request, settings) {
    ga('send', 'event', 'Ajax Error', settings.url + ' => ' + e.result);
});            
```
