### PR TITLE
Bug: Downloading a file gives me the preview, not the file

### DIFF
--- a/node_modules/oae-core/revisions/revisions.html
+++ b/node_modules/oae-core/revisions/revisions.html
@@ -50,13 +50,13 @@
 <div id="revisions-list-template"><!--
     {for revision in results}
         {var revisionDate = oae.api.l10n.transformDateTime(revision.created)}
-        {var preview = ''}
+        {var previewUrl = ''}
         {if revision.mediumUrl}
-            {var preview = revision.mediumUrl}
+            {var previewUrl = revision.mediumUrl}
         {elseif resourceSubType === 'file' && revision.mime.indexOf('image/') === 0}
-            {var preview = '/api/content/' + revision.contentId + '/download/' + revision.revisionId}
+            {var previewUrl = revision.downloadPath}
         {/if}
-        <li class="well" tabindex="0" data-revisionid="${revision.revisionId}" data-mediumurl="${preview}" data-resourceSubType="${resourceSubType}">
+        <li class="well" tabindex="0" data-revisionid="${revision.revisionId}" data-mediumurl="${previewUrl}" data-resourceSubType="${resourceSubType}">
             <div class="revisions-list-metadata">
                 <strong>${oae.api.l10n.transformDateTime(revision.created)}</strong>
                 <span class="oae-threedots">${revision.createdBy.displayName|encodeForHTML}</span>
@@ -67,7 +67,7 @@
                     <i class="icon-undo"></i> __MSG__RESTORE__
                 </button>
                 {if resourceSubType === 'file'}
-                    <a href="${preview}" class="btn btn-sm revisions-list-actions-download" title="__MSG__REVISION_DOWNLOAD_FROM__">
+                    <a href="${revision.downloadPath}" class="btn btn-sm revisions-list-actions-download" title="__MSG__REVISION_DOWNLOAD_FROM__">
                         <i class="icon-download"></i> __MSG__DOWNLOAD__
                     </a>
                 {/if}


### PR DESCRIPTION
I upload a Mac Excel xslx file. Then I go to another machine, find the document and go to Revisions. There is an option to download the file. I click the button, but the file I get is called medium.png and is an image of the pages in the document, not the document itself.
