### PR TITLE
Restoring previous revision of PDF document results in conflicting styles

### DIFF
--- a/node_modules/oae-core/documentpreview/js/documentpreview.js
+++ b/node_modules/oae-core/documentpreview/js/documentpreview.js
@@ -587,6 +587,9 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
          * current document
          */
         var loadStyleSheets = function() {
+            // Remove old stylesheets (e.g. from previous revision of content)
+            $('head .lazyload').remove();
+
             // The stylesheets are loaded before the pages are loaded to avoid display issues
             // when any of the pages are be loaded before the stylesheets are loaded
             LazyLoad.css([constructDocumentPreviewURL('combined.css')], function() {


### PR DESCRIPTION
Restoring a previous revision of a PDF document injects that revision's CSS style sheets, but it doesn't remove the (now out of date) style sheets from the revision first shown on the page. This can result in a garbled display.

![screen shot 2014-05-08 at 11 24 43 am](https://cloud.githubusercontent.com/assets/1731910/2917378/75fc4be8-d6c5-11e3-889d-24f4fc678f71.png)

Refreshing the page fixes the display

![screen shot 2014-05-08 at 11 26 11 am](https://cloud.githubusercontent.com/assets/1731910/2917386/84634da8-d6c5-11e3-9a64-0e22c24e4311.png)
