### PR TITLE
Fix regex.match() in doRegexTest() missing start of string

### DIFF
--- a/tests/qunit/tests/js/cssformatting.js
+++ b/tests/qunit/tests/js/cssformatting.js
@@ -32,6 +32,7 @@ require(['jquery', 'oae.core', '/tests/qunit/js/util.js'], function($, oae, util
         var count = 0;
 
         if (regex.test(testFile)) {
+            regex.lastIndex = 0; // Reset search start position which was moved by regex.test()
             while ((match = regex.exec(cssFile)) !== null) {
                 var beforeMatch = cssFile.substring(0, match.index);
                 var matchLine = beforeMatch.split(/\n/).length;


### PR DESCRIPTION
Code is currently doing the equivalent of this:

```
> var regex = /\w+/g;
undefined
> var text = "once upon a time";
undefined
> regex.test(text)
true
> regex.exec(text)
["upon"]
> regex.exec(text)
["a"]
> regex.exec(text)
["time"]
> regex.exec(text)
null
```

See commit msg for more details.
