### PR TITLE
User to which I don't have access is showing as a link in my activity feed

### DIFF
--- a/shared/oae/bundles/ui/default.properties
+++ b/shared/oae/bundles/ui/default.properties
@@ -3,140 +3,140 @@
 ACCESS_DENIED = Access denied
 ACCESS_TO_CONTENT = Access to Content
 ACCOUNT_INVALIDCHAR = Username contains an invalid character
-ACTIVITY_CONTENT_ADD_LIBRARY_2 = <a href="${actor1URL}">${actor1}</a> added &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot; to their library
-ACTIVITY_CONTENT_ADD_LIBRARY_2+ = <a href="${actor1URL}">${actor1}</a> added &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCountMinusOne} others to their library
-ACTIVITY_CONTENT_ADD_LIBRARY_COLLABDOC = <a href="${actor1URL}">${actor1}</a> added the document &quot;<a href="${object1URL}">${object1}</a>&quot; to their library
-ACTIVITY_CONTENT_ADD_LIBRARY_FILE = <a href="${actor1URL}">${actor1}</a> added the file &quot;<a href="${object1URL}">${object1}</a>&quot; to their library
-ACTIVITY_CONTENT_ADD_LIBRARY_LINK = <a href="${actor1URL}">${actor1}</a> added the link &quot;<a href="${object1URL}">${object1}</a>&quot; to their library
-ACTIVITY_CONTENT_COMMENT_COLLABDOC_1 = <a href="${actor1URL}">${actor1}</a> commented on the document &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_COMMENT_COLLABDOC_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> commented on the document &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_COMMENT_COLLABDOC_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others commented on the document &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_COMMENT_FILE_1 = <a href="${actor1URL}">${actor1}</a> commented on the file &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_COMMENT_FILE_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> commented on the file &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_COMMENT_FILE_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others commented on the file &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_COMMENT_LINK_1 = <a href="${actor1URL}">${actor1}</a> commented on the link &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_COMMENT_LINK_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> commented on the link &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_COMMENT_LINK_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others commented on the link &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_CREATE_2 = <a href="${actor1URL}">${actor1}</a> created &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot;
-ACTIVITY_CONTENT_CREATE_2+ = <a href="${actor1URL}">${actor1}</a> created &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCountMinusOne} others
-ACTIVITY_CONTENT_CREATE_COLLABDOC = <a href="${actor1URL}">${actor1}</a> created the document &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_CREATE_FILE = <a href="${actor1URL}">${actor1}</a> uploaded &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_CREATE_LINK = <a href="${actor1URL}">${actor1}</a> added the link &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_RESTORED_2 = <a href="${actor1URL}">${actor1}</a> restored an older version of  &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot;
-ACTIVITY_CONTENT_RESTORED_2+ = <a href="${actor1URL}">${actor1}</a> restored an older version of  &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCountMinusOne} others
-ACTIVITY_CONTENT_RESTORED_COLLABDOC = <a href="${actor1URL}">${actor1}</a> restored an older version of the document &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_RESTORED_FILE = <a href="${actor1URL}">${actor1}</a> restored an older version of the file &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_REVISION_COLLABDOC_1 = <a href="${actor1URL}">${actor1}</a> edited the document &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_REVISION_COLLABDOC_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> edited the document &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_REVISION_COLLABDOC_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others edited the document &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_REVISION_FILE_1 = <a href="${actor1URL}">${actor1}</a> uploaded a new version of &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_REVISION_FILE_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> uploaded new versions of &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_REVISION_FILE_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others uploaded new version of &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_REVISION_LINK_1 = <a href="${actor1URL}">${actor1}</a> edited the link &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_REVISION_LINK_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> edited the link &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_REVISION_LINK_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others edited the link &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_SHARE_2 = <a href="${actor1URL}">${actor1}</a> shared &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot; with <a href="${target1URL}">${target1}</a>
-ACTIVITY_CONTENT_SHARE_2+ = <a href="${actor1URL}">${actor1}</a> shared &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCountMinusOne} others with <a href="${target1URL}">${target1}</a>
-ACTIVITY_CONTENT_SHARE_COLLABDOC_1 = <a href="${actor1URL}">${actor1}</a> shared the document &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a>
-ACTIVITY_CONTENT_SHARE_COLLABDOC_2 = <a href="${actor1URL}">${actor1}</a> shared the document &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a> and <a href="${target2URL}">${target2}</a>
-ACTIVITY_CONTENT_SHARE_COLLABDOC_2+ = <a href="${actor1URL}">${actor1}</a> shared the document &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a> and ${targetCountMinusOne} others
-ACTIVITY_CONTENT_SHARE_COLLABDOC_YOU = <a href="${actor1URL}">${actor1}</a> shared the document &quot;<a href="${object1URL}">${object1}</a>&quot; with you
-ACTIVITY_CONTENT_SHARE_FILE_1 = <a href="${actor1URL}">${actor1}</a> shared the file &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a>
-ACTIVITY_CONTENT_SHARE_FILE_2 = <a href="${actor1URL}">${actor1}</a> shared the file &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a> and <a href="${target2URL}">${target2}</a>
-ACTIVITY_CONTENT_SHARE_FILE_2+ = <a href="${actor1URL}">${actor1}</a> shared the file &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a> and ${targetCountMinusOne} others
-ACTIVITY_CONTENT_SHARE_FILE_YOU = <a href="${actor1URL}">${actor1}</a> shared the file &quot;<a href="${object1URL}">${object1}</a>&quot; with you
-ACTIVITY_CONTENT_SHARE_LINK_1 = <a href="${actor1URL}">${actor1}</a> shared the link &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a>
-ACTIVITY_CONTENT_SHARE_LINK_2 = <a href="${actor1URL}">${actor1}</a> shared the link &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a> and <a href="${target2URL}">${target2}</a>
-ACTIVITY_CONTENT_SHARE_LINK_2+ = <a href="${actor1URL}">${actor1}</a> shared the link &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a> and ${targetCountMinusOne} others
-ACTIVITY_CONTENT_SHARE_LINK_YOU = <a href="${actor1URL}">${actor1}</a> shared the link &quot;<a href="${object1URL}">${object1}</a>&quot; with you
-ACTIVITY_CONTENT_SHARE_YOU_2 = <a href="${actor1URL}">${actor1}</a> shared &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot; with you
-ACTIVITY_CONTENT_SHARE_YOU_2+ = <a href="${actor1URL}">${actor1}</a> shared &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCountMinusOne} others with you
-ACTIVITY_CONTENT_UPDATE_COLLABDOC_1 = <a href="${actor1URL}">${actor1}</a> updated the document &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_COLLABDOC_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> updated the document &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_COLLABDOC_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others updated the document &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_FILE_1 = <a href="${actor1URL}">${actor1}</a> updated the file &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_FILE_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> updated the file &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_FILE_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others updated the file &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_LINK_1 = <a href="${actor1URL}">${actor1}</a> updated the link &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_LINK_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> updated the link &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_LINK_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others updated the link &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_COLLABDOC_1 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> on the document &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_COLLABDOC_2 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and <a href="${object2URL}">${object2}</a> on the document &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_COLLABDOC_2+ = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and ${objectCountMinusOne} others on the document &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_COLLABDOC_YOU = <a href="${actor1URL}">${actor1}</a> updated your role on the document &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_FILE_1 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> on the file &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_FILE_2 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and <a href="${object2URL}">${object2}</a> on the file &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_FILE_2+ = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and ${objectCountMinusOne} others on the file &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_FILE_YOU = <a href="${actor1URL}">${actor1}</a> updated your role on the file &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_LINK_1 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> on the link &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_LINK_2 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and <a href="${object2URL}">${object2}</a> on the link &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_LINK_2+ = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and ${objectCountMinusOne} others on the link &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_LINK_YOU = <a href="${actor1URL}">${actor1}</a> updated your role on the link &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_CONTENT_VISIBILITY_COLLABDOC_LOGGEDIN = <a href="${actor1URL}">${actor1}</a> changed the visibility of the document &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>${object1Tenant}</strong> only
-ACTIVITY_CONTENT_VISIBILITY_COLLABDOC_PRIVATE = <a href="${actor1URL}">${actor1}</a> changed the visibility of the document &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>private</strong>
-ACTIVITY_CONTENT_VISIBILITY_COLLABDOC_PUBLIC = <a href="${actor1URL}">${actor1}</a> changed the visibility of the document &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>public</strong>
-ACTIVITY_CONTENT_VISIBILITY_FILE_LOGGEDIN = <a href="${actor1URL}">${actor1}</a> changed the visibility of the file &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>${object1Tenant}</strong> only
-ACTIVITY_CONTENT_VISIBILITY_FILE_PRIVATE = <a href="${actor1URL}">${actor1}</a> changed the visibility of the file &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>private</strong>
-ACTIVITY_CONTENT_VISIBILITY_FILE_PUBLIC = <a href="${actor1URL}">${actor1}</a> changed the visibility of the file &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>public</strong>
-ACTIVITY_CONTENT_VISIBILITY_LINK_LOGGEDIN = <a href="${actor1URL}">${actor1}</a> changed the visibility of the link &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>${object1Tenant}</strong> only
-ACTIVITY_CONTENT_VISIBILITY_LINK_PRIVATE = <a href="${actor1URL}">${actor1}</a> changed the visibility of the link &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>private</strong>
-ACTIVITY_CONTENT_VISIBILITY_LINK_PUBLIC = <a href="${actor1URL}">${actor1}</a> changed the visibility of the link &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>public</strong>
-ACTIVITY_DEFAULT_1 = <a href="${actor1URL}">${actor1}</a> performed the action &quot;${verb}&quot;
-ACTIVITY_DEFAULT_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> performed the action &quot;${verb}&quot;
-ACTIVITY_DEFAULT_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others performed the action &quot;${verb}&quot;
-ACTIVITY_DISCUSSION_ADD_LIBRARY = <a href="${actor1URL}">${actor1}</a> added &quot;<a href="${object1URL}">${object1}</a>&quot; to their discussions
-ACTIVITY_DISCUSSION_ADD_LIBRARY_2 = <a href="${actor1URL}">${actor1}</a> added &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot; to their discussions
-ACTIVITY_DISCUSSION_ADD_LIBRARY_2+ = <a href="${actor1URL}">${actor1}</a> added &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCountMinusOne} others to their discussions
-ACTIVITY_DISCUSSION_CREATE_1 = <a href="${actor1URL}">${actor1}</a> started the discussion &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_DISCUSSION_CREATE_2 = <a href="${actor1URL}">${actor1}</a> started the discussions &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot;
-ACTIVITY_DISCUSSION_CREATE_2+ = <a href="${actor1URL}">${actor1}</a> started the discussion &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCountMinusOne} others
-ACTIVITY_DISCUSSION_MESSAGE_1 = <a href="${actor1URL}">${actor1}</a> posted to the discussion &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_DISCUSSION_MESSAGE_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> posted to the discussion &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_DISCUSSION_MESSAGE_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others posted to the discussion &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_DISCUSSION_SHARE_1 = <a href="${actor1URL}">${actor1}</a> shared the discussion &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a>
-ACTIVITY_DISCUSSION_SHARE_2 = <a href="${actor1URL}">${actor1}</a> shared the discussion &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a> and <a href="${target2URL}">${target2}</a>
-ACTIVITY_DISCUSSION_SHARE_2+ = <a href="${actor1URL}">${actor1}</a> shared the discussion &quot;<a href="${object1URL}">${object1}</a>&quot; with <a href="${target1URL}">${target1}</a> and ${targetCountMinusOne} others
-ACTIVITY_DISCUSSION_SHARE_YOU = <a href="${actor1URL}">${actor1}</a> shared the discussion &quot;<a href="${object1URL}">${object1}</a>&quot; with you
-ACTIVITY_DISCUSSION_SHARE_YOU_2 = <a href="${actor1URL}">${actor1}</a> shared the discussions &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot; with you
-ACTIVITY_DISCUSSION_SHARE_YOU_2+ = <a href="${actor1URL}">${actor1}</a> shared the discussions &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCountMinusOne} others with you
-ACTIVITY_DISCUSSION_UPDATE_1 = <a href="${actor1URL}">${actor1}</a> updated the discussion &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_DISCUSSION_UPDATE_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> updated the discussion &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_DISCUSSION_UPDATE_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others updated the discussion &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_DISCUSSION_UPDATE_MEMBER_ROLE_1 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> in the discussion &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_DISCUSSION_UPDATE_MEMBER_ROLE_2 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and <a href="${object2URL}">${object2}</a> in the discussion &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_DISCUSSION_UPDATE_MEMBER_ROLE_2+ = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and ${objectCountMinusOne} others in the discussion &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_DISCUSSION_UPDATE_MEMBER_ROLE_YOU = <a href="${actor1URL}">${actor1}</a> updated your role in the discussion &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_DISCUSSION_VISIBILITY_LOGGEDIN = <a href="${actor1URL}">${actor1}</a> changed the visibility of the discussion &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>${object1Tenant}</strong> only
-ACTIVITY_DISCUSSION_VISIBILITY_PRIVATE = <a href="${actor1URL}">${actor1}</a> changed the visibility of the discussion &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>private</strong>
-ACTIVITY_DISCUSSION_VISIBILITY_PUBLIC = <a href="${actor1URL}">${actor1}</a> changed the visibility of the discussion &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>public</strong>
-ACTIVITY_FOLLOWING_1_1 = <a href="${actor1URL}">${actor1}</a> is following <a href="${object1URL}">${object1}</a>
-ACTIVITY_FOLLOWING_1_2 = <a href="${actor1URL}">${actor1}</a> is following <a href="${object1URL}">${object1}</a> and <a href="${object2URL}">${object2}</a>
-ACTIVITY_FOLLOWING_1_2+ = <a href="${actor1URL}">${actor1}</a> is following <a href="${object1URL}">${object1}</a> and ${objectCountMinusOne} others
-ACTIVITY_FOLLOWING_1_YOU = <a href="${actor1URL}">${actor1}</a> is following you
-ACTIVITY_FOLLOWING_2+_1 = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others are following <a href="${object1URL}">${object1}</a>
-ACTIVITY_FOLLOWING_2+_YOU = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others are following you
-ACTIVITY_FOLLOWING_2_1 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> are following <a href="${object1URL}">${object1}</a>
-ACTIVITY_FOLLOWING_2_YOU = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> are following you
-ACTIVITY_GROUP_ADD_MEMBER_1 = <a href="${actor1URL}">${actor1}</a> added <a href="${object1URL}">${object1}</a> to the group &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_GROUP_ADD_MEMBER_2 = <a href="${actor1URL}">${actor1}</a> added <a href="${object1URL}">${object1}</a> and <a href="${object2URL}">${object2}</a> to the group &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_GROUP_ADD_MEMBER_2+ = <a href="${actor1URL}">${actor1}</a> added <a href="${object1URL}">${object1}</a> and ${objectCountMinusOne} others to the group &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_GROUP_ADD_MEMBER_YOU = <a href="${actor1URL}">${actor1}</a> added you to the group &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_GROUP_CREATE_1 = <a href="${actor1URL}">${actor1}</a> created the group &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_GROUP_CREATE_2 = <a href="${actor1URL}">${actor1}</a> created the groups &quot;<a href="${object1URL}">${object1}</a>&quot; and &quot;<a href="${object2URL}">${object2}</a>&quot;
-ACTIVITY_GROUP_CREATE_2+ = <a href="${actor1URL}">${actor1}</a> created the group &quot;<a href="${object1URL}">${object1}</a>&quot; and ${objectCountMinusOne} others
-ACTIVITY_GROUP_JOIN_1 = <a href="${actor1URL}">${actor1}</a> joined the group &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_GROUP_JOIN_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> joined the group &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_GROUP_JOIN_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others joined the group &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_GROUP_UPDATE_1 = <a href="${actor1URL}">${actor1}</a> updated the group &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_GROUP_UPDATE_2 = <a href="${actor1URL}">${actor1}</a> and <a href="${actor2URL}">${actor2}</a> updated the group &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_GROUP_UPDATE_2+ = <a href="${actor1URL}">${actor1}</a> and ${actorCountMinusOne} others updated the group &quot;<a href="${object1URL}">${object1}</a>&quot;
-ACTIVITY_GROUP_UPDATE_MEMBER_ROLE_1 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> in the group &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_GROUP_UPDATE_MEMBER_ROLE_2 = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and <a href="${object2URL}">${object2}</a> in the group &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_GROUP_UPDATE_MEMBER_ROLE_2+ = <a href="${actor1URL}">${actor1}</a> updated the role of <a href="${object1URL}">${object1}</a> and ${objectCountMinusOne} others in the group &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_GROUP_UPDATE_MEMBER_ROLE_YOU = <a href="${actor1URL}">${actor1}</a> updated your role in the group &quot;<a href="${target1URL}">${target1}</a>&quot;
-ACTIVITY_GROUP_VISIBILITY_LOGGEDIN = <a href="${actor1URL}">${actor1}</a> changed the visibility of the group &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>${object1Tenant}</strong> only
-ACTIVITY_GROUP_VISIBILITY_PRIVATE = <a href="${actor1URL}">${actor1}</a> changed the visibility of the group &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>private</strong>
-ACTIVITY_GROUP_VISIBILITY_PUBLIC = <a href="${actor1URL}">${actor1}</a> changed the visibility of the group &quot;<a href="${object1URL}">${object1}</a>&quot; to <strong>public</strong>
+ACTIVITY_CONTENT_ADD_LIBRARY_2 = ${actor1Link} added &quot;${object1Link}&quot; and &quot;${object2Link}&quot; to their library
+ACTIVITY_CONTENT_ADD_LIBRARY_2+ = ${actor1Link} added &quot;${object1Link}&quot; and ${objectCountMinusOne} others to their library
+ACTIVITY_CONTENT_ADD_LIBRARY_COLLABDOC = ${actor1Link} added the document &quot;${object1Link}&quot; to their library
+ACTIVITY_CONTENT_ADD_LIBRARY_FILE = ${actor1Link} added the file &quot;${object1Link}&quot; to their library
+ACTIVITY_CONTENT_ADD_LIBRARY_LINK = ${actor1Link} added the link &quot;${object1Link}&quot; to their library
+ACTIVITY_CONTENT_COMMENT_COLLABDOC_1 = ${actor1Link} commented on the document &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_COMMENT_COLLABDOC_2 = ${actor1Link} and ${actor2Link} commented on the document &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_COMMENT_COLLABDOC_2+ = ${actor1Link} and ${actorCountMinusOne} others commented on the document &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_COMMENT_FILE_1 = ${actor1Link} commented on the file &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_COMMENT_FILE_2 = ${actor1Link} and ${actor2Link} commented on the file &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_COMMENT_FILE_2+ = ${actor1Link} and ${actorCountMinusOne} others commented on the file &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_COMMENT_LINK_1 = ${actor1Link} commented on the link &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_COMMENT_LINK_2 = ${actor1Link} and ${actor2Link} commented on the link &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_COMMENT_LINK_2+ = ${actor1Link} and ${actorCountMinusOne} others commented on the link &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_CREATE_2 = ${actor1Link} created &quot;${object1Link}&quot; and &quot;${object2Link}&quot;
+ACTIVITY_CONTENT_CREATE_2+ = ${actor1Link} created &quot;${object1Link}&quot; and ${objectCountMinusOne} others
+ACTIVITY_CONTENT_CREATE_COLLABDOC = ${actor1Link} created the document &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_CREATE_FILE = ${actor1Link} uploaded &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_CREATE_LINK = ${actor1Link} added the link &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_RESTORED_2 = ${actor1Link} restored an older version of  &quot;${object1Link}&quot; and &quot;${object2Link}&quot;
+ACTIVITY_CONTENT_RESTORED_2+ = ${actor1Link} restored an older version of  &quot;${object1Link}&quot; and ${objectCountMinusOne} others
+ACTIVITY_CONTENT_RESTORED_COLLABDOC = ${actor1Link} restored an older version of the document &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_RESTORED_FILE = ${actor1Link} restored an older version of the file &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_REVISION_COLLABDOC_1 = ${actor1Link} edited the document &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_REVISION_COLLABDOC_2 = ${actor1Link} and ${actor2Link} edited the document &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_REVISION_COLLABDOC_2+ = ${actor1Link} and ${actorCountMinusOne} others edited the document &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_REVISION_FILE_1 = ${actor1Link} uploaded a new version of &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_REVISION_FILE_2 = ${actor1Link} and ${actor2Link} uploaded new versions of &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_REVISION_FILE_2+ = ${actor1Link} and ${actorCountMinusOne} others uploaded new version of &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_REVISION_LINK_1 = ${actor1Link} edited the link &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_REVISION_LINK_2 = ${actor1Link} and ${actor2Link} edited the link &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_REVISION_LINK_2+ = ${actor1Link} and ${actorCountMinusOne} others edited the link &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_SHARE_2 = ${actor1Link} shared &quot;${object1Link}&quot; and &quot;${object2Link}&quot; with ${target1Link}
+ACTIVITY_CONTENT_SHARE_2+ = ${actor1Link} shared &quot;${object1Link}&quot; and ${objectCountMinusOne} others with ${target1Link}
+ACTIVITY_CONTENT_SHARE_COLLABDOC_1 = ${actor1Link} shared the document &quot;${object1Link}&quot; with ${target1Link}
+ACTIVITY_CONTENT_SHARE_COLLABDOC_2 = ${actor1Link} shared the document &quot;${object1Link}&quot; with ${target1Link} and ${target2Link}
+ACTIVITY_CONTENT_SHARE_COLLABDOC_2+ = ${actor1Link} shared the document &quot;${object1Link}&quot; with ${target1Link} and ${targetCountMinusOne} others
+ACTIVITY_CONTENT_SHARE_COLLABDOC_YOU = ${actor1Link} shared the document &quot;${object1Link}&quot; with you
+ACTIVITY_CONTENT_SHARE_FILE_1 = ${actor1Link} shared the file &quot;${object1Link}&quot; with ${target1Link}
+ACTIVITY_CONTENT_SHARE_FILE_2 = ${actor1Link} shared the file &quot;${object1Link}&quot; with ${target1Link} and ${target2Link}
+ACTIVITY_CONTENT_SHARE_FILE_2+ = ${actor1Link} shared the file &quot;${object1Link}&quot; with ${target1Link} and ${targetCountMinusOne} others
+ACTIVITY_CONTENT_SHARE_FILE_YOU = ${actor1Link} shared the file &quot;${object1Link}&quot; with you
+ACTIVITY_CONTENT_SHARE_LINK_1 = ${actor1Link} shared the link &quot;${object1Link}&quot; with ${target1Link}
+ACTIVITY_CONTENT_SHARE_LINK_2 = ${actor1Link} shared the link &quot;${object1Link}&quot; with ${target1Link} and ${target2Link}
+ACTIVITY_CONTENT_SHARE_LINK_2+ = ${actor1Link} shared the link &quot;${object1Link}&quot; with ${target1Link} and ${targetCountMinusOne} others
+ACTIVITY_CONTENT_SHARE_LINK_YOU = ${actor1Link} shared the link &quot;${object1Link}&quot; with you
+ACTIVITY_CONTENT_SHARE_YOU_2 = ${actor1Link} shared &quot;${object1Link}&quot; and &quot;${object2Link}&quot; with you
+ACTIVITY_CONTENT_SHARE_YOU_2+ = ${actor1Link} shared &quot;${object1Link}&quot; and ${objectCountMinusOne} others with you
+ACTIVITY_CONTENT_UPDATE_COLLABDOC_1 = ${actor1Link} updated the document &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_COLLABDOC_2 = ${actor1Link} and ${actor2Link} updated the document &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_COLLABDOC_2+ = ${actor1Link} and ${actorCountMinusOne} others updated the document &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_FILE_1 = ${actor1Link} updated the file &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_FILE_2 = ${actor1Link} and ${actor2Link} updated the file &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_FILE_2+ = ${actor1Link} and ${actorCountMinusOne} others updated the file &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_LINK_1 = ${actor1Link} updated the link &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_LINK_2 = ${actor1Link} and ${actor2Link} updated the link &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_LINK_2+ = ${actor1Link} and ${actorCountMinusOne} others updated the link &quot;${object1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_COLLABDOC_1 = ${actor1Link} updated the role of ${object1Link} on the document &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_COLLABDOC_2 = ${actor1Link} updated the role of ${object1Link} and ${object2Link} on the document &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_COLLABDOC_2+ = ${actor1Link} updated the role of ${object1Link} and ${objectCountMinusOne} others on the document &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_COLLABDOC_YOU = ${actor1Link} updated your role on the document &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_FILE_1 = ${actor1Link} updated the role of ${object1Link} on the file &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_FILE_2 = ${actor1Link} updated the role of ${object1Link} and ${object2Link} on the file &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_FILE_2+ = ${actor1Link} updated the role of ${object1Link} and ${objectCountMinusOne} others on the file &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_FILE_YOU = ${actor1Link} updated your role on the file &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_LINK_1 = ${actor1Link} updated the role of ${object1Link} on the link &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_LINK_2 = ${actor1Link} updated the role of ${object1Link} and ${object2Link} on the link &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_LINK_2+ = ${actor1Link} updated the role of ${object1Link} and ${objectCountMinusOne} others on the link &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_UPDATE_MEMBER_ROLE_LINK_YOU = ${actor1Link} updated your role on the link &quot;${target1Link}&quot;
+ACTIVITY_CONTENT_VISIBILITY_COLLABDOC_LOGGEDIN = ${actor1Link} changed the visibility of the document &quot;${object1Link}&quot; to <strong>${object1Tenant}</strong> only
+ACTIVITY_CONTENT_VISIBILITY_COLLABDOC_PRIVATE = ${actor1Link} changed the visibility of the document &quot;${object1Link}&quot; to <strong>private</strong>
+ACTIVITY_CONTENT_VISIBILITY_COLLABDOC_PUBLIC = ${actor1Link} changed the visibility of the document &quot;${object1Link}&quot; to <strong>public</strong>
+ACTIVITY_CONTENT_VISIBILITY_FILE_LOGGEDIN = ${actor1Link} changed the visibility of the file &quot;${object1Link}&quot; to <strong>${object1Tenant}</strong> only
+ACTIVITY_CONTENT_VISIBILITY_FILE_PRIVATE = ${actor1Link} changed the visibility of the file &quot;${object1Link}&quot; to <strong>private</strong>
+ACTIVITY_CONTENT_VISIBILITY_FILE_PUBLIC = ${actor1Link} changed the visibility of the file &quot;${object1Link}&quot; to <strong>public</strong>
+ACTIVITY_CONTENT_VISIBILITY_LINK_LOGGEDIN = ${actor1Link} changed the visibility of the link &quot;${object1Link}&quot; to <strong>${object1Tenant}</strong> only
+ACTIVITY_CONTENT_VISIBILITY_LINK_PRIVATE = ${actor1Link} changed the visibility of the link &quot;${object1Link}&quot; to <strong>private</strong>
+ACTIVITY_CONTENT_VISIBILITY_LINK_PUBLIC = ${actor1Link} changed the visibility of the link &quot;${object1Link}&quot; to <strong>public</strong>
+ACTIVITY_DEFAULT_1 = ${actor1Link} performed the action &quot;${verb}&quot;
+ACTIVITY_DEFAULT_2 = ${actor1Link} and ${actor2Link} performed the action &quot;${verb}&quot;
+ACTIVITY_DEFAULT_2+ = ${actor1Link} and ${actorCountMinusOne} others performed the action &quot;${verb}&quot;
+ACTIVITY_DISCUSSION_ADD_LIBRARY = ${actor1Link} added &quot;${object1Link}&quot; to their discussions
+ACTIVITY_DISCUSSION_ADD_LIBRARY_2 = ${actor1Link} added &quot;${object1Link}&quot; and &quot;${object2Link}&quot; to their discussions
+ACTIVITY_DISCUSSION_ADD_LIBRARY_2+ = ${actor1Link} added &quot;${object1Link}&quot; and ${objectCountMinusOne} others to their discussions
+ACTIVITY_DISCUSSION_CREATE_1 = ${actor1Link} started the discussion &quot;${object1Link}&quot;
+ACTIVITY_DISCUSSION_CREATE_2 = ${actor1Link} started the discussions &quot;${object1Link}&quot; and &quot;${object2Link}&quot;
+ACTIVITY_DISCUSSION_CREATE_2+ = ${actor1Link} started the discussion &quot;${object1Link}&quot; and ${objectCountMinusOne} others
+ACTIVITY_DISCUSSION_MESSAGE_1 = ${actor1Link} posted to the discussion &quot;${target1Link}&quot;
+ACTIVITY_DISCUSSION_MESSAGE_2 = ${actor1Link} and ${actor2Link} posted to the discussion &quot;${target1Link}&quot;
+ACTIVITY_DISCUSSION_MESSAGE_2+ = ${actor1Link} and ${actorCountMinusOne} others posted to the discussion &quot;${target1Link}&quot;
+ACTIVITY_DISCUSSION_SHARE_1 = ${actor1Link} shared the discussion &quot;${object1Link}&quot; with ${target1Link}
+ACTIVITY_DISCUSSION_SHARE_2 = ${actor1Link} shared the discussion &quot;${object1Link}&quot; with ${target1Link} and ${target2Link}
+ACTIVITY_DISCUSSION_SHARE_2+ = ${actor1Link} shared the discussion &quot;${object1Link}&quot; with ${target1Link} and ${targetCountMinusOne} others
+ACTIVITY_DISCUSSION_SHARE_YOU = ${actor1Link} shared the discussion &quot;${object1Link}&quot; with you
+ACTIVITY_DISCUSSION_SHARE_YOU_2 = ${actor1Link} shared the discussions &quot;${object1Link}&quot; and &quot;${object2Link}&quot; with you
+ACTIVITY_DISCUSSION_SHARE_YOU_2+ = ${actor1Link} shared the discussions &quot;${object1Link}&quot; and ${objectCountMinusOne} others with you
+ACTIVITY_DISCUSSION_UPDATE_1 = ${actor1Link} updated the discussion &quot;${object1Link}&quot;
+ACTIVITY_DISCUSSION_UPDATE_2 = ${actor1Link} and ${actor2Link} updated the discussion &quot;${object1Link}&quot;
+ACTIVITY_DISCUSSION_UPDATE_2+ = ${actor1Link} and ${actorCountMinusOne} others updated the discussion &quot;${object1Link}&quot;
+ACTIVITY_DISCUSSION_UPDATE_MEMBER_ROLE_1 = ${actor1Link} updated the role of ${object1Link} in the discussion &quot;${target1Link}&quot;
+ACTIVITY_DISCUSSION_UPDATE_MEMBER_ROLE_2 = ${actor1Link} updated the role of ${object1Link} and ${object2Link} in the discussion &quot;${target1Link}&quot;
+ACTIVITY_DISCUSSION_UPDATE_MEMBER_ROLE_2+ = ${actor1Link} updated the role of ${object1Link} and ${objectCountMinusOne} others in the discussion &quot;${target1Link}&quot;
+ACTIVITY_DISCUSSION_UPDATE_MEMBER_ROLE_YOU = ${actor1Link} updated your role in the discussion &quot;${target1Link}&quot;
+ACTIVITY_DISCUSSION_VISIBILITY_LOGGEDIN = ${actor1Link} changed the visibility of the discussion &quot;${object1Link}&quot; to <strong>${object1Tenant}</strong> only
+ACTIVITY_DISCUSSION_VISIBILITY_PRIVATE = ${actor1Link} changed the visibility of the discussion &quot;${object1Link}&quot; to <strong>private</strong>
+ACTIVITY_DISCUSSION_VISIBILITY_PUBLIC = ${actor1Link} changed the visibility of the discussion &quot;${object1Link}&quot; to <strong>public</strong>
+ACTIVITY_FOLLOWING_1_1 = ${actor1Link} is following ${object1Link}
+ACTIVITY_FOLLOWING_1_2 = ${actor1Link} is following ${object1Link} and ${object2Link}
+ACTIVITY_FOLLOWING_1_2+ = ${actor1Link} is following ${object1Link} and ${objectCountMinusOne} others
+ACTIVITY_FOLLOWING_1_YOU = ${actor1Link} is following you
+ACTIVITY_FOLLOWING_2+_1 = ${actor1Link} and ${actorCountMinusOne} others are following ${object1Link}
+ACTIVITY_FOLLOWING_2+_YOU = ${actor1Link} and ${actorCountMinusOne} others are following you
+ACTIVITY_FOLLOWING_2_1 = ${actor1Link} and ${actor2Link} are following ${object1Link}
+ACTIVITY_FOLLOWING_2_YOU = ${actor1Link} and ${actor2Link} are following you
+ACTIVITY_GROUP_ADD_MEMBER_1 = ${actor1Link} added ${object1Link} to the group &quot;${target1Link}&quot;
+ACTIVITY_GROUP_ADD_MEMBER_2 = ${actor1Link} added ${object1Link} and ${object2Link} to the group &quot;${target1Link}&quot;
+ACTIVITY_GROUP_ADD_MEMBER_2+ = ${actor1Link} added ${object1Link} and ${objectCountMinusOne} others to the group &quot;${target1Link}&quot;
+ACTIVITY_GROUP_ADD_MEMBER_YOU = ${actor1Link} added you to the group &quot;${target1Link}&quot;
+ACTIVITY_GROUP_CREATE_1 = ${actor1Link} created the group &quot;${object1Link}&quot;
+ACTIVITY_GROUP_CREATE_2 = ${actor1Link} created the groups &quot;${object1Link}&quot; and &quot;${object2Link}&quot;
+ACTIVITY_GROUP_CREATE_2+ = ${actor1Link} created the group &quot;${object1Link}&quot; and ${objectCountMinusOne} others
+ACTIVITY_GROUP_JOIN_1 = ${actor1Link} joined the group &quot;${object1Link}&quot;
+ACTIVITY_GROUP_JOIN_2 = ${actor1Link} and ${actor2Link} joined the group &quot;${object1Link}&quot;
+ACTIVITY_GROUP_JOIN_2+ = ${actor1Link} and ${actorCountMinusOne} others joined the group &quot;${object1Link}&quot;
+ACTIVITY_GROUP_UPDATE_1 = ${actor1Link} updated the group &quot;${object1Link}&quot;
+ACTIVITY_GROUP_UPDATE_2 = ${actor1Link} and ${actor2Link} updated the group &quot;${object1Link}&quot;
+ACTIVITY_GROUP_UPDATE_2+ = ${actor1Link} and ${actorCountMinusOne} others updated the group &quot;${object1Link}&quot;
+ACTIVITY_GROUP_UPDATE_MEMBER_ROLE_1 = ${actor1Link} updated the role of ${object1Link} in the group &quot;${target1Link}&quot;
+ACTIVITY_GROUP_UPDATE_MEMBER_ROLE_2 = ${actor1Link} updated the role of ${object1Link} and ${object2Link} in the group &quot;${target1Link}&quot;
+ACTIVITY_GROUP_UPDATE_MEMBER_ROLE_2+ = ${actor1Link} updated the role of ${object1Link} and ${objectCountMinusOne} others in the group &quot;${target1Link}&quot;
+ACTIVITY_GROUP_UPDATE_MEMBER_ROLE_YOU = ${actor1Link} updated your role in the group &quot;${target1Link}&quot;
+ACTIVITY_GROUP_VISIBILITY_LOGGEDIN = ${actor1Link} changed the visibility of the group &quot;${object1Link}&quot; to <strong>${object1Tenant}</strong> only
+ACTIVITY_GROUP_VISIBILITY_PRIVATE = ${actor1Link} changed the visibility of the group &quot;${object1Link}&quot; to <strong>private</strong>
+ACTIVITY_GROUP_VISIBILITY_PUBLIC = ${actor1Link} changed the visibility of the group &quot;${object1Link}&quot; to <strong>public</strong>
 ADD = Add
 ARCHIVE = Archive
 ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_DISCUSSION = Are you sure you want to delete this discussion?


### PR DESCRIPTION
A loggedin Fold user added Josh to a group.

While the user is scrubbed and there is no profilePath parameter for the user, the UI still shows as a link, and the link just goes to my own `/me` page (see bottom left status bar for the link target)

![screen shot 2014-05-29 at 9 44 51 am](https://cloud.githubusercontent.com/assets/102265/3118079/e5cf808e-e737-11e3-9b12-9340c673d011.png)

Note that the bug is **not** the fact that a loggedin user from another tenant is showing in my activity feed, that is expected because we use the public alias instead of the displayName. The bug is that the user's name is a link, whereas it should just be plain text with no profilePath.
