### PR TITLE
Changing profile picture updates activity comments picture but not actor picture

### DIFF
--- a/shared/oae/macros/list.html
+++ b/shared/oae/macros/list.html
@@ -210,6 +210,11 @@
         {var resourceId = entityData.id}
     {/if}
 
+    <!-- Also make sure the resourceId is really an ID and not a full URL -->
+    {if resourceId.substring(0,4) === 'http'}
+        {var resourceId = resourceId.substring(resourceId.lastIndexOf('/')+1)}
+    {/if}
+
     {if customImage}
         {var thumbnailUrl = customImage}
     {elseif entityData.thumbnailUrl}


### PR DESCRIPTION
When uploading a new profile picture the UI should be updated everywhere the old picture was displayed. Currently there is a regression where the activity actor picture isn't updated after uploading the picture. In the screenshot you'll see that general ackbar is still set as my profile picture and hasn't been updated to a selfie.

![screen shot 2014-06-17 at 16 25 38](https://cloud.githubusercontent.com/assets/218391/3302368/ba9242fc-f633-11e3-9b12-468fe192a42a.png)
