### PR TITLE
Profile pictures in activity stream update when user changes profile picture, but revert to old picture when screen is refreshed

### DIFF
--- a/shared/oae/js/activityadapter.js
+++ b/shared/oae/js/activityadapter.js
@@ -57,13 +57,13 @@ var _expose = function(exports) {
      */
     var _adaptActivity = function(context, me, activity, sanitization) {
         // Move the relevant items (comments, previews, ..) to the top
-        _prepareActivity(activity, me);
+        _prepareActivity(me, activity);
 
         // Generate an i18nable summary for this activity
         var summary = _generateSummary(me, activity, sanitization);
 
         // Generate the primary actor view
-        var primaryActor = _generatePrimaryActor(activity, me);
+        var primaryActor = _generatePrimaryActor(me, activity);
 
         // Generate the activity preview items
         var activityItems = _generateActivityItems(context, activity);
@@ -119,10 +119,10 @@ var _expose = function(exports) {
     /**
      * A model that holds the necessary data to generate a beautiful tile
      *
-     * @param  {ActivityEntity}     entity      The entity that should be used to generate the view
      * @param  {User}               [me]        The currently loggedin user
+     * @param  {ActivityEntity}     entity      The entity that should be used to generate the view
      */
-    var ActivityViewItem = function(entity, me) {
+    var ActivityViewItem = function(me, entity) {
         var that = {
             'oae:id': entity['oae:id'],
             'id': entity.id,
@@ -169,11 +169,11 @@ var _expose = function(exports) {
      *  - comments are processed into an ordered set
      *  - each comment is assigned the level in the comment tree
      *
-     * @param  {Activity}   activity    The activity to prepare
      * @param  {User}       me          The currently loggedin user
+     * @param  {Activity}   activity    The activity to prepare
      * @api private
      */
-    var _prepareActivity = function(activity, me) {
+    var _prepareActivity = function(me, activity) {
         // Sort the entity collections based on whether or not they have a thumbnail
         if (activity.actor['oae:collection']) {
             // Reverse the items so the item that was changed last is shown first
@@ -213,10 +213,10 @@ var _expose = function(exports) {
 
             // Prepare each comment
             latestComments.forEach(function(comment) {
-                comment.activityItem = new ActivityViewItem(comment.author, me);
+                comment.activityItem = new ActivityViewItem(me, comment.author);
             });
             allComments.forEach(function(comment) {
-                comment.activityItem = new ActivityViewItem(comment.author, me);
+                comment.activityItem = new ActivityViewItem(me, comment.author);
             });
 
             activity.object.objectType = 'comments';
@@ -333,18 +333,18 @@ var _expose = function(exports) {
      * Get the primary view for an activity. This is usually the actor
      * or in case of an aggregated activity, the first in the collection of actors
      *
-     * @param  {Activity}           activity    The activity for which to return the primary actor
      * @param  {User}               me          The currently loggedin user
+     * @param  {Activity}           activity    The activity for which to return the primary actor
      * @return {ActivityViewItem}               The object that identifies the primary actor
      * @api private
      */
-    var _generatePrimaryActor = function(activity, me) {
+    var _generatePrimaryActor = function(me, activity) {
         var actor = activity.actor;
         if (actor['oae:collection']) {
             actor = actor['oae:collection'][0];
         }
 
-        return new ActivityViewItem(actor, me);
+        return new ActivityViewItem(me, actor);
     };
 
     /**
@@ -381,11 +381,11 @@ var _expose = function(exports) {
 
         var items = [];
         if (previewObj['oae:wideImage']) {
-            items.push(new ActivityViewItem(previewObj));
+            items.push(new ActivityViewItem(null, previewObj));
         } else {
             var previewItems = (previewObj['oae:collection'] || [previewObj]);
             items = previewItems.map(function(previewItem) {
-                return new ActivityViewItem(previewItem);
+                return new ActivityViewItem(null, previewItem);
             });
         }
 


### PR DESCRIPTION
A while back there was a change that gave profile pictures a different URL each time it was updated, therefore activity streams contain older versions of images.

A change was recently made that fixed the issue with profile pictures not being updated live on the UI in the activity stream.

Now what happens is that when you change your profile picture, the updated picture is put in the activity stream, them when the user refreshes the page the pictures revert to the old one.

Somehow I think we knew and accepted this would be a side-effect of making the profile picture URL different, so I'm not sure we need to fix the issue of showing the older profile image the activity stream, as opposed to just make it so that profile picture updates don't update the activity stream automatically.
