### PR TITLE
Fix unusedkeys test not detecting key use in widgets with no js

### DIFF
--- a/tests/qunit/tests/js/unusedkeys.js
+++ b/tests/qunit/tests/js/unusedkeys.js
@@ -109,10 +109,10 @@ require(['jquery', 'oae.core', '/tests/qunit/js/util.js'], function($, oae, util
                         if (_.keys(bundle).length) {
                             $.each(bundle, function(i18nKey, i18nValue) {
                                 if (i18nValue) {
-                                    var htmlUsed = false;
+                                    var htmlUsed = runTest(widgetId, widget.html, i18nKey);
                                     var jsUsed = false;
+
                                     $.each(widget.js, function(widgetJSIndex, widgetJS) {
-                                        htmlUsed = htmlUsed || runTest(widgetId, widget.html, i18nKey);
                                         jsUsed = jsUsed || runTest(widgetId, widgetJS, i18nKey);
                                     });
                                     if (htmlUsed || jsUsed) {


### PR DESCRIPTION
If a widget has no javascript then the unusedkeys test wouldn't look in its HTML for key use.
