### PR TITLE
PDF upload preview chops off first page on mobile

### DIFF
--- a/node_modules/oae-core/documentpreview/js/documentpreview.js
+++ b/node_modules/oae-core/documentpreview/js/documentpreview.js
@@ -479,7 +479,7 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
          * page to move it up or down and vertically position it
          * appropriately based on the zoom factor.
          *
-         * @param  {Number}     [pageNumber]            page number to start
+         * @param  {Number}     [pageNumber]            document page number to start (first page is 1)
          */
         var zoomPages = function(pageNumber) {
             // Index into pages array (default to 0)


### PR DESCRIPTION
Iphone 5 and 4s are at least experiencing this issue. 
