### PR TITLE
Server error when creating user results in no feedback

### DIFF
--- a/node_modules/oae-core/register/bundles/default.properties
+++ b/node_modules/oae-core/register/bundles/default.properties
@@ -1,4 +1,6 @@
+AN_ERROR_OCCURRED_WHILE_CREATING_THE_USER_ACCOUNT = An error occurred while creating the user account.
 BACK = Back
+CANNOT_CREATE_USER = Cannot create user.
 CAPTCHA_ERROR = Captcha validation failed. Please enter the challenge words.
 CREATE_ACCOUNT = Create account
 ENTER_THE_TEXT = Enter the text

--- a/node_modules/oae-core/register/js/register.js
+++ b/node_modules/oae-core/register/js/register.js
@@ -198,10 +198,16 @@ define(['jquery', 'underscore', 'oae.core', 'markdown'], function($, _, oae) {
                     if (recaptchaEnabled) {
                         // Refresh reCaptcha
                         Recaptcha.reload();
-                        // The user entered an invalid reCaptcha token
-                        if (err.msg === 'Invalid reCaptcha token') {
-                            showRecaptchaError();
-                        }
+                    }
+                    // The user entered an invalid reCaptcha token
+                    if (err.msg === 'Invalid reCaptcha token') {
+                        showRecaptchaError();
+                    } else {
+                        oae.api.util.notification(
+                            oae.api.i18n.translate('__MSG__CANNOT_CREATE_USER__', 'register'),
+                            oae.api.i18n.translate('__MSG__AN_ERROR_OCCURRED_WHILE_CREATING_THE_USER_ACCOUNT__', 'register'),
+                            'error'
+                        );
                     }
                     // Unlock the register button
                     $('button, input', $rootel).prop('disabled', false);


### PR DESCRIPTION
Noticed this when trying to create a new user after upgrading to OAE 7.0 but before adding the `emailPreference` property in Cassandra. The API call returns a `500 Server Error` but the modal provides no feedback.
