### PR TITLE
Password Reset Option is Confusing for those using External Authentication

### DIFF
--- a/node_modules/oae-core/preferences/js/preferences.js
+++ b/node_modules/oae-core/preferences/js/preferences.js
@@ -37,7 +37,7 @@ define(['jquery', 'oae.core'], function($, oae) {
             $('form', $rootel).removeClass('active');
 
             // Active the first tab and its corresponding panel
-            $('#preferences-tab-container ul li:first-child', $rootel).addClass('active');
+            $('#preferences-tab-account', $rootel).addClass('active');
             $('#preferences-account', $rootel).addClass('active');
         };
 

--- a/node_modules/oae-core/preferences/preferences.html
+++ b/node_modules/oae-core/preferences/preferences.html
@@ -12,7 +12,7 @@
 
             <div id="preferences-tab-container" class="modal-body">
                 <ul class="hide nav nav-tabs" role="tablist">
-                    <li class="active" role="presentation">
+                    <li class="active" role="presentation" id="preferences-tab-account">
                         <a href="#preferences-account" data-toggle="tab" role="tab">__MSG__ACCOUNT__</a>
                     </li>
                     <li role="presentation">

--- a/node_modules/oae-core/preferences/tests/preferences.js
+++ b/node_modules/oae-core/preferences/tests/preferences.js
@@ -9,7 +9,8 @@ casper.test.begin('Widget - Preferences', function(test) {
             test.assertExists('.oae-trigger-preferences', 'Preferences trigger exists');
             casper.click('.oae-trigger-preferences');
             casper.waitUntilVisible('#preferences-modal', function() {
-                test.assertVisible('#preferences-modal', 'Preferences pane is showing after trigger');
+                // Assert that the first tab (preferences panel) is the one that is shown when opening the modal
+                test.assertVisible('#preferences-account', 'Preferences pane is showing after trigger');
                 casper.click('#me-clip-container .oae-clip-content > button');
             });
         });
@@ -173,6 +174,11 @@ casper.test.begin('Widget - Preferences', function(test) {
             });
             casper.then(function() {
                 verifyChangePassword();
+            });
+
+            // Sanity check that if we open the preferences modal again, we show the first tab (account preferences)
+            casper.then(function() {
+                verifyOpenPreferences();
             });
 
             userUtil().doLogOut();


### PR DESCRIPTION
When you go to your "My Preferences" and click on the Password tab you get a screen which appears to allow you to change your password.  If you are using external authentication (via CAS/LDAP, Twitter, etc.) any password change you make within OAE will not actually change your password in the external system.  We have had confusion on this for similar reasons in Sakai when we left the internal "password reset" option in place.  I'm not sure if it would be possible to have that feature get de-activated if you are not using internal OAE authentication, might be something to consider.
