### PR TITLE
When changing the profile visibility of a user in the manageuser widget the email options become unselected

### DIFF
--- a/node_modules/oae-admin/manageuser/js/manageuser.js
+++ b/node_modules/oae-admin/manageuser/js/manageuser.js
@@ -323,10 +323,11 @@ define(['jquery', 'oae.core'], function($, oae) {
 
             // Catch changes in the visibility radio group
             $rootel.on('change', '.oae-large-options-container input[type="radio"]', function() {
-                $('.oae-large-options-container label', $rootel).removeClass('checked');
-                $('.oae-large-options i', $rootel).removeClass('selected');
-                $(this).parents('label').addClass('checked');
-                $(this).parents('label').find('.oae-large-options i').addClass('selected');
+                var $optionsContainer = $(this).closest('.oae-large-options-container');
+                $optionsContainer.find('label').removeClass('checked');
+                $('.oae-large-options i', $optionsContainer).removeClass('selected');
+                $(this).closest('label').addClass('checked');
+                $(this).closest('label').find('.oae-large-options i').addClass('selected');
             });
         };
 


### PR DESCRIPTION
We need to limit the selector to the profile/email pane for the visibility/email options in the manageuser widget.
