### PR TITLE
Using date-range reprocessing of content doesn't pick up any items

### DIFF
--- a/node_modules/oae-admin/maintenance/js/maintenance.js
+++ b/node_modules/oae-admin/maintenance/js/maintenance.js
@@ -223,8 +223,8 @@ define(['jquery', 'oae.core', 'bootstrap.datepicker'], function($, oae) {
          */
         var reprocessDateRange = function() {
             var data = {
-                'revision_createdAfter': $('#maintenance-reprocess-daterange-from', $rootel).datepicker('getDate'),
-                'revision_createdBefore': $('#maintenance-reprocess-daterange-to', $rootel).datepicker('getDate')
+                'revision_createdAfter': new Date($('#maintenance-reprocess-daterange-from', $rootel).datepicker('getDate')).getTime(),
+                'revision_createdBefore': new Date($('#maintenance-reprocess-daterange-to', $rootel).datepicker('getDate')).getTime()
             };
 
             oae.api.admin.reprocessPreviews(data, reprocessHandler);


### PR DESCRIPTION
I think a stringified date is being passed into the argument as opposed to millis since epoch of the dates:

![image](https://cloud.githubusercontent.com/assets/102265/3256901/91c22e26-f220-11e3-8679-8966436178d6.png)

That would likely be it.
