### PR TITLE
Google indexing noscript page instead of widget-generated content

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -95,7 +95,7 @@ http {
         rewrite ^/notfound          /shared/oae/errors/notfound.html last;
         rewrite ^/unavailable       /shared/oae/errors/unavailable.html last;
 
-        rewrite ^/favicon.ico /shared/oae/img/favicon.ico last;
+        rewrite ^/favicon.ico       /shared/oae/img/favicon.ico last;
         rewrite ^/robots.txt        /shared/oae/robots.txt last;
 
 

--- a/shared/oae/robots.txt
+++ b/shared/oae/robots.txt
@@ -1,2 +1,7 @@
 User-agent: *
 Disallow: /shared/oae/errors/
+Disallow: /accessdenied
+Disallow: /servermaintenance
+Disallow: /noscript
+Disallow: /notfound
+Disallow: /unavailable


### PR DESCRIPTION
(Reporting on behalf of @timdegroote.)

https://www.google.co.uk/search?q=open+academic+environment
![google-search-oae](https://cloud.githubusercontent.com/assets/5596105/3329431/e2b18c68-f7c6-11e3-9d02-8be7b96055cd.png)

https://www.google.co.uk/search?q=open+access+cambridge
![google-search-openaccess](https://cloud.githubusercontent.com/assets/5596105/3329433/e676e94c-f7c6-11e3-9d19-268fb74b5078.png)

The Open Access page has a description meta tag in the static HTML response to GET /.
