### PR TITLE
Flickr photo does not embed in content profile

### DIFF
--- a/node_modules/oae-core/linkpreview/js/linkpreview.js
+++ b/node_modules/oae-core/linkpreview/js/linkpreview.js
@@ -102,16 +102,26 @@ define(['jquery', 'oae.core', 'jquery.oembed'], function($, oae) {
         };
 
         /**
-         * In case the current link doesn't match any of the oEmbed providers, we try to embed the link as an iframe.
-         * If the preview processor has marked the link as non-embeddable because of cross-domain embedding policies,
-         * we try to show the preview image if available. If the link's protocol is `http` but the user is accessing
-         * OAE over `https`, the link is converted to `https` if it is accessible over `https` to avoid browser security
-         * issues/warnings.
+         * Render the link preview using a preview image.
          */
         var renderDefaultPreview = function() {
+            oae.api.util.template().render($('#linkpreview-default-template', $rootel), {'linkProfile': widgetData}, $('#linkpreview-container'), $rootel);
+        };
+
+        /**
+         * Render the link preview using a live iframe if possible.
+         *
+         * In case the current link doesn't match any of the oEmbed providers,
+         * we can try to embed the link as an iframe. If the preview processor
+         * has marked the link as non-embeddable because of cross-domain embedding
+         * policies, we resort to default rendering. If the link's protocol is `http`
+         * but the user is accessing OAE over `https`, the link is converted to
+         * `https` if it is accessible over `https` to avoid browser security
+         * issues/warnings.
+         */
+        var renderIframePreview = function() {
             var link = widgetData.link;
             var embeddable = widgetData.previews.embeddable;
-
             // If there is a protocol mismatch, the link is converted to `https` if it is
             // accessible over `https`
             if (window.location.protocol === 'https:' && link.indexOf('http:' === 0)) {
@@ -127,7 +137,7 @@ define(['jquery', 'oae.core', 'jquery.oembed'], function($, oae) {
                 oae.api.util.template().render($('#linkpreview-iframe-template', $rootel), {'link': link}, $('#linkpreview-container'), $rootel);
             // The link can not be embedded
             } else {
-                oae.api.util.template().render($('#linkpreview-default-template', $rootel), {'linkProfile': widgetData}, $('#linkpreview-container'), $rootel);
+                renderDefaultPreview();
             }
         };
 
@@ -162,7 +172,7 @@ define(['jquery', 'oae.core', 'jquery.oembed'], function($, oae) {
             if (useOEmbed) {
                 renderOEmbedPreview();
             } else {
-                renderDefaultPreview();
+                renderIframePreview();
             }
         };
 


### PR DESCRIPTION
I create a link with this URL: https://www.flickr.com/photos/h-k-d/6782560429

Then in the console after previews are processed I have this error:

```
Refused to execute script from 'https://www.flickr.com/services/oembed?
format=json&url=https%3A//www.flickr…tos/h-k-d/6782560429&
jsoncallback=jQuery20005380745416041464_1405355789385'
because its MIME type ('application/json') is not executable, and strict MIME
type checking is enabled.
```

Browser is 35.0.1916.153 Mac
