### PR TITLE
Short URL links are not being embedded due to an HTTPs insecure content error

### DIFF
--- a/shared/vendor/js/jquery-plugins/jquery.oembed.js
+++ b/shared/vendor/js/jquery-plugins/jquery.oembed.js
@@ -81,7 +81,10 @@
 							} else {
 								settings.onProviderNotFound.call(container, resourceURL);
 							}
-						  }
+						  },
+						  error: function() {
+                              				settings.onError.call(container, resourceURL)
+                            			  }
 						}, settings.ajaxOptions || {});
 
 						$.ajax(ajaxopts);


### PR DESCRIPTION
Run OAE behind https and add a short url (ex: http://youtu.be/JrtWhFtjXTA). You'll get the following warning:

> [blocked] The page at 'https://oae.gatech.edu/content/gatech/WylLgWJ8l' was loaded over HTTPS, but ran insecure content from 'http://api.longurl.org/v2/expand?callback=jQuery20005210501232650131_1405678391547&url=http%3A%2F%2Fyoutu.be%2FJrtWhFtjXTA&format=json': this content should also be loaded over HTTPS.

This probably has something to do with the oembed plugin
