### PR TITLE
Admin UI: Add ability to clear config values

### DIFF
--- a/node_modules/oae-admin/modules/bundles/default.properties
+++ b/node_modules/oae-admin/modules/bundles/default.properties
@@ -1,8 +1,13 @@
+CONFIGURATION_COULD_NOT_BE_REVERTED = The configuration could not be reverted.
 CONFIGURATION_COULD_NOT_BE_SAVED = The configuration could not be saved.
+CONFIGURATION_NOT_REVERTED = Configuration not reverted.
 CONFIGURATION_NOT_SAVED = Configuration not saved.
+CONFIGURATION_REVERTED = Configuration reverted.
 CONFIGURATION_SAVED = Configuration saved.
+CONFIGURATION_SUCCESSFULLY_REVERTED = The configuration was successfully reverted.
 CONFIGURATION_SUCCESSFULLY_SAVED = The configuration was successfully saved.
 EDIT_THE_MODULE = Edit the ${moduleTitle}
+REVERT_TO_DEFAULTS = Revert to defaults
 SAVE_CONFIGURATION = Save configuration
 TENANT_OVERRIDE_DISABLED = Tenant override disabled
 

--- a/node_modules/oae-admin/modules/js/modules.js
+++ b/node_modules/oae-admin/modules/js/modules.js
@@ -20,35 +20,67 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
         // The widget container
         var $rootel = $('#' + uid);
 
+        // The schema for the configuration
+        var schema = [];
+
+        // Convert the configuration schema to an array as we can't sort a dictionary
+        $.each(widgetData.configurationSchema, function(moduleName, module) {
+            schema.push({'module': module, 'moduleName': moduleName});
+        });
+
+        // Sort the array based on the module title
+        schema.sort(function(a, b) {
+            if (a.module.title > b.module.title) {
+                return 1;
+            }
+            if (a.module.title < b.module.title) {
+                return -1;
+            }
+            return 0;
+        });
+
+        /**
+         * Create appropriate API URL root for admin or tenant
+         */
+        var getApiUrl = function() {
+            var url = '/api/config';
+            // Tenant and global servers do not need the tenantId to be specified in the URL
+            // If a tenant server is accessed through the global server the tenantId needs to be specified
+            if (widgetData.context.isTenantOnGlobalAdminServer) {
+                url += '/' + widgetData.context.alias;
+            }
+            return url;
+        };
+
         /**
          * Render the available configuration modules and their configured values
          */
         var renderModules = function() {
-            var schema = [];
-
-            // Convert the configuration schema to an array as we can't sort a dictionary
-            $.each(widgetData.configurationSchema, function(moduleName, module) {
-                schema.push({'module': module, 'moduleName': moduleName});
-            });
-
-            // Sort the array based on the module title
-            schema.sort(function(a, b) {
-                if (a.module.title > b.module.title) {
-                    return 1;
-                }
-                if (a.module.title < b.module.title) {
-                    return -1;
-                }
-
-                return 0;
-            });
-
             oae.api.util.template().render($('#modules-template', $rootel), {
                 'schema': schema,
                 'configuration': widgetData.configuration,
                 'context': widgetData.context,
                 'languages': widgetData.configurationSchema['oae-principals'].user.elements.defaultLanguage.list
             }, $('#modules-container', $rootel));
+        };
+
+        /**
+         * Update a single module in the DOM
+         */
+        var updateRenderedModule = function(module) {
+            // Render the modules template outside of the DOM
+            var modulesHtml = oae.api.util.template().render($('#modules-template', $rootel), {
+                'schema': schema,
+                'configuration': widgetData.configuration,
+                'context': widgetData.context,
+                'languages': widgetData.configurationSchema['oae-principals'].user.elements.defaultLanguage.list
+            });
+            // Strip out leading whitespace
+            modulesHtml = modulesHtml.substring(modulesHtml.indexOf('<'));
+            // Find the updated module
+            var $moduleHtml = $(modulesHtml).find('form[data-module="' + module + '"]');
+            // Replace it in the DOM
+            $('form[data-module="' + module + '"]', $rootel).replaceWith($moduleHtml);
         };
 
         /**
@@ -103,17 +135,10 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
                 });
             });
 
-            var url = '/api/config';
-            // Tenant and global servers do not need the tenantId to be specified in the URL
-            // If a tenant server is accessed through the global server the tenantId needs to be specified
-            if (widgetData.context.isTenantOnGlobalAdminServer) {
-                url += '/' + widgetData.context.alias;
-            }
-
             // Only update when a change has actually been made
             if (!$.isEmptyObject(data)) {
                 $.ajax({
-                    'url': url,
+                    'url': getApiUrl(),
                     'type': 'POST',
                     'data': data,
                     'success': function() {
@@ -133,6 +158,56 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
         };
 
         /**
+         * Handle click on revert to defaults
+         */
+        var revertToDefaults = function() {
+            // List of keys to revert for this action
+            var keysToClear = [];
+            // Identify the module to revert
+            var module = $(this).parent('form.modules-configuration-form').attr('data-module');
+            // Find all the keys in the module
+            var schema = widgetData.configurationSchema[module];
+            _.each(_.omit(schema, 'title'), function(optionValue, option) {
+                _.each(_.omit(optionValue.elements, ['name', 'tenantOverride']), function(elementValue, element) {
+                    if (widgetData.configurationSchema[module][option].elements[element].type === 'internationalizableText') {
+                        keysToClear.push(module + '/' + option + '/' + element + '/default');
+                        _.each(widgetData.configurationSchema['oae-principals'].user.elements.defaultLanguage.list, function(lang) {
+                            keysToClear.push(module + '/' + option + '/' + element + '/' + lang.value);
+                        });
+                    } else {
+                        keysToClear.push(module + '/' + option + '/' + element);
+                    }
+                });
+            });
+
+            // Clear the keys via the API
+            $.ajax({
+                'url': getApiUrl() + '/clear',
+                'type': 'POST',
+                'data': {'configFields': keysToClear},
+                'success': function() {
+                    oae.api.util.notification(
+                        oae.api.i18n.translate('__MSG__CONFIGURATION_REVERTED__', 'modules'),
+                        oae.api.i18n.translate('__MSG__CONFIGURATION_SUCCESSFULLY_REVERTED__', 'modules'));
+                    // Get the updated configuration after the reversion
+                    $.getJSON(getApiUrl(), function (config) {
+                        widgetData.configuration = config;
+                        // Update the relevant module in the DOM
+                        updateRenderedModule(module);
+                    });
+                },
+                'error': function() {
+                    oae.api.util.notification(
+                        oae.api.i18n.translate('__MSG__CONFIGURATION_NOT_REVERTED__', 'modules'),
+                        oae.api.i18n.translate('__MSG__CONFIGURATION_COULD_NOT_BE_REVERTED__', 'modules'),
+                        'error');
+                }
+            });
+
+            return true;
+        };
+
+        /**
          * Toggle internationalizable field container
          */
         var toggleInternationalizableFieldContainer = function() {
@@ -143,6 +218,7 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
             $targetContainer.find('.form-group:first-child').show();
             // Show the selected language form group in the target container
             $targetContainer.find('div[data-id="' + $(this).val() + '"]').show();
+            return true;
         };
 
         /**
@@ -150,6 +226,7 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
          */
         var toggleContainer = function() {
             $(this).next().toggle(400);
+            return true;
         };
 
         /**
@@ -160,6 +237,8 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
             $rootel.on('click', '.admin-table-striped-toggle', toggleContainer);
             // Change config values
             $rootel.on('submit', '.modules-configuration-form', updateConfiguration);
+            // Revert to defaults
+            $rootel.on('click', '.modules-configuration-revert', revertToDefaults);
             // Toggle internationalizable field containers
             $rootel.on('change', '.admin-internationalizabletext-language-picker', toggleInternationalizableFieldContainer);
         };

--- a/node_modules/oae-admin/modules/modules.html
+++ b/node_modules/oae-admin/modules/modules.html
@@ -95,6 +95,7 @@
                                 {/for}
                             {/if}
                         {/for}
+                        <button type="button" class="btn btn-default modules-configuration-revert">__MSG__REVERT_TO_DEFAULTS__</button>
                         <button type="submit" class="btn btn-primary">__MSG__SAVE_CONFIGURATION__</button>
                     </form>
                 </div>


### PR DESCRIPTION
There are endpoints in the backend that allows you to clear a config value.

They are available at
- Global admin: `/api/config/:tenantAlias/clear`
- Tenant admin: `/api/config/clear`

Send a `configFields` parameter which is an array of those elements (`oae-module/feature/element`) which need to be cleared.

It'd be neat if those were to be hooked up in the admin UI
