### PR TITLE
Create Nginx location entry to disable retries of restoring revisions

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -447,9 +447,23 @@ http {
             proxy_pass http://tenantworkers;
         }
 
+        location ~* /api/content/([^\/]+)/publish {
+            expires -1;
+            proxy_read_timeout 300;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
         location ~* /api/content/([^\/]+)/revisions/([^\/]+)/previews {
             expires -1;
             proxy_read_timeout 1200;
+            proxy_next_upstream error http_502;
+            proxy_pass http://tenantworkers;
+        }
+
+        location ~* /api/content/([^\/]+)/revisions/([^\/]+)/restore {
+            expires -1;
+            proxy_read_timeout 300;
             proxy_next_upstream error http_502;
             proxy_pass http://tenantworkers;
         }


### PR DESCRIPTION
Since this is a "destructive" operation (will create multiple revisions if it times out and retries against other app nodes), it should not be retried, similar to our "create" entries.

I really wish Nginx could just let us specify "Don't retry for any POST request" :(
