### PR TITLE
Re-skin Etherpad

### DIFF
--- a/node_modules/oae-core/etherpad/css/etherpad.css
+++ b/node_modules/oae-core/etherpad/css/etherpad.css
@@ -22,6 +22,7 @@
 }
 
 #etherpad-container #etherpad-edit-mode {
+    height: 700px;
     padding: 20px 0;
 }
 
@@ -31,13 +32,7 @@
     width: 100%;
 }
 
-@media (min-width: 780px) {
-    #etherpad-container #etherpad-edit-mode {
-        height: 700px;
-    }
-}
-
-@media (min-width: 400px) and (max-width: 780px) {
+@media (max-width: 767px) {
     #etherpad-container #etherpad-edit-mode {
         height: 550px;
     }


### PR DESCRIPTION
We'd like to re-skin Etherpad to make it fit better into the overall UX and make it simpler to use. The designs can be found at `Dropbox/OAE/22. EtherPad Upgrades/EtherPad.v03.pdf`.

A couple of notes:
- [x] The default font of the Editor should become `Open Sans Regular`, with a default font size of 14px and a default line-height of 18px
- [x] When using `400px` width, no controls should be shown
- [x] The `Document Saved` notification should not be implemented
- [x] The editor should not have a dynamic height. Scrolling inside of the editor is acceptable. However, we should have some media queries to make the height of the editor dependent on the height of the browser
- [x] The print button should just trigger the `Export to PDF` functionality and download the PDF straight away
- [x] Authorship colors should not be shown by default but should be toggle-able from the online dropdown.
