### PR TITLE
The TemplateCache variable in oae.api.util is defined as an Array while it should be a plain Object

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -150,7 +150,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'jquery.
 
     // Variable that will cache all of the parsed Trimpath templates.
     // This avoids the same template being parsed over and over again
-    var templateCache = [];
+    var templateCache = {};
     // Variable that will be used to cache the OAE Trimpath macros for
     // common HTML structures across different pages. This is currently
     // only being used for rendering list view items


### PR DESCRIPTION
In https://github.com/oaeproject/3akai-ux/blob/master/shared/oae/api/oae.api.util.js#L153:

The templateCache variable is defined as an array
`var templateCache = [];`

But compiled templates are added to the templateCache as properties ([link](https://github.com/oaeproject/3akai-ux/blob/master/shared/oae/api/oae.api.util.js#L299)):
`templateCache[templateId] = TrimPath.parseTemplate(templateContent, templateId);`

The cache works, but it makes debugging really hard as logging the variable will always print out an empty array.
