### PR TITLE
Group create and update activities using small profile image instead of medium

### DIFF
--- a/shared/oae/js/activityadapter.js
+++ b/shared/oae/js/activityadapter.js
@@ -134,13 +134,9 @@ var _expose = function(exports) {
             'visibility': entity['oae:visibility']
         };
 
+        // Use the most up-to-date profile picture when available
         if (me && me.id === entity['oae:id'] && me.picture) {
-            if (entity['image']) {
-                that['image'] = entity['image'];
-                that['image'].url = me.picture.small || me.picture.medium;
-            } else {
-                that.thumbnailUrl = me.picture.small || me.picture.medium;
-            }
+            that.thumbnailUrl = me.picture.medium || me.picture.small;
         } else {
             if (entity.image && entity.image.url) {
                 that.thumbnailUrl = entity.image.url;


### PR DESCRIPTION
When creating and updating a group the activity feed entries show a scaled up small image when the medium one looks much better.

Here's the small images:
![smallprofile](https://cloud.githubusercontent.com/assets/70221/4013426/10221362-2a16-11e4-9810-9432cdd9f9e6.png)

Here's what it looks like on the memberships page where the medium image is used:
![medprofile](https://cloud.githubusercontent.com/assets/70221/4013435/2d7f06f4-2a16-11e4-906b-d7f6875f946f.png)
