### PR TITLE
Spinner icons no longer spin

### DIFF
--- a/node_modules/oae-admin/importusers/importusers.html
+++ b/node_modules/oae-admin/importusers/importusers.html
@@ -40,7 +40,7 @@
                                 <span class="sr-only">0%</span>
                             </div>
                         </div>
-                        <i class="fa fa-spinner fa-spin hide"><span class="sr-only">__MSG__UPLOADING__</span></i>
+                        <i class="fa fa-spinner fa-spin"><span class="sr-only">__MSG__UPLOADING__</span></i>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/node_modules/oae-admin/importusers/js/importusers.js
+++ b/node_modules/oae-admin/importusers/js/importusers.js
@@ -165,6 +165,9 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport'], f
                 $('#importusers-modal', $rootel).modal({
                     'backdrop': 'static'
                 });
+
+                // Hide the spinners using jQuery (@see https://github.com/FortAwesome/Font-Awesome/issues/729)
+                $('.fa-spinner', $rootel).hide();
             });
         };
 

--- a/node_modules/oae-core/changepic/changepic.html
+++ b/node_modules/oae-core/changepic/changepic.html
@@ -22,7 +22,7 @@
                                 <span class="sr-only">0%</span>
                             </div>
                         </div>
-                        <i class="fa fa-spinner fa-spin hide">
+                        <i class="fa fa-spinner fa-spin">
                             <span class="sr-only">__MSG__UPLOADING__</span>
                         </i>
                     </div>

--- a/node_modules/oae-core/changepic/js/changepic.js
+++ b/node_modules/oae-core/changepic/js/changepic.js
@@ -397,6 +397,9 @@ define(['jquery', 'oae.core', 'jquery.jcrop', 'jquery.fileupload', 'jquery.ifram
 
                 // Request the context information
                 $(document).trigger('oae.context.get', 'changepic');
+
+                // Hide the spinners using jQuery (@see https://github.com/FortAwesome/Font-Awesome/issues/729)
+                $('#changepic-uploading-container .fa-spinner', $rootel).hide();
             });
 
             // Receive the content profile information and set up the fileupload plugin

--- a/node_modules/oae-core/createlink/createlink.html
+++ b/node_modules/oae-core/createlink/createlink.html
@@ -31,7 +31,7 @@
 
 <div id="createlink-selected-template"><!--
     {macro linkListItemActions()}
-        <i class="hide fa fa-spinner fa-spin">
+        <i class="fa fa-spinner fa-spin">
             <span class="sr-only">__MSG__ADDING_LINK__</span>
         </i>
         <i class="hide fa fa-check">

--- a/node_modules/oae-core/createlink/js/createlink.js
+++ b/node_modules/oae-core/createlink/js/createlink.js
@@ -224,6 +224,9 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
                 }
             }, $('#createlink-selected-container', $rootel));
 
+            // Hide the spinners using jQuery (@see https://github.com/FortAwesome/Font-Awesome/issues/729)
+            $('.fa-spinner', $rootel).hide();
+
             // Initiate the widget that will deal with permission management
             setUpSetPermissions();
 

--- a/node_modules/oae-core/leavegroup/js/leavegroup.js
+++ b/node_modules/oae-core/leavegroup/js/leavegroup.js
@@ -33,6 +33,9 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
                     'metadata': false
                 }
             }, $('#leavegroup-modal-content', $rootel));
+
+            // Hide the spinners using jQuery (@see https://github.com/FortAwesome/Font-Awesome/issues/729)
+            $('.fa-spinner', $rootel).hide();
         };
 
         /**

--- a/node_modules/oae-core/leavegroup/leavegroup.html
+++ b/node_modules/oae-core/leavegroup/leavegroup.html
@@ -16,7 +16,7 @@
 
 <div id="leavegroup-list-template"><!--
     {macro leaveGroupListItemActions()}
-        <i class="fa fa-spinner fa-spin hide">
+        <i class="fa fa-spinner fa-spin">
             <span class="sr-only">__MSG__LEAVING_GROUP__</span>
         </i>
         <i class="fa fa-check hide">

--- a/node_modules/oae-core/unfollow/js/unfollow.js
+++ b/node_modules/oae-core/unfollow/js/unfollow.js
@@ -33,6 +33,9 @@ define(['jquery', 'oae.core'], function ($, oae) {
                     'metadata': false
                 }
             }, $('#unfollow-list-container', $rootel));
+
+            // Hide the spinners using jQuery (@see https://github.com/FortAwesome/Font-Awesome/issues/729)
+            $('.fa-spinner', $rootel).hide();
         };
 
         /**

--- a/node_modules/oae-core/unfollow/unfollow.html
+++ b/node_modules/oae-core/unfollow/unfollow.html
@@ -22,7 +22,7 @@
 
 <div id="unfollow-list-template"><!--
     {macro unfollowUserListItemActions()}
-        <i class="fa fa-spinner fa-spin hide">
+        <i class="fa fa-spinner fa-spin">
             <span class="sr-only">__MSG__UNFOLLOWING_USER__</span>
         </i>
         <i class="fa fa-check hide">

--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -264,6 +264,9 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
                 }
             }, $('#upload-selected-container', $rootel));
 
+            // Hide the spinners using jQuery (@see https://github.com/FortAwesome/Font-Awesome/issues/729)
+            $('.fa-spinner', $rootel).hide();
+
             // Initiate the widget that will deal with permission management
             setUpSetPermissions();
 

--- a/node_modules/oae-core/upload/upload.html
+++ b/node_modules/oae-core/upload/upload.html
@@ -43,7 +43,7 @@
 
 <div id="upload-selected-template"><!--
     {macro uploadListItemActions()}
-        <i class="fa fa-spinner fa-spin hide">
+        <i class="fa fa-spinner fa-spin">
             <span class="sr-only">__MSG__UPLOADING_FILE__</span>
         </i>
         <i class="fa fa-check hide">

--- a/node_modules/oae-core/uploadnewversion/js/uploadnewversion.js
+++ b/node_modules/oae-core/uploadnewversion/js/uploadnewversion.js
@@ -192,6 +192,9 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport'], f
 
                 // Request the content profile information
                 $(document).trigger('oae.context.get', 'uploadnewversion');
+
+                // Hide the spinners using jQuery (@see https://github.com/FortAwesome/Font-Awesome/issues/729)
+                $('.fa-spinner', $rootel).hide();
             });
 
             // Receive the content profile information and set up the fileupload plugin

--- a/node_modules/oae-core/uploadnewversion/uploadnewversion.html
+++ b/node_modules/oae-core/uploadnewversion/uploadnewversion.html
@@ -25,7 +25,7 @@
                                 <span class="sr-only">0%</span>
                             </div>
                         </div>
-                        <i class="fa fa-spinner fa-spin hide">
+                        <i class="fa fa-spinner fa-spin">
                             <span class="sr-only">__MSG__UPLOADING__</span>
                         </i>
                     </div>


### PR DESCRIPTION
Spinner icons that were hidden before they are shown no longer spin. This is almost definitely a regression from the spinner icon hack that was removed in https://github.com/oaeproject/3akai-ux/pull/3808.
