### PR TITLE
Left hand navigation display issue

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -887,9 +887,7 @@ div.oae-thumbnail i.fa {
 
 .oae-lhnavigation > ul.nav > li a div,
 .oae-lhnavigation > ul.nav > li button div {
-    overflow: auto;
-    padding-top: 8px;
-    word-break: break-word;
+    padding: 8px 0 0 31px;
 }
 
 .oae-lhnavigation > ul.nav > li {


### PR DESCRIPTION
The text for items in the left hand navigation that take up more than 1 line should align rather than jump below the icon.

![screen shot 2014-09-30 at 00 16 47](https://cloud.githubusercontent.com/assets/109850/4451109/0bd1c9f6-482f-11e4-984a-126eb3eb1f45.png)
