### PR TITLE
Browsing to cam.oae.com/usermanagement actually brings you to cam.oae.com/tenants

### DIFF
--- a/node_modules/oae-core/lhnavigation/js/lhnavigation.js
+++ b/node_modules/oae-core/lhnavigation/js/lhnavigation.js
@@ -126,7 +126,8 @@ define(['jquery', 'oae.core', 'jquery.history'], function($, oae) {
             var loadedUrl = $.url(History.getState().hash);
 
             // Remove the `baseUrl` from the URL
-            loadedUrlSegments = loadedUrl.segment().slice(baseUrl.split('/').length - 1);
+            var baseUrlSegments = _.compact(baseUrl.split('/'));
+            var loadedUrlSegments = loadedUrl.segment().slice(baseUrlSegments.length);
             // Extract the selected page from the URL. Note that the page id will not be
             // present in the URL when the base URL has been opened in itself. In that case,
             // we re-assign the page id once the first page in the navigation has been returned.


### PR DESCRIPTION
Browsing to cam.oae.com/usermanagement actually brings you to cam.oae.com/tenants. The URL doesn't seem to be respected anymore.
