### PR TITLE
Markdown rendering improvements

### DIFF
--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -833,6 +833,14 @@ ul.as-list li.as-result-item.active {
     margin: 0.75em 0 0.5em;
 }
 
-.oae-markdown-embedded p:last-child {
-    margin-bottom: 0;
+.oae-markdown-embedded ol,
+.oae-markdown-embedded ul,
+.oae-markdown-embedded p {
+    margin: 10px 0 0 0;
+}
+
+.oae-markdown-embedded ol:first-child,
+.oae-markdown-embedded ul:first-child,
+.oae-markdown-embedded p:first-child {
+    margin-top: 0;
 }


### PR DESCRIPTION
- [ ] There is not enough space between the last bullet point in a list and the following paragraph:

![screen shot 2014-10-13 at 12 46 00](https://cloud.githubusercontent.com/assets/109850/4612881/981ceb62-52ce-11e4-9d26-ec07b73a2c17.png)
- [ ] The initial post in a discussion should also be rendered as Markdown
