### PR TITLE
Terms and Conditions display improvements

### DIFF
--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -795,17 +795,7 @@ ul.as-list li.as-result-item.active {
     max-width: 100%;
 }
 
-/**
- * Adjust heading margins for markdown rendered within a well
- * (e.g. Terms and conditions)
- */
-
-.well > .oae-markdown > h1:first-child,
-.well > .oae-markdown > h2:first-child,
-.well > .oae-markdown > h3:first-child,
-.well > .oae-markdown > h4:first-child,
-.well > .oae-markdown > h5:first-child,
-.well > .oae-markdown > h6:first-child {
+.oae-markdown *:first-child {
     margin-top: 0;
 }
 


### PR DESCRIPTION
When the first element of the rendered terms and conditions is a header element, an unnecessary margin-top is present on that header element. In that case, the margin-top should be removed.

![screen shot 2014-10-19 at 23 58 07](https://cloud.githubusercontent.com/assets/109850/4694899/406c678c-57db-11e4-8aec-2afa14ee3961.png)
