### PR TITLE
Fixed display of default link preview

### DIFF
--- a/node_modules/oae-core/linkpreview/js/linkpreview.js
+++ b/node_modules/oae-core/linkpreview/js/linkpreview.js
@@ -105,7 +105,14 @@ define(['jquery', 'oae.core', 'jquery.oembed'], function($, oae) {
          * Render the default link preview. This will use a screenshot of the link when available.
          */
         var renderDefaultPreview = function() {
-            oae.api.util.template().render($('#linkpreview-default-template', $rootel), {'linkProfile': widgetData}, $('#linkpreview-container'), $rootel);
+            oae.api.util.template().render($('#linkpreview-default-template', $rootel), {
+                'linkProfile': widgetData,
+                'displayOptions': {
+                    'addLink': false,
+                    'addVisibilityIcon': false,
+                    'largeDefault': true
+                }
+            }, $('#linkpreview-container'), $rootel);
         };
 
         /**

--- a/node_modules/oae-core/linkpreview/linkpreview.html
+++ b/node_modules/oae-core/linkpreview/linkpreview.html
@@ -18,7 +18,7 @@
             <div id="linkpreview-default" class="text-center">
                 <div>
                     <a href="${linkProfile.link}" title="${linkProfile.displayName|encodeForHTMLAttribute}">
-                        ${renderThumbnail(linkProfile)}
+                        ${renderThumbnail(linkProfile, displayOptions)}
                     </a>
                 </div>
                 <a href="${linkProfile.link}" class="btn" target="_blank">__MSG__OPEN_LINK__</a>


### PR DESCRIPTION
The default link preview was no longer behaving as intended, which seems to have been caused by a incorrect merge conflict resolution.

The default preview should have the following attributes:
- No link
- No visibility icon
- Large icon

![screen shot 2014-10-24 at 15 57 34](https://cloud.githubusercontent.com/assets/109850/4770429/b9ab8dd2-5b85-11e4-8cdf-115ba33575d3.png)
