### PR TITLE
(A11y severity 1) Preserve keyboard focus on file uploads

### DIFF
--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -399,7 +399,6 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
                 'url': '/api/content/create',
                 'dropZone': $('#upload-dropzone', $rootel),
                 'forceIframeTransport': useIframeTransport,
-                'replaceFileInput': false,
                 // Drop is fired when a user drops files on the dropzone
                 'drop': function(ev, data) {
                     // Ensure at least one file is valid


### PR DESCRIPTION
When a user selects a file to upload in the "Upload file(s)" modal, the modal changes causing keyboard focus to be lost. Once keyboard focus is lost, the user essentially becomes trapped and cannot navigate at all. Ensure that keyboard focus is set to a logical place within the modal once a file has been selected.