### PR TITLE
(A11y severity 2) Associate notifications dropdown content more closely with icon

### DIFF
--- a/node_modules/oae-core/notifications/css/notifications.css
+++ b/node_modules/oae-core/notifications/css/notifications.css
@@ -16,7 +16,7 @@
 /* Clickover positioning relative to its trigger */
 
 #notifications-popover {
-    left: 30px !important;
+    left: 15px !important;
     max-width: none;
     top: 50px !important;
 }

--- a/node_modules/oae-core/notifications/js/notifications.js
+++ b/node_modules/oae-core/notifications/js/notifications.js
@@ -142,6 +142,8 @@ define(['jquery', 'underscore', 'oae.core', 'activityadapter'], function($, _, o
             $(document).on('click', '.oae-trigger-notifications', function() {
                 // Trigger the notifications clickover
                 oae.api.util.clickover($(this), $('.notifications-widget'), {
+                    'container': '#menuitem-notifications',
+                    'onHidden': removeUnreadCount,
                     'onShown': function($currentRootEl) {
                         $rootel = $currentRootEl;
                         getNotifications();
@@ -150,7 +152,6 @@ define(['jquery', 'underscore', 'oae.core', 'activityadapter'], function($, _, o
                         // clickover on the current page
                         markAsRead();
                     },
-                    'onHidden': removeUnreadCount,
                     'tip_id': 'notifications-popover'
                 });
             });

--- a/node_modules/oae-core/notifications/js/notifications.js
+++ b/node_modules/oae-core/notifications/js/notifications.js
@@ -142,7 +142,7 @@ define(['jquery', 'underscore', 'oae.core', 'activityadapter'], function($, _, o
             $(document).on('click', '.oae-trigger-notifications', function() {
                 // Trigger the notifications clickover
                 oae.api.util.clickover($(this), $('.notifications-widget'), {
-                    'container': '#menuitem-notifications',
+                    'container': '#topnavigation-notifications-container',
                     'onHidden': removeUnreadCount,
                     'onShown': function($currentRootEl) {
                         $rootel = $currentRootEl;

--- a/node_modules/oae-core/topnavigation/topnavigation.html
+++ b/node_modules/oae-core/topnavigation/topnavigation.html
@@ -155,7 +155,7 @@
                 <i class="fa fa-home"><span class="sr-only">__MSG__HOME__</span></i>
             </a>
         </li>
-        <li id="menuitem-notifications">
+        <li id="topnavigation-notifications-container">
             <button type="button" class="btn btn-link oae-trigger-notifications" title="__MSG__NOTIFICATIONS__" role="menuitem">
                 <i class="fa fa-bullhorn"><span class="sr-only">__MSG__NOTIFICATIONS__</span></i>
                 <span id="topnavigation-notification-count" class="badge badge-important">${oae.data.me.notificationsUnread || ''}</span>

--- a/node_modules/oae-core/topnavigation/topnavigation.html
+++ b/node_modules/oae-core/topnavigation/topnavigation.html
@@ -155,7 +155,7 @@
                 <i class="fa fa-home"><span class="sr-only">__MSG__HOME__</span></i>
             </a>
         </li>
-        <li>
+        <li id="menuitem-notifications">
             <button type="button" class="btn btn-link oae-trigger-notifications" title="__MSG__NOTIFICATIONS__" role="menuitem">
                 <i class="fa fa-bullhorn"><span class="sr-only">__MSG__NOTIFICATIONS__</span></i>
                 <span id="topnavigation-notification-count" class="badge badge-important">${oae.data.me.notificationsUnread || ''}</span>


### PR DESCRIPTION
The "Notifications" icon (), when selected, opens a drop down of recent notifications. While the drop down is accessible by keyboard, users can only access it after they have navigated through the entire page. Keyboard focus should be set to the dropdown content upon selecting the icon or, optimally, the underlying code should be rearranged to ensure the dropdown content comes immediately after the icon instead of at the end of the page.