### PR TITLE
(A11y severity 2) Remove dialog role from modals

### DIFF
--- a/node_modules/oae-admin/confirmdialog/confirmdialog.html
+++ b/node_modules/oae-admin/confirmdialog/confirmdialog.html
@@ -1,7 +1,7 @@
 <div id="confirmdialog-modal-container"><!-- --></div>
 
 <div id="confirmdialog-modal-template"><!--
-    <div class="modal fade" id="confirmdialog-modal" tabindex="-1" role="dialog" aria-labelledby="confirmdialog-modal-title" aria-hidden="true">
+    <div class="modal fade" id="confirmdialog-modal" tabindex="-1" aria-labelledby="confirmdialog-modal-title" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">

--- a/node_modules/oae-admin/createuser/createuser.html
+++ b/node_modules/oae-admin/createuser/createuser.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/createuser.css" />
 
 <!-- MODAL -->
-<div id="createuser-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="createuser-modal-title" aria-hidden="true">
+<div id="createuser-modal" class="modal fade" tabindex="-1" aria-labelledby="createuser-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-admin/importusers/importusers.html
+++ b/node_modules/oae-admin/importusers/importusers.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/importusers.css" />
 
 <!-- MODAL -->
-<div id="importusers-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="importusers-modal-title" aria-hidden="true">
+<div id="importusers-modal" class="modal fade" tabindex="-1" aria-labelledby="importusers-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-admin/manageuser/manageuser.html
+++ b/node_modules/oae-admin/manageuser/manageuser.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/manageuser.css" />
 
 <!-- MODAL -->
-<div id="manageuser-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="manageuser-modal-title" aria-hidden="true">
+<div id="manageuser-modal" class="modal fade" tabindex="-1" aria-labelledby="manageuser-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/aboutcontent/aboutcontent.html
+++ b/node_modules/oae-core/aboutcontent/aboutcontent.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/aboutcontent.css" />
 
 <!-- MODAL -->
-<div id="aboutcontent-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="aboutcontent-modal-title" aria-hidden="true">
+<div id="aboutcontent-modal" class="modal fade" tabindex="-1" aria-labelledby="aboutcontent-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/aboutdiscussion/aboutdiscussion.html
+++ b/node_modules/oae-core/aboutdiscussion/aboutdiscussion.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/aboutdiscussion.css" />
 
 <!-- MODAL -->
-<div id="aboutdiscussion-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="aboutdiscussion-modal-title" aria-hidden="true">
+<div id="aboutdiscussion-modal" class="modal fade" tabindex="-1" aria-labelledby="aboutdiscussion-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/aboutfolder/aboutfolder.html
+++ b/node_modules/oae-core/aboutfolder/aboutfolder.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/aboutfolder.css" />
 
 <!-- MODAL -->
-<div id="aboutfolder-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="aboutfolder-modal-title" aria-hidden="true">
+<div id="aboutfolder-modal" class="modal fade" tabindex="-1" aria-labelledby="aboutfolder-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/aboutgroup/aboutgroup.html
+++ b/node_modules/oae-core/aboutgroup/aboutgroup.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/aboutgroup.css" />
 
 <!-- MODAL -->
-<div id="aboutgroup-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="aboutgroup-modal-title" aria-hidden="true">
+<div id="aboutgroup-modal" class="modal fade" tabindex="-1" aria-labelledby="aboutgroup-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/addtofolder/addtofolder.html
+++ b/node_modules/oae-core/addtofolder/addtofolder.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/addtofolder.css" />
 
 <!-- MODAL -->
-<div id="addtofolder-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="addtofolder-modal-title" aria-hidden="true">
+<div id="addtofolder-modal" class="modal fade" tabindex="-1" aria-labelledby="addtofolder-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/changepic/changepic.html
+++ b/node_modules/oae-core/changepic/changepic.html
@@ -3,7 +3,7 @@
 <link rel="stylesheet" type="text/css" href="/shared/vendor/js/jquery-plugins/jcrop/jquery.Jcrop.css" />
 
 <!-- MODAL -->
-<div id="changepic-modal" class="changepic-initial-view modal fade" tabindex="-1" role="dialog" aria-labelledby="changepic-modal-title" aria-hidden="true">
+<div id="changepic-modal" class="changepic-initial-view modal fade" tabindex="-1" aria-labelledby="changepic-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/contentshared/contentshared.html
+++ b/node_modules/oae-core/contentshared/contentshared.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/contentshared.css" />
 
 <!-- MODAL -->
-<div id="contentshared-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="contentshared-modal-title" aria-hidden="true">
+<div id="contentshared-modal" class="modal fade" tabindex="-1" aria-labelledby="contentshared-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/createcollabdoc/createcollabdoc.html
+++ b/node_modules/oae-core/createcollabdoc/createcollabdoc.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/createcollabdoc.css" />
 
 <!-- MODAL -->
-<div id="createcollabdoc-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="createcollabdoc-modal-title" aria-hidden="true">
+<div id="createcollabdoc-modal" class="modal fade" tabindex="-1" aria-labelledby="createcollabdoc-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/creatediscussion/creatediscussion.html
+++ b/node_modules/oae-core/creatediscussion/creatediscussion.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/creatediscussion.css" />
 
 <!-- MODAL -->
-<div id="creatediscussion-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="creatediscussion-modal-title" aria-hidden="true">
+<div id="creatediscussion-modal" class="modal fade" tabindex="-1" aria-labelledby="creatediscussion-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/createfolder/createfolder.html
+++ b/node_modules/oae-core/createfolder/createfolder.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/createfolder.css" />
 
 <!-- MODAL -->
-<div id="createfolder-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="createfolder-modal-title" aria-hidden="true">
+<div id="createfolder-modal" class="modal fade" tabindex="-1" aria-labelledby="createfolder-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/creategroup/creategroup.html
+++ b/node_modules/oae-core/creategroup/creategroup.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/creategroup.css" />
 
 <!-- MODAL -->
-<div id="creategroup-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="creategroup-modal-title" aria-hidden="true">
+<div id="creategroup-modal" class="modal fade" tabindex="-1" aria-labelledby="creategroup-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/createlink/createlink.html
+++ b/node_modules/oae-core/createlink/createlink.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/createlink.css" />
 
 <!-- MODAL -->
-<div id="createlink-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="createlink-modal-title" aria-hidden="true">
+<div id="createlink-modal" class="modal fade" tabindex="-1" aria-labelledby="createlink-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/deletecomment/deletecomment.html
+++ b/node_modules/oae-core/deletecomment/deletecomment.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/deletecomment.css" />
 
 <!-- DELETE MODAL -->
-<div id="deletecomment-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deletecomment-modal-title" aria-hidden="true">
+<div id="deletecomment-modal" class="modal fade" tabindex="-1" aria-labelledby="deletecomment-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/deletefolder/deletefolder.html
+++ b/node_modules/oae-core/deletefolder/deletefolder.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/deletefolder.css" />
 
 <!-- MODAL -->
-<div id="deletefolder-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deletefolder-modal-title" aria-hidden="true">
+<div id="deletefolder-modal" class="modal fade" tabindex="-1" aria-labelledby="deletefolder-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/deleteresource/deleteresource.html
+++ b/node_modules/oae-core/deleteresource/deleteresource.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/deleteresource.css" />
 
 <!-- MODAL -->
-<div id="deleteresource-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deleteresource-modal-title" aria-hidden="true"><!-- --></div>
+<div id="deleteresource-modal" class="modal fade" tabindex="-1" aria-labelledby="deleteresource-modal-title" aria-hidden="true"><!-- --></div>
 
 <div id="deleteresource-template"><!--
     <div class="modal-dialog">

--- a/node_modules/oae-core/deleteresources/deleteresources.html
+++ b/node_modules/oae-core/deleteresources/deleteresources.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/deleteresources.css" />
 
 <!-- MODAL -->
-<div id="deleteresources-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="deleteresources-modal-title" aria-hidden="true">
+<div id="deleteresources-modal" class="modal fade" tabindex="-1" aria-labelledby="deleteresources-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/discussionshared/discussionshared.html
+++ b/node_modules/oae-core/discussionshared/discussionshared.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/discussionshared.css" />
 
 <!-- MODAL -->
-<div id="discussionshared-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="discussionshared-modal-title" aria-hidden="true">
+<div id="discussionshared-modal" class="modal fade" tabindex="-1" aria-labelledby="discussionshared-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/editcontent/editcontent.html
+++ b/node_modules/oae-core/editcontent/editcontent.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/editcontent.css" />
 
 <!-- MODAL -->
-<div id="editcontent-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editcontent-modal-title" aria-hidden="true">
+<div id="editcontent-modal" class="modal fade" tabindex="-1" aria-labelledby="editcontent-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/editdiscussion/editdiscussion.html
+++ b/node_modules/oae-core/editdiscussion/editdiscussion.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/editdiscussion.css" />
 
 <!-- MODAL -->
-<div id="editdiscussion-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editdiscussion-modal-title" aria-hidden="true">
+<div id="editdiscussion-modal" class="modal fade" tabindex="-1" aria-labelledby="editdiscussion-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/editfolder/editfolder.html
+++ b/node_modules/oae-core/editfolder/editfolder.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/editfolder.css" />
 
 <!-- MODAL -->
-<div id="editfolder-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editfolder-modal-title" aria-hidden="true">
+<div id="editfolder-modal" class="modal fade" tabindex="-1" aria-labelledby="editfolder-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/editgroup/editgroup.html
+++ b/node_modules/oae-core/editgroup/editgroup.html
@@ -1,5 +1,5 @@
 <!-- MODAL -->
-<div id="editgroup-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editgroup-modal-title" aria-hidden="true">
+<div id="editgroup-modal" class="modal fade" tabindex="-1" aria-labelledby="editgroup-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/editprofile/editprofile.html
+++ b/node_modules/oae-core/editprofile/editprofile.html
@@ -1,5 +1,5 @@
 <!-- MODAL -->
-<div id="editprofile-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="editprofile-modal-title" aria-hidden="true">
+<div id="editprofile-modal" class="modal fade" tabindex="-1" aria-labelledby="editprofile-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/foldercontentvisibility/foldercontentvisibility.html
+++ b/node_modules/oae-core/foldercontentvisibility/foldercontentvisibility.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/foldercontentvisibility.css" />
 
 <!-- MODAL -->
-<div id="foldercontentvisibility-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="foldercontentvisibility-modal-title" aria-hidden="true">
+<div id="foldercontentvisibility-modal" class="modal fade" tabindex="-1" aria-labelledby="foldercontentvisibility-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/foldershared/foldershared.html
+++ b/node_modules/oae-core/foldershared/foldershared.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/foldershared.css" />
 
 <!-- MODAL -->
-<div id="foldershared-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="foldershared-modal-title" aria-hidden="true">
+<div id="foldershared-modal" class="modal fade" tabindex="-1" aria-labelledby="foldershared-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/leavegroup/leavegroup.html
+++ b/node_modules/oae-core/leavegroup/leavegroup.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/leavegroup.css" />
 
 <!-- MODAL -->
-<div id="leavegroup-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="leavegroup-modal-title" aria-hidden="true">
+<div id="leavegroup-modal" class="modal fade" tabindex="-1" aria-labelledby="leavegroup-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/manageaccess/manageaccess.html
+++ b/node_modules/oae-core/manageaccess/manageaccess.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/manageaccess.css" />
 
 <!-- MODAL -->
-<div id="manageaccess-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="manageaccess-modal-title" aria-hidden="true">
+<div id="manageaccess-modal" class="modal fade" tabindex="-1" aria-labelledby="manageaccess-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <form role="form">

--- a/node_modules/oae-core/preferences/preferences.html
+++ b/node_modules/oae-core/preferences/preferences.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/preferences.css" />
 
 <!-- MODAL -->
-<div id="preferences-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="preferences-modal-title" aria-hidden="true">
+<div id="preferences-modal" class="modal fade" tabindex="-1" aria-labelledby="preferences-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/register/register.html
+++ b/node_modules/oae-core/register/register.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/register.css" />
 
 <!-- MODAL -->
-<div id="register-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="register-modal-title" aria-hidden="true">
+<div id="register-modal" class="modal fade" tabindex="-1" aria-labelledby="register-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/revisions/revisions.html
+++ b/node_modules/oae-core/revisions/revisions.html
@@ -3,7 +3,7 @@
 
 
 <!-- MODAL -->
-<div id="revisions-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="revisions-modal-title" aria-hidden="true">
+<div id="revisions-modal" class="modal fade" tabindex="-1" aria-labelledby="revisions-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/share/share.html
+++ b/node_modules/oae-core/share/share.html
@@ -1,5 +1,5 @@
 <!-- MODAL -->
-<div id="share-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="share-modal-title" aria-hidden="true">
+<div id="share-modal" class="modal fade" tabindex="-1" aria-labelledby="share-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/termsandconditions/termsandconditions.html
+++ b/node_modules/oae-core/termsandconditions/termsandconditions.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/termsandconditions.css" />
 
 <!-- MODAL -->
-<div id="termsandconditions-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="termsandconditions-modal-title" aria-hidden="true">
+<div id="termsandconditions-modal" class="modal fade" tabindex="-1" aria-labelledby="termsandconditions-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/unfollow/unfollow.html
+++ b/node_modules/oae-core/unfollow/unfollow.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/unfollow.css" />
 
 <!-- MODAL -->
-<div id="unfollow-modal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="unfollow-modal-title" aria-hidden="true">
+<div id="unfollow-modal" class="modal hide fade" tabindex="-1" aria-labelledby="unfollow-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/upload/upload.html
+++ b/node_modules/oae-core/upload/upload.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/upload.css" />
 
 <!-- MODAL -->
-<div id="upload-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="upload-modal-title" aria-hidden="true">
+<div id="upload-modal" class="modal fade" tabindex="-1" aria-labelledby="upload-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/node_modules/oae-core/uploadnewversion/uploadnewversion.html
+++ b/node_modules/oae-core/uploadnewversion/uploadnewversion.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/uploadnewversion.css"/>
 
 <!-- MODAL -->
-<div id="uploadnewversion-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="uploadnewversion-modal-title" aria-hidden="true">
+<div id="uploadnewversion-modal" class="modal fade" tabindex="-1" aria-labelledby="uploadnewversion-modal-title" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
Modals in this site have a `role="dialog"` (e.g., `<div id="createcollabdoc-modal">`). This role triggers application/forms mode for the dialog elements, which means that standard screen reading functionality (such as the down arrow key to read the next line) is inhibited. This can be very unintuitive for users. Remove `role="dialog"` from all dialogs.
