### PR TITLE
(A11y severity 2) Add grouping and legend to form controls (or equivalent)

### DIFF
--- a/node_modules/oae-core/setpermissions/css/setpermissions.css
+++ b/node_modules/oae-core/setpermissions/css/setpermissions.css
@@ -13,11 +13,26 @@
  * permissions and limitations under the License.
  */
 
-#setpermissions-container h4 {
+#setpermissions-container h4,
+#setpermissions-container legend {
     margin-top: 12px;
 }
 
+#setpermissions-container fieldset > legend:first-of-type,
 #setpermissions-container h4:first-child {
+    margin-top: 0;
+}
+
+/* 
+ * Hack for webkit bug with legend margins
+ *   @see https://github.com/twbs/bootstrap/issues/5313
+ *   @see https://github.com/twbs/bootstrap/issues/8688
+ *   @see https://github.com/twbs/bootstrap/issues/9187
+ *   @see https://github.com/twbs/bootstrap/issues/9583
+ *   @see https://github.com/twbs/bootstrap/issues/9623
+ */
+
+#setpermissions-container fieldset > legend:first-of-type + * {
     margin-top: 0;
 }
 

--- a/node_modules/oae-core/setpermissions/setpermissions.html
+++ b/node_modules/oae-core/setpermissions/setpermissions.html
@@ -5,31 +5,35 @@
 
 <div id="setpermissions-template"><!--
     <div id="setpermissions-form" role="form">
-        <h4>__MSG__VISIBILITY__</h4>
-        <div class="radio">
-            <label>
-                <input type="radio" value="private" name="setpermissions-visibility" class="pull-left" {if visibility === 'private'} checked="checked"{/if}/>
-                <i class="fa fa-oae-private pull-left"></i>
-                <span>__MSG__PRIVATE__</span>
-            </label>
-        </div>
-        <div class="radio">
-            <label>
-                <input type="radio" value="loggedin" name="setpermissions-visibility" class="pull-left" {if visibility === 'loggedin'} checked="checked"{/if}/>
-                <i class="fa fa-oae-loggedin pull-left"></i>
-                <span>${oae.data.me.tenant.displayName|encodeForHTML}</span>
-            </label>
-        </div>
-        <div class="radio">
-            <label>
-                <input type="radio" value="public" name="setpermissions-visibility" class="pull-left" {if visibility === 'public'} checked="checked"{/if}/>
-                <i class="fa fa-oae-public pull-left"></i>
-                <span>__MSG__PUBLIC__</span>
-            </label>
-        </div>
+        <fieldset>
+            <legend>__MSG__VISIBILITY__</legend>
+            <div class="radio">
+                <label>
+                    <input type="radio" value="private" name="setpermissions-visibility" class="pull-left" {if visibility === 'private'} checked="checked"{/if}/>
+                    <i class="fa fa-oae-private pull-left"></i>
+                    <span>__MSG__PRIVATE__</span>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" value="loggedin" name="setpermissions-visibility" class="pull-left" {if visibility === 'loggedin'} checked="checked"{/if}/>
+                    <i class="fa fa-oae-loggedin pull-left"></i>
+                    <span>${oae.data.me.tenant.displayName|encodeForHTML}</span>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" value="public" name="setpermissions-visibility" class="pull-left" {if visibility === 'public'} checked="checked"{/if}/>
+                    <i class="fa fa-oae-public pull-left"></i>
+                    <span>__MSG__PUBLIC__</span>
+                </label>
+            </div>
+        </fieldset>
 
-        <h4>__MSG__SHARE_WITH__</h4>
-        <input type="text" id="setpermissions-share" placeholder="__MSG__ENTER_NAME_HERE__"/>
+        <fieldset>
+            <legend>__MSG__SHARE_WITH__</legend>
+            <input type="text" id="setpermissions-share" placeholder="__MSG__ENTER_NAME_HERE__"/>
+        </fieldset>
 
         <div id="setpermissions-footer" class="modal-footer">
             <button type="button" id="setpermissions-cancelpermissions" class="btn btn-link">__MSG__CANCEL__</button>

--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -344,11 +344,18 @@ input.search-query {
     padding: 5px 25px 10px;
 }
 
-.modal-body h4 {
+.modal-body h4,
+.modal-body legend {
     font-size: 14px;
     font-style: italic;
     font-weight: 200;
     margin-top: 0;
+}
+
+.modal-body legend {
+    border-bottom: none;
+    line-height: 21px;
+    margin-bottom: 10px;
 }
 
 .modal-body form,

--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -899,6 +899,27 @@ div.oae-thumbnail i.fa {
     border-bottom-width: 1px;
 }
 
+/* left hand navigation containing a form (e.g. search refinements) */
+
+.oae-lhnavigation > fieldset.nav {
+    border: 0;
+    margin: 18px 0 0 0;
+    padding: 0;
+    width: 210px;
+}
+
+.oae-lhnavigation > fieldset.nav > legend.nav-header {
+    border-bottom: none;
+    margin: 10px 12px 0 0;
+    padding: 0 15px;
+    width: auto;
+}
+
+.oae-lhnavigation > fieldset.nav > label {
+    margin: 10px 12px 0 0;
+    padding: 0 15px;
+}
+
 /* Left hand navigation toggle */
 
 .oae-lhnavigation > ul.nav > li button div.lhnavigation-caret-container {

--- a/shared/oae/css/oae.skin.less
+++ b/shared/oae/css/oae.skin.less
@@ -436,7 +436,7 @@ ul.as-selections.as-selections-focus {
     border-bottom-color: @modal-gradient1-color;
 }
 
-.modal-header h3, .modal-body h4 {
+.modal-header h3, .modal-body h4, .modal-body legend {
     color: @modal-title-color;
 }
 

--- a/ui/search.html
+++ b/ui/search.html
@@ -50,7 +50,7 @@
             <!-- CONTENT -->
             <div>
                 <div id="search-content-container" class="row">
-                    <div class="oae-lhnavigation">
+                    <div class="oae-lhnavigation" role="form">
                         <fieldset id="search-refine-type" class="nav nav-list">
                             <legend class="nav-header">__MSG__REFINE_SEARCH_BY_TYPE_COLON__</legend>
                             <label class="checkbox"><input type="checkbox" data-type="user" />__MSG__PEOPLE__</label>

--- a/ui/search.html
+++ b/ui/search.html
@@ -51,24 +51,14 @@
             <div>
                 <div id="search-content-container" class="row">
                     <div class="oae-lhnavigation">
-                        <ul id="search-refine-type" class="nav nav-list">
-                            <li class="nav-header">__MSG__REFINE_SEARCH_BY_TYPE_COLON__</li>
-                            <li>
-                                <label class="checkbox"><input type="checkbox" data-type="user" />__MSG__PEOPLE__</label>
-                            </li>
-                            <li>
-                                <label class="checkbox"><input type="checkbox" data-type="group" />__MSG__GROUPS__</label>
-                            </li>
-                            <li>
-                                <label class="checkbox"><input type="checkbox" data-type="content" />__MSG__CONTENT__</label>
-                            </li>
-                            <li>
-                                <label class="checkbox"><input type="checkbox" data-type="folder" />__MSG__FOLDERS__</label>
-                            </li>
-                            <li>
-                                <label class="checkbox"><input type="checkbox" data-type="discussion" />__MSG__DISCUSSIONS__</label>
-                            </li>
-                        </ul>
+                        <fieldset id="search-refine-type" class="nav nav-list">
+                            <legend class="nav-header">__MSG__REFINE_SEARCH_BY_TYPE_COLON__</legend>
+                            <label class="checkbox"><input type="checkbox" data-type="user" />__MSG__PEOPLE__</label>
+                            <label class="checkbox"><input type="checkbox" data-type="group" />__MSG__GROUPS__</label>
+                            <label class="checkbox"><input type="checkbox" data-type="content" />__MSG__CONTENT__</label>
+                            <label class="checkbox"><input type="checkbox" data-type="folder" />__MSG__FOLDERS__</label>
+                            <label class="checkbox"><input type="checkbox" data-type="discussion" />__MSG__DISCUSSIONS__</label>
+                        </fieldset>
                     </div>
                     <div class="clearfix oae-page">
                         <div class="oae-list-container">


### PR DESCRIPTION
Checkboxes and radio buttons are not properly associated with their labels or descriptions, as, for example, on the search form.

Users navigating through the page might be confused when reading the checkboxes as the "Refine your search" label for the boxes is not associated with them. This can be resolved in multiple ways:

* Place the heading and all associated options within a `<fieldset>` element with the heading being a `<legend>` for that fieldset. See http://webaim.org/techniques/forms/controls#checkbox

* Mark up radio buttons and checkboxes within an element with `role="radio group"`. This will identify the answers as a group. Then use `aria-describedby` on this element to reference the element that contains the descriptive text. This will cause the screen reader to read the question text for each answer within the radiogroup (i.e., identical functionality to fieldset/legend).

* Add `tabindex="0"` to the label itself, thus placing it in the keyboard navigation flow and causing it to be navigated to and read previous to the privacy options.

The privacy radio buttons on file upload modals have a similar problem