### PR TITLE
(A11y severity 2) Add ARIA markup to expandable content

### DIFF
--- a/shared/oae/js/jquery-plugins/jquery.clip.js
+++ b/shared/oae/js/jquery-plugins/jquery.clip.js
@@ -28,6 +28,14 @@ define(['jquery'], function (jQuery) {
          * @param  {Object}  $clip  jQuery-wrapped clip to toggle
          */
         var toggleClip = function($clip) {
+            // Toggle the ARIA attributes
+            if ($('button', $clip).attr('aria-expanded') === 'true') {
+                $('button', $clip).attr('aria-expanded', 'false');
+                $('ul', $clip).attr('aria-hidden', 'true');
+            } else {
+                $('button', $clip).attr('aria-expanded', 'true');
+                $('ul', $clip).attr('aria-hidden', 'false');
+            }
             // Toggle the clip options
             $('ul', $clip).toggle();
             // Toggle the caret icons

--- a/shared/oae/js/jquery-plugins/jquery.list.js
+++ b/shared/oae/js/jquery-plugins/jquery.list.js
@@ -31,6 +31,15 @@ define(['jquery', 'oae.api.util', 'jquery.history'], function ($, oaeUtil) {
                 $listHeaderActions.slideDown(200);
             }
 
+            // Toggle ARIA attributes, adding them if necessary
+            if ($(this).attr('aria-expanded') === 'true') {
+                $(this).attr('aria-expanded', 'false');
+                $listHeaderActions.attr('aria-hidden', 'true');
+            } else {
+                $(this).attr('aria-expanded', 'true');
+                $listHeaderActions.attr('aria-hidden', 'false');
+            }
+
             // Toggle the caret icon in the list header
             $(this).find('i').toggleClass('fa-caret-down fa-caret-up');
         });

--- a/shared/oae/macros/list.html
+++ b/shared/oae/macros/list.html
@@ -26,9 +26,9 @@
 {macro listHeader(title, _showSearch, _actions, _showViewOptions)}
     {var showSearch = (_showSearch !== false)}
     {var actions = _actions || []}
+    {var actionsId = oae.api.util.generateId()}
     {var showViewOptions = (_showViewOptions !== false)}
     {var showActionsToggle = (actions.length > 0 || showViewOptions)}
-    {var actionsId = oae.api.util.generateId()}
 
     <div class="oae-list-header">
         <div class="row">

--- a/shared/oae/macros/list.html
+++ b/shared/oae/macros/list.html
@@ -28,6 +28,7 @@
     {var actions = _actions || []}
     {var showViewOptions = (_showViewOptions !== false)}
     {var showActionsToggle = (actions.length > 0 || showViewOptions)}
+    {var actionsId = oae.api.util.generateId()}
 
     <div class="oae-list-header">
         <div class="row">
@@ -38,7 +39,7 @@
                 </button>
 
                 {if showActionsToggle}
-                    <button class="oae-list-header-toggle btn">
+                    <button class="oae-list-header-toggle btn" aria-expanded="false" aria-controls="${actionsId}">
                 {else}
                     <div class="oae-list-header-toggle">
                 {/if}
@@ -70,7 +71,7 @@
             {/if}
         </div>
         {if showActionsToggle}
-            <div class="oae-list-header-actions clearfix hide">
+            <div class="oae-list-header-actions clearfix hide" id="${actionsId}" aria-hidden="true">
                 {if actions.length > 0}
                     {var selectAllId = oae.api.util.generateId()}
                     <input type="checkbox" id="${selectAllId}" class="oae-list-selectall" />

--- a/ui/content.html
+++ b/ui/content.html
@@ -34,7 +34,7 @@
                             <div class="oae-clip-fold-outer"></div>
                         </div>
                         <div class="oae-clip-content">
-                            <button type="button">
+                            <button type="button" aria-expanded="false" aria-controls="content-clip-detail">
                                 ${renderThumbnail(content, displayOptions)}
                                 <div>
                                     <div>
@@ -45,7 +45,7 @@
                                 </div>
                             </button>
                             <div>
-                                <ul>
+                                <ul id="content-clip-detail" aria-hidden="true">
                                     {if content.resourceSubType === 'file'}
                                         <li><a href="${content.downloadPath}"><i class="fa fa-cloud-download"></i>__MSG__DOWNLOAD__</a></li>
                                     {/if}

--- a/ui/discussion.html
+++ b/ui/discussion.html
@@ -35,7 +35,7 @@
                             <div class="oae-clip-fold-outer"></div>
                         </div>
                         <div class="oae-clip-content">
-                            <button type="button">
+                            <button type="button" aria-expanded="false" aria-controls="discussion-clip-detail">
                                 ${renderThumbnail(discussion, displayOptions)}
                                 <div>
                                     <div>
@@ -46,7 +46,7 @@
                                 </div>
                             </button>
                             <div>
-                                <ul>
+                                <ul id="discussion-clip-detail" aria-hidden="true">
                                     {if discussion.isManager}
                                         <li><button class="discussion-trigger-manageaccess"><i class="fa fa-lock"></i>__MSG__MANAGE_ACCESS__</button></li>
                                         <li><button class="discussion-trigger-manageaccess-add"><i class="fa fa-share-square-o"></i>__MSG__SHARE__</button></li>

--- a/ui/folder.html
+++ b/ui/folder.html
@@ -34,7 +34,7 @@
                             <div class="oae-clip-fold-outer"></div>
                         </div>
                         <div class="oae-clip-content">
-                            <button type="button">
+                            <button type="button" aria-expanded="false" aria-controls="folder-clip-detail">
                                 ${renderThumbnail(folder, displayOptions)}
                                 <div>
                                     <div>
@@ -45,7 +45,7 @@
                                 </div>
                             </button>
                             <div>
-                                <ul>
+                                <ul id="folder-clip-detail" aria-hidden="true">
                                     {if folder.canManage}
                                         <li><button class="folder-trigger-manageaccess"><i class="fa fa-lock"></i>__MSG__MANAGE_ACCESS__</button></li>
                                         <li><button class="folder-trigger-manageaccess-add"><i class="fa fa-share-square-o"></i>__MSG__SHARE__</button></li>

--- a/ui/folder.html
+++ b/ui/folder.html
@@ -87,7 +87,7 @@
                                 <div class="oae-clip-fold-outer"></div>
                             </div>
                             <div class="oae-clip-content">
-                                <button>
+                                <button type="button" aria-expanded="false" aria-controls="folder-secondary-clip-detail">
                                     <div>
                                         <i class="fa fa-plus-circle pull-left"></i>
                                         <h1>__MSG__CREATE__</h1>
@@ -95,7 +95,7 @@
                                     </div>
                                 </button>
                                 <div>
-                                    <ul>
+                                    <ul id="folder-secondary-clip-detail" aria-hidden="true">
                                         <li><button class="oae-trigger-createlink"><i class="fa fa-link"></i>__MSG__LINK__</button></li>
                                         <li><button class="oae-trigger-createcollabdoc"><i class="fa fa-pencil-square-o"></i>__MSG__DOCUMENT__</button></li>
                                     </ul>

--- a/ui/group.html
+++ b/ui/group.html
@@ -99,7 +99,7 @@
                                 <div class="oae-clip-fold-outer"></div>
                             </div>
                             <div class="oae-clip-content">
-                                <button>
+                                <button type="button" aria-expanded="false" aria-controls="group-secondary-clip-detail">
                                     <div>
                                         <i class="fa fa-plus-circle pull-left"></i>
                                         <h1>__MSG__CREATE__</h1>
@@ -107,7 +107,7 @@
                                     </div>
                                 </button>
                                 <div>
-                                    <ul>
+                                    <ul id="group-secondary-clip-detail" aria-hidden="true">
                                         <li><button class="oae-trigger-createfolder"><i class="fa fa-folder-open"></i>__MSG__FOLDER__</button></li>
                                         <li><button class="oae-trigger-createlink"><i class="fa fa-link"></i>__MSG__LINK__</button></li>
                                         <li><button class="oae-trigger-createcollabdoc"><i class="fa fa-pencil-square-o"></i>__MSG__DOCUMENT__</button></li>

--- a/ui/group.html
+++ b/ui/group.html
@@ -34,7 +34,7 @@
                             <div class="oae-clip-fold-outer"></div>
                         </div>
                         <div class="oae-clip-content">
-                            <button type="button">
+                            <button type="button" aria-expanded="false" aria-controls="group-clip-detail">
                                 ${renderThumbnail(group, displayOptions)}
                                 <div>
                                     <div>
@@ -45,7 +45,7 @@
                                 </div>
                             </button>
                             <div>
-                                <ul>
+                                <ul id="group-clip-detail" aria-hidden="true">
                                     {if group.isManager}
                                         <li><button class="oae-trigger-changepic"><i class="fa fa-camera"></i>__MSG__CHANGE_PICTURE__</button></li>
                                         <li><button class="group-trigger-manageaccess"><i class="fa fa-user"></i>__MSG__MANAGE_ACCESS__</button></li>

--- a/ui/me.html
+++ b/ui/me.html
@@ -75,7 +75,7 @@
                             <div class="oae-clip-fold-outer"></div>
                         </div>
                         <div class="oae-clip-content">
-                            <button type="button" aria-expanded="false" aria-controls="secondary-clip-detail">
+                            <button type="button" aria-expanded="false" aria-controls="me-secondary-clip-detail">
                                 <div>
                                     <i class="fa fa-plus-circle pull-left"></i>
                                     <h1>__MSG__CREATE__</h1>
@@ -83,7 +83,7 @@
                                 </div>
                             </button>
                             <div>
-                                <ul id="secondary-clip-detail" aria-hidden="true">
+                                <ul id="me-secondary-clip-detail" aria-hidden="true">
                                     <li><button class="oae-trigger-creategroup"><i class="fa fa-group"></i>__MSG__GROUP__</button></li>
                                     <li><button class="oae-trigger-createfolder"><i class="fa fa-folder-open"></i>__MSG__FOLDER__</button></li>
                                     <li><button class="oae-trigger-createlink"><i class="fa fa-link"></i>__MSG__LINK__</button></li>

--- a/ui/me.html
+++ b/ui/me.html
@@ -32,7 +32,7 @@
                             <div class="oae-clip-fold-outer"></div>
                         </div>
                         <div class="oae-clip-content">
-                            <button type="button">
+                            <button type="button" aria-expanded="false" aria-controls="me-clip-detail">
                                 ${renderThumbnail(oae.data.me, displayOptions)}
                                 <div>
                                     <div>
@@ -43,7 +43,7 @@
                                 </div>
                             </button>
                             <div>
-                                <ul>
+                                <ul id="me-clip-detail" aria-hidden="true">
                                     <li><button class="oae-trigger-changepic"><i class="fa fa-camera"></i>__MSG__MY_PICTURE__</button></li>
                                     <li><button class="oae-trigger-editprofile"><i class="fa fa-user"></i>__MSG__MY_PROFILE__</button></li>
                                     <li><button class="oae-trigger-preferences"><i class="fa fa-wrench"></i>__MSG__MY_PREFERENCES__</button></li>
@@ -75,7 +75,7 @@
                             <div class="oae-clip-fold-outer"></div>
                         </div>
                         <div class="oae-clip-content">
-                            <button type="button">
+                            <button type="button" aria-expanded="false" aria-controls="secondary-clip-detail">
                                 <div>
                                     <i class="fa fa-plus-circle pull-left"></i>
                                     <h1>__MSG__CREATE__</h1>
@@ -83,7 +83,7 @@
                                 </div>
                             </button>
                             <div>
-                                <ul>
+                                <ul id="secondary-clip-detail" aria-hidden="true">
                                     <li><button class="oae-trigger-creategroup"><i class="fa fa-group"></i>__MSG__GROUP__</button></li>
                                     <li><button class="oae-trigger-createfolder"><i class="fa fa-folder-open"></i>__MSG__FOLDER__</button></li>
                                     <li><button class="oae-trigger-createlink"><i class="fa fa-link"></i>__MSG__LINK__</button></li>


### PR DESCRIPTION
Several of the expandable buttons on the site (e.g. clips) do not inform screen reader users that the button expands a menu. Additionally, the state of the expansion (e.g., expanded, not expanded) is not conveyed. Providing this information aids users who are unable to see how the controls are meant to function. Add `aria-expanded` with the appropriate true or false values to all buttons that control expansion.