### PR TITLE
(A11y severity 2) Make push notifications accessible 

### DIFF
--- a/shared/vendor/js/bootstrap-plugins/bootstrap.notify.oae-edited.js
+++ b/shared/vendor/js/bootstrap-plugins/bootstrap.notify.oae-edited.js
@@ -21,7 +21,7 @@
     // Element collection
     this.options  = $.extend(true, {}, $.fn.notify.defaults, options);
     this.$element = $(element);
-    this.$note    = $('<div class="alert"></div>');
+    this.$note    = $('<div class="alert" role="alert"></div>');
     if (this.options.closable) {
         this.$note.addClass('alert-dismissable');
     }


### PR DESCRIPTION
Whenever an action is completed (e.g., uploading a file, deleting a file, invoking an error, etc.) a banner briefly appears.
This information is not presented to screen reader users. This can be accomplished setting `role="alert"` on the element. This will cause it to be read immediately when the element appears and the alert role is set.

* Ensure that the alert role is reset (i.e., set to a new element, or the role changed or removed if using one element with differing content) after the information has been presented to the user. Not resetting the alert can lead to subsequent alerts not being read by screen readers.
* Alternatively, focus can be set directly to the notification area. In this case, the element must not automatically disappear after a period of time. Instead, the user must be allowed to read the notification text and manually dismiss it (or perhaps automatically close it if focus moves away from the notification area).