### PR TITLE
(A11y severity 2) Remove redundant links from grid contents

### DIFF
--- a/node_modules/oae-core/activity/activity.html
+++ b/node_modules/oae-core/activity/activity.html
@@ -61,7 +61,7 @@
                             <div class="media-body">
                                 <h4 class="media-heading">
                                     {if item.comment.author['oae:profilePath']}
-                                        <a href="${item.comment.author['oae:profilePath']|profilePath}">${item.comment.author.displayName|encodeForHTML}</a>
+                                        <a href="${item.comment.author['oae:profilePath']|profilePath}" aria-hidden="true">${item.comment.author.displayName|encodeForHTML}</a>
                                     {else}
                                         ${item.comment.author.displayName|encodeForHTML}
                                     {/if}

--- a/node_modules/oae-core/comments/comments.html
+++ b/node_modules/oae-core/comments/comments.html
@@ -52,7 +52,7 @@
                     </div>
                     <h4 class="media-heading">
                         {if comment.createdBy.profilePath}
-                            <a href="${comment.createdBy.profilePath|profilePath}">
+                            <a href="${comment.createdBy.profilePath|profilePath}" aria-hidden="true">
                                 ${comment.createdBy.displayName|encodeForHTML}
                             </a>
                         {else}

--- a/shared/oae/macros/list.html
+++ b/shared/oae/macros/list.html
@@ -268,7 +268,7 @@
     <div class="oae-thumbnail {if displayOptions.largeDefault} oae-thumbnail-large {/if} fa fa-oae-${resourceSubType} fa-oae-${resourceType}" data-id="${resourceId}">
         {if profilePath && displayOptions.addLink !== false}<a href="${profilePath|profilePath}" title="${entityData.displayName|encodeForHTMLAttribute}" {if displayOptions.linkTarget} target="${displayOptions.linkTarget}"{/if}>{/if}
         {if thumbnailUrl}
-            <div role="img" aria-label="${entityData.displayName|encodeForHTMLAttribute}" style="background-image: url('${thumbnailUrl}');"></div>
+            <div role="img" style="background-image: url('${thumbnailUrl}');"></div>
         {/if}
         {if displayOptions.addVisibilityIcon !== false && resourceType !== 'user'}
             ${renderVisibilityIcon(entityData)}


### PR DESCRIPTION
User name and user images are another common issue throughout the site with redundant information and links being presented to users.
The image container as well as the name "Jonathan Whiting" both link to the same location. Additionally, the image container has an aria-label that matches the name text. This causes the name to be repeated unnecessarily by screen readers (this is particularly problematic and cumbersome when comments are read within the activity stream). Since the context of the image can easily be understood by the following name, remove the ARIA label, and either remove the link from the image container (the element could be scripted to respond to mouse click) or combine the image and the adjacent text ("Added by Jonathan Whiting") into one link.