### PR TITLE
(A11y severity 2) Tooltip accessibility

### DIFF
--- a/node_modules/oae-core/createlink/js/createlink.js
+++ b/node_modules/oae-core/createlink/js/createlink.js
@@ -233,8 +233,14 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
                 'select' : true
             });
 
-            // Apply jQuery Tooltip to the link title field to show that the fields are editable
-            $('[rel="tooltip"]', $rootel).tooltip();
+            // Apply jQuery Tooltip to the file title field to show that the fields are editable.
+            // Custom template adds ARIA accessibility to default bootstrap functionality.
+            $('[rel="tooltip"]', $rootel).each(function() {
+                var tooltipId = oae.api.util.generateId();
+                $(this).attr('aria-describedby', tooltipId).tooltip({
+                    'template': '<div class="tooltip" role="tooltip" id="' + tooltipId + '"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
+                });
+            })
         };
 
 

--- a/node_modules/oae-core/createlink/js/createlink.js
+++ b/node_modules/oae-core/createlink/js/createlink.js
@@ -233,7 +233,7 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
                 'select' : true
             });
 
-            // Apply jQuery Tooltip to the file title field to show that the fields are editable.
+            // Apply jQuery Tooltip to the link title field to show that the fields are editable.
             // Custom template adds ARIA accessibility to default bootstrap functionality.
             $('[rel="tooltip"]', $rootel).each(function() {
                 var tooltipId = oae.api.util.generateId();

--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -274,8 +274,14 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
                 'select' : true
             });
 
-            // Apply jQuery Tooltip to the file title field to show that the fields are editable
-            $('[rel="tooltip"]', $rootel).tooltip();
+            // Apply jQuery Tooltip to the file title field to show that the fields are editable.
+            // Custom template adds ARIA accessibility to default bootstrap functionality.
+            $('[rel="tooltip"]', $rootel).each(function() {
+                var tooltipId = oae.api.util.generateId();
+                $(this).attr('aria-describedby', tooltipId).tooltip({
+                    'template': '<div class="tooltip" role="tooltip" id="' + tooltipId + '"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
+                });
+            })
         };
 
 


### PR DESCRIPTION
When a user navigates to the file name after selecting it, a tooltip appears visually (Click to rename), but this information is not presented to screen reader users. This field may be associated to the element via `aria-describedby`.