### PR TITLE
(A11y severity 2) Label page number input in document preview

### DIFF
--- a/node_modules/oae-core/documentpreview/bundles/default.properties
+++ b/node_modules/oae-core/documentpreview/bundles/default.properties
@@ -1,4 +1,5 @@
 NEXT_PAGE = Next page
+PAGE_NUMBER = Page number
 PAGE_X_OF_Y_MIDDLE = of
 PAGE_X_OF_Y_PREFIX = Page
 PAGE_X_OF_Y_SUFFIX =

--- a/node_modules/oae-core/documentpreview/documentpreview.html
+++ b/node_modules/oae-core/documentpreview/documentpreview.html
@@ -24,7 +24,7 @@
                         </i>
                     </button>
                     __MSG__PAGE_X_OF_Y_PREFIX__
-                    <input id="documentpreview-page-num" class="form-control text-center" type="text">
+                    <input id="documentpreview-page-num" aria-label="__MSG__PAGE_NUMBER__" class="form-control text-center" type="text">
                     __MSG__PAGE_X_OF_Y_MIDDLE__
                     <span id="documentpreview-page-count"><!-- --></span>
                     __MSG__PAGE_X_OF_Y_SUFFIX__


### PR DESCRIPTION
The page number text box does not have an associated label. Because there is no text next to this field that informs the user to the purpose of the textbox (e.g., "Enter page number "), the label will need to be hidden off-screen using CSS (see webaim.org/techniques/css/invisiblecontent/) or the field given a descriptive `title` or `aria-label` attribute.