### PR TITLE
(A11y severity 2) Limit alerts in activity stream

### DIFF
--- a/node_modules/oae-core/activity/js/activity.js
+++ b/node_modules/oae-core/activity/js/activity.js
@@ -122,8 +122,9 @@ define(['jquery', 'underscore', 'oae.core', 'activityadapter'], function($, _, o
             infinityScroll = $('.oae-list', $rootel).infiniteScroll(url, {
                 'limit': 10
             }, '#activity-items-template', {
-                'postProcessor': processActivities,
-                'emptyListProcessor': handleEmptyResultList
+                'ariaLive': 'off',  // Notifications will alert screen readers
+                'emptyListProcessor': handleEmptyResultList,
+                'postProcessor': processActivities
             });
         };
 

--- a/shared/oae/js/jquery-plugins/jquery.infinitescroll.js
+++ b/shared/oae/js/jquery-plugins/jquery.infinitescroll.js
@@ -34,6 +34,7 @@ define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n', 'oae.api.l10n'],
      * @param  {Object}                            [options]                       Optional object containing additional configuraton options.
      * @param  {String|Element}                    [options.scrollContainer]       jQuery element or selector for that jQuery element that identifies the container on which the scrollposition should be watched to check when we are close enough to the bottom to load a new set of results. If this is not provided, the document body will be used.
      * @param  {String|Function}                   [options.initialContent]        HTML string that should be prepended to the list upon initialization. If a function is provided, the function will be called with no parameters and should return the HTML string to prepend.
+     * @param  {String         }                   [options.ariaLive]              `aria-live` attribute for container. Defaults to "assertive"
      * @param  {Function}                          [options.emptyListProcessor]    Function that will be executed when the rendered list doesn't have any elements.
      * @param  {Function}                          [options.postProcessor]         Function used to transform the search results before rendering the template. This function will be called with a data parameter containing the retrieved data and should return the processed data
      * @param  {Function}                          [options.postRenderer]          Function executed after the rendered HTML has been appended to the rendered list. The full retrieved server response will be passed into this function.
@@ -49,7 +50,9 @@ define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n', 'oae.api.l10n'],
 
         // Default values
         parameters = parameters || {};
-        options = options || {};
+        options = $.extend({
+            'ariaLive': 'assertive'
+        }, options);
 
         // Number of items to load per call to the server
         parameters.limit = parameters.limit || 10;
@@ -386,7 +389,7 @@ define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n', 'oae.api.l10n'],
         // Initialisation //
         ////////////////////
 
-        $listContainer.attr('aria-live', 'assertive');
+        $listContainer.attr('aria-live', options.ariaLive);
         setUpLoadingImage();
         setUpInitialContent();
         loadResultList();


### PR DESCRIPTION
When a user’s activity stream is updated with new content, the new content on the page is given `role="alert"`. This causes all the new content on the page to be read to a screen reader, which is typically too much information. Additionally a consistent method for notifying users should be maintained. (cf. issue https://github.com/oaeproject/3akai-ux/issues/3921)

A much simpler and succinct approach would be to set the alert to the banner that appears when content is updated:

This method not only provides all pertinent information, but also avoids overwhelming users with information. Users would then be free to either navigate to the activity stream or continue their current task.