### PR TITLE
(A11y severity 1) Investigate accessibility of preview documents

### DIFF
--- a/node_modules/oae-core/documentpreview/documentpreview.html
+++ b/node_modules/oae-core/documentpreview/documentpreview.html
@@ -52,10 +52,13 @@
 
 <!-- TEMPLATES -->
 <div id="documentpreview-content-page-template"><!--
-    <div class="documentpreview-content-page ${cssScopeClass}" data-page-number="${pageNumber}">
-        <div class="documentpreview-content-page-loading text-center">
-            <i class="fa fa-spinner fa-spin"><span class="sr-only">__MSG__LOADING__</span></i>
+    <div class="documentpreview-content-page" data-page-number="${pageNumber}" >
+        <div class="documentpreview-content-html-page ${cssScopeClass}" aria-hidden="true">
+            <div class="documentpreview-content-page-loading text-center">
+                <i class="fa fa-spinner fa-spin"><span class="sr-only">__MSG__LOADING__</span></i>
+            </div>
         </div>
+        <div class="documentpreview-content-text-page sr-only" data-page-number="${pageNumber}"></div>
     </div>
 --></div>
 

--- a/node_modules/oae-core/documentpreview/js/documentpreview.js
+++ b/node_modules/oae-core/documentpreview/js/documentpreview.js
@@ -108,14 +108,14 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
             page.height = page.$el.height();
             page.marginTop = CONTENT_PAGE_SPACING;
 
-            // Request the page content
+            // Request the page content HTML version
             $.ajax({
                 'url': constructDocumentPreviewURL('page.' + page.pageNumber + '.html'),
                 'crossDomain': true,
                 'dataType': 'text',
                 'success': function(response) {
                     // Replace the loading indicator with the page content
-                    page.$el.html(response);
+                    $('.documentpreview-content-html-page', page.$el).html(response);
 
                     // Update the height now that we have real content
                     page.height = page.$el.height();
@@ -162,6 +162,17 @@ define(['jquery', 'underscore', 'oae.core', 'lazyload'], function($, _, oae) {
 
                     // For all other error responses, we pass the error back up the call stack
                     return callback({'code': jqXHR.status, 'msg': jqXHR.responseText});
+                }
+            });
+
+            // Request the page content text version
+            $.ajax({
+                'url': constructDocumentPreviewURL('page.' + page.pageNumber + '.txt'),
+                'crossDomain': true,
+                'dataType': 'text',
+                'success': function(response) {
+                    // Add the text version of the content
+                    $('.documentpreview-content-text-page', page.$el).text(response);
                 }
             });
         };


### PR DESCRIPTION
(Given the constraints of pdf2htmlEX this may not be fixable.)

The documents within the preview don’t read properly. Some sentences are read while entire sections are either skipped or no information is presented.

Also need to ensure any work here doesn't conflict with annotations.