### PR TITLE
Display issue for new comments

### DIFF
--- a/node_modules/oae-core/comments/css/comments.css
+++ b/node_modules/oae-core/comments/css/comments.css
@@ -40,6 +40,15 @@
 
 /* iPhone resolution */
 @media (max-width: 480px) {
+    .comments-widget #comments-container > .media > .media-body {
+        overflow: visible;
+    }
+
+    .comments-widget .comments-level-0 .comments-reply-container,
+    .comments-widget .comments-level-1 .comments-reply-container {
+        margin-left: 35px;
+    }
+
     .comments-widget .comments-level-1 {
         margin-left: 35px;
     }


### PR DESCRIPTION
On mobile devices, we give second and third level replies less margin-left compared to larger screens:

![screen shot 2015-01-12 at 22 20 08](https://cloud.githubusercontent.com/assets/109850/5716736/f608b2d4-9aa8-11e4-9ec6-1ffaa12d9218.png)

However, when entering the comment, these rules don't appear to be respected. The comment box should be aligned with where the comment will show up.

![screen shot 2015-01-12 at 22 19 58](https://cloud.githubusercontent.com/assets/109850/5716750/35f051a4-9aa9-11e4-86b2-1d5e6050b336.png)

There is also a secondary issue when replying to 3rd level comments. A reply to a 3rd level comment will show as a 3rd level comment as well. Therefore, that reply box should be shown in the same place as where the comment will end up. However, the reply box is currently indented to level 4.

![screen shot 2015-01-12 at 22 23 40](https://cloud.githubusercontent.com/assets/109850/5716762/6ef13e0a-9aa9-11e4-8332-e55c8586b074.png)
