### PR TITLE
Adjust 'return' label on iOS

### DIFF
--- a/node_modules/oae-core/topnavigation/topnavigation.html
+++ b/node_modules/oae-core/topnavigation/topnavigation.html
@@ -13,7 +13,7 @@
         <!-- RIGHT MENU -->
         <div id="topnavigation-right" class="col-xs-5 text-right">
             <!-- SEARCH FORM -->
-            <form id="topnavigation-search-form" class="form-inline" role="search" aria-label="__MSG__TOPNAV_SEARCH_ARIA_LABEL__">
+            <form action="." id="topnavigation-search-form" class="form-inline" role="search" aria-label="__MSG__TOPNAV_SEARCH_ARIA_LABEL__">
                 <div class="form-group">
                     <label for="topnavigation-search-query" class="control-label sr-only">__MSG__SEARCH__</label>
                     <input type="text" id="topnavigation-search-query" name="topnavigation-search-query" class="search-query form-control pull-left" title="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__"/>

--- a/shared/oae/macros/list.html
+++ b/shared/oae/macros/list.html
@@ -62,7 +62,7 @@
             {if showSearch}
                 {var searchQueryId = oae.api.util.generateId()}
                 <div class="col-xs-12 col-sm-4 oae-list-header-search">
-                    <form class="form-search" role="search">
+                    <form action="." class="form-search" role="search">
                         <label for="${searchQueryId}" class="control-label sr-only">__MSG__NARROW_BY_KEYWORD__</label>
                         <input type="text" id="${searchQueryId}" class="oae-list-header-search-query form-control pull-right search-query" name="search-query" placeholder="__MSG__NARROW_BY_KEYWORD__"/>
                         <button type="submit" class="sr-only">__MSG__SEARCH__</button>

--- a/ui/index.html
+++ b/ui/index.html
@@ -28,7 +28,7 @@
                 {macro renderSearchBlock()}
                     <form action="." class="index-search-form" role="search" aria-label="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__">
                         <div class="form-group">
-                            <input type="text" class="form-control search-query form-control pull-left index-search-query" title="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__" placeholder="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__"/>
+                            <input type="text" class="form-control search-query form-control pull-left index-search-query" title="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__" placeholder="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__" name="index-search"/>
                             <button type="submit" class="btn btn-link pull-left index-search-icon">
                                 <i class="fa fa-search"><span class="sr-only">__MSG__SEARCH__</span></i>
                             </button>

--- a/ui/index.html
+++ b/ui/index.html
@@ -26,7 +26,7 @@
             <div id="index-page-container" class="row"><!-- --></div>
             <div id="index-page-template"><!--
                 {macro renderSearchBlock()}
-                    <form class="index-search-form" role="search" aria-label="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__">
+                    <form action="." class="index-search-form" role="search" aria-label="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__">
                         <div class="form-group">
                             <input type="text" class="form-control search-query form-control pull-left index-search-query" title="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__" placeholder="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__"/>
                             <button type="submit" class="btn btn-link pull-left index-search-icon">

--- a/ui/index.html
+++ b/ui/index.html
@@ -28,7 +28,7 @@
                 {macro renderSearchBlock()}
                     <form action="." class="index-search-form" role="search" aria-label="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__">
                         <div class="form-group">
-                            <input type="text" class="form-control search-query form-control pull-left index-search-query" title="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__" placeholder="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__" name="index-search"/>
+                            <input type="text" class="form-control search-query form-control pull-left index-search-query" title="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__" placeholder="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__" name="index-search-${oae.api.util.generateId()}"/>
                             <button type="submit" class="btn btn-link pull-left index-search-icon">
                                 <i class="fa fa-search"><span class="sr-only">__MSG__SEARCH__</span></i>
                             </button>

--- a/ui/search.html
+++ b/ui/search.html
@@ -34,7 +34,7 @@
                             <div class="oae-clip-fold-outer"></div>
                         </div>
                         <div class="clearfix oae-clip-content">
-                            <form id="search-form" class="form-search form-horizontal" role="search" aria-label="__MSG__SEARCH__">
+                            <form action="." id="search-form" class="form-search form-horizontal" role="search" aria-label="__MSG__SEARCH__">
                                 <div class="form-group">
                                     <input type="text" id="search-query" class="form-control search-query form-control pull-left" title="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__" autofocus />
                                     <button type="submit" id="search-search-icon" class="btn btn-link pull-left" title="__MSG__SEARCH_FOR_CONTENT_FOLDERS_PEOPLE_GROUPS__">


### PR DESCRIPTION
When using iOS, the label on the submit button in the iOS keyboard reads "return". Is it possible to modify this to make it say "Search" instead?

![screen shot 2015-01-27 at 20 54 26](https://cloud.githubusercontent.com/assets/109850/5932623/8a1c1f2e-a666-11e4-9ab4-5b6180b39a74.png)