### PR TITLE
(A11y severity 2) Hide collapsed menu options from screen readers

### DIFF
--- a/node_modules/oae-core/lhnavigation/lhnavigation.html
+++ b/node_modules/oae-core/lhnavigation/lhnavigation.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="css/lhnavigation.css"/>
 
 <div id="lhnavigation-container" class="row">
-    <div class="oae-lhnavigation">
+    <div class="oae-lhnavigation" id="oae-lhnavigation" aria-hidden="true">
         <ul class="nav nav-list"><!-- --></ul>
     </div>
     <div class="oae-page"><!-- --></div>

--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -936,6 +936,15 @@ div.oae-thumbnail i.fa {
 
 /* Left-hand navigation collapsed view */
 @media (max-width: 991px) {
+    /* hide from screen readers */
+    .oae-lhnavigation {
+        display: none;
+    }
+
+    .oae-lhnavigation.oae-lhnav-expanded {
+        display: block;
+    }
+
     .oae-page {
         margin-left: 0;
         padding-left: 25px;

--- a/shared/oae/js/jquery-plugins/jquery.responsive.js
+++ b/shared/oae/js/jquery-plugins/jquery.responsive.js
@@ -36,6 +36,15 @@ define(['jquery', 'oae.api.util'], function (jQuery, oaeUtil) {
          * Toggle the left hand navigation between its expanded and collapsed state
          */
         var toggleLhNav = function() {
+            // Toggle ARIA attributes, adding them if necessary
+            if ($('#oae-lhnavigation').attr('aria-hidden') === 'true') {
+                $('#oae-lhnavigation').attr('aria-hidden', 'false');
+                $('button[aria-controls="oae-lhnavigation"]').attr('aria-expanded', 'true');
+            } else {
+                $('#oae-lhnavigation').attr('aria-hidden', 'true');
+                $('button[aria-controls="oae-lhnavigation"]').attr('aria-expanded', 'false');
+            }
+
             $('.oae-lhnavigation').toggleClass('oae-lhnav-expanded');
         };
 

--- a/shared/oae/macros/list.html
+++ b/shared/oae/macros/list.html
@@ -33,7 +33,7 @@
     <div class="oae-list-header">
         <div class="row">
             <div class="col-xs-12{if showSearch} col-sm-8{/if}">
-                <button type="button" class="oae-lhnavigation-toggle btn btn-link pull-left hidden-md hidden-lg">
+                <button type="button" class="oae-lhnavigation-toggle btn btn-link pull-left hidden-md hidden-lg" aria-expanded="false" aria-controls="oae-lhnavigation">
                     <i class="fa fa-bars"></i>
                     <span class="sr-only">__MSG__TOGGLE_NAVIGATION__</span>
                 </button>


### PR DESCRIPTION
When the display of the site is reduced, a menu icon appears to allow users to expand or contract the menu options. Although the menu is collapsed by default, users still navigate through all of the hidden options such as "Upload" before they can even access the icon to expand and contract the menu. Not only does the navigation order need to be changed to allow for the icon to be accessed before the menu options, but the options should be inaccessible to keyboard users (i.e., hidden with CSS display:none) when the menu is collapsed. This ensures that sighted keyboard users won’t navigate through elements that they cannot see.