### PR TITLE
(A11y severity 3) Hide close buttons from screen readers

### DIFF
--- a/node_modules/oae-admin/confirmdialog/confirmdialog.html
+++ b/node_modules/oae-admin/confirmdialog/confirmdialog.html
@@ -5,7 +5,9 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&#215;</span>
+                    </button>
                     <h3 id="confirmdialog-modal-title">${modal.title}</h3>
                 </div>
                 <div class="modal-body">

--- a/node_modules/oae-admin/createuser/createuser.html
+++ b/node_modules/oae-admin/createuser/createuser.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="createuser-modal-title">__MSG__CREATE_USER__</h3>
             </div>
             <form id="createuser-form" class="form-horizontal" role="form">

--- a/node_modules/oae-admin/importusers/importusers.html
+++ b/node_modules/oae-admin/importusers/importusers.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="importusers-modal-title">__MSG__IMPORT_USERS__</h3>
             </div>
             <form id="importusers-form">

--- a/node_modules/oae-admin/manageuser/manageuser.html
+++ b/node_modules/oae-admin/manageuser/manageuser.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="manageuser-modal-title"><!-- --></h3>
             </div>
             <div id="manageuser-tab-container" class="modal-body">

--- a/node_modules/oae-core/aboutcontent/aboutcontent.html
+++ b/node_modules/oae-core/aboutcontent/aboutcontent.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="aboutcontent-modal-title">__MSG__ABOUT__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/aboutdiscussion/aboutdiscussion.html
+++ b/node_modules/oae-core/aboutdiscussion/aboutdiscussion.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="aboutdiscussion-modal-title">__MSG__ABOUT__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/aboutfolder/aboutfolder.html
+++ b/node_modules/oae-core/aboutfolder/aboutfolder.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="aboutfolder-modal-title">__MSG__ABOUT__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/aboutgroup/aboutgroup.html
+++ b/node_modules/oae-core/aboutgroup/aboutgroup.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="aboutgroup-modal-title">__MSG__ABOUT__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/addtofolder/addtofolder.html
+++ b/node_modules/oae-core/addtofolder/addtofolder.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="addtofolder-modal-title">__MSG__ADD_TO_FOLDER__</h3>
             </div>
             <form id="addtofolder-form" role="form">

--- a/node_modules/oae-core/changepic/changepic.html
+++ b/node_modules/oae-core/changepic/changepic.html
@@ -7,7 +7,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="changepic-modal-title">__MSG__PROFILE_PICTURE__</h3>
             </div>
             <form id="changepic-form" role="form">

--- a/node_modules/oae-core/contentshared/contentshared.html
+++ b/node_modules/oae-core/contentshared/contentshared.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="contentshared-modal-title">__MSG__SHARED_WITH__</h3>
             </div>
             <div class="modal-body clearfix">

--- a/node_modules/oae-core/createcollabdoc/createcollabdoc.html
+++ b/node_modules/oae-core/createcollabdoc/createcollabdoc.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="createcollabdoc-modal-title">__MSG__CREATE_DOCUMENT__</h3>
             </div>
             <form id="createcollabdoc-form" role="form">

--- a/node_modules/oae-core/creatediscussion/creatediscussion.html
+++ b/node_modules/oae-core/creatediscussion/creatediscussion.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="creatediscussion-modal-title">__MSG__START_DISCUSSION__</h3>
             </div>
             <form id="creatediscussion-form" role="form">

--- a/node_modules/oae-core/createfolder/createfolder.html
+++ b/node_modules/oae-core/createfolder/createfolder.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="createfolder-modal-title">__MSG__CREATE_FOLDER__</h3>
             </div>
             <form id="createfolder-form" role="form">

--- a/node_modules/oae-core/creategroup/creategroup.html
+++ b/node_modules/oae-core/creategroup/creategroup.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="creategroup-modal-title">__MSG__CREATE_GROUP__</h3>
             </div>
             <form id="creategroup-form" role="form">

--- a/node_modules/oae-core/createlink/createlink.html
+++ b/node_modules/oae-core/createlink/createlink.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="createlink-modal-title">__MSG__ADD_LINKS__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/deletecomment/deletecomment.html
+++ b/node_modules/oae-core/deletecomment/deletecomment.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3>__MSG__DELETE_COMMENT__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/deletefolder/deletefolder.html
+++ b/node_modules/oae-core/deletefolder/deletefolder.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="deletefolder-modal-title">__MSG__DELETE_FOLDER__</h3>
             </div>
             <div id="deletefolder-overview">

--- a/node_modules/oae-core/deleteresource/deleteresource.html
+++ b/node_modules/oae-core/deleteresource/deleteresource.html
@@ -8,7 +8,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="deleteresource-modal-title">
                     {if contextProfile.resourceType === 'discussion'}
                         __MSG__DELETE_DISCUSSION__

--- a/node_modules/oae-core/deleteresources/deleteresources.html
+++ b/node_modules/oae-core/deleteresources/deleteresources.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="deleteresources-modal-title"><!-- --></h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/discussionshared/discussionshared.html
+++ b/node_modules/oae-core/discussionshared/discussionshared.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="discussionshared-modal-title">__MSG__SHARED_WITH__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/editcontent/editcontent.html
+++ b/node_modules/oae-core/editcontent/editcontent.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="editcontent-modal-title">__MSG__EDIT_DETAILS__</h3>
             </div>
             <form id="editcontent-form" role="form">

--- a/node_modules/oae-core/editdiscussion/editdiscussion.html
+++ b/node_modules/oae-core/editdiscussion/editdiscussion.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="editdiscussion-modal-title">__MSG__EDIT_DETAILS__</h3>
             </div>
             <form id="editdiscussion-form">

--- a/node_modules/oae-core/editfolder/editfolder.html
+++ b/node_modules/oae-core/editfolder/editfolder.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="editfolder-modal-title">__MSG__EDIT_DETAILS__</h3>
             </div>
             <form id="editfolder-form">

--- a/node_modules/oae-core/editgroup/editgroup.html
+++ b/node_modules/oae-core/editgroup/editgroup.html
@@ -3,7 +3,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="editgroup-modal-title">__MSG__EDIT_DETAILS__</h3>
             </div>
             <form id="editgroup-form" role="form">

--- a/node_modules/oae-core/editprofile/editprofile.html
+++ b/node_modules/oae-core/editprofile/editprofile.html
@@ -3,7 +3,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="editprofile-modal-title">__MSG__EDIT_DETAILS__</h3>
             </div>
             <form id="editprofile-form" role="form">

--- a/node_modules/oae-core/foldercontentvisibility/foldercontentvisibility.html
+++ b/node_modules/oae-core/foldercontentvisibility/foldercontentvisibility.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="foldercontentvisibility-modal-title">__MSG__UPDATE_VISIBILITY__</h3>
             </div>
             <div id="foldercontentvisibility-overview">

--- a/node_modules/oae-core/foldershared/foldershared.html
+++ b/node_modules/oae-core/foldershared/foldershared.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="foldershared-modal-title">__MSG__SHARED_WITH__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/leavegroup/leavegroup.html
+++ b/node_modules/oae-core/leavegroup/leavegroup.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="leavegroup-modal-title">__MSG__LEAVE_GROUP__</h3>
             </div>
             <div id="leavegroup-modal-content"><!-- --></div>

--- a/node_modules/oae-core/manageaccess/manageaccess.html
+++ b/node_modules/oae-core/manageaccess/manageaccess.html
@@ -7,7 +7,9 @@
         <div class="modal-content">
             <form role="form">
                 <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&#215;</span>
+                    </button>
                     <h3 id="manageaccess-modal-title">__MSG__MANAGE_ACCESS__</h3>
                 </div>
                 <div class="modal-body">

--- a/node_modules/oae-core/preferences/preferences.html
+++ b/node_modules/oae-core/preferences/preferences.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="preferences-modal-title">__MSG__MY_PREFERENCES__</h3>
             </div>
 

--- a/node_modules/oae-core/register/register.html
+++ b/node_modules/oae-core/register/register.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="register-modal-title">__MSG__SIGN_UP__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/revisions/revisions.html
+++ b/node_modules/oae-core/revisions/revisions.html
@@ -7,7 +7,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="revisions-modal-title">__MSG__REVISION_HISTORY__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/share/share.html
+++ b/node_modules/oae-core/share/share.html
@@ -3,7 +3,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="share-modal-title">__MSG__SHARE__</h3>
             </div>
             <form id="share-form" role="form">

--- a/node_modules/oae-core/termsandconditions/termsandconditions.html
+++ b/node_modules/oae-core/termsandconditions/termsandconditions.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="termsandconditions-modal-title">__MSG__TERMS_AND_CONDITIONS__</h3>
             </div>
             <div class="modal-body"><!-- --></div>

--- a/node_modules/oae-core/unfollow/unfollow.html
+++ b/node_modules/oae-core/unfollow/unfollow.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="createlink-modal-title">__MSG__UNFOLLOW__</h3>
             </div>
             <div class="modal-body">

--- a/node_modules/oae-core/upload/upload.html
+++ b/node_modules/oae-core/upload/upload.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="upload-modal-title">__MSG__UPLOAD_FILES__</h3>
             </div>
             <div class="modal-body"><!-- --></div>

--- a/node_modules/oae-core/uploadnewversion/uploadnewversion.html
+++ b/node_modules/oae-core/uploadnewversion/uploadnewversion.html
@@ -6,7 +6,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&#215;</button>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&#215;</span>
+                </button>
                 <h3 id="uploadnewversion-modal-title">__MSG__UPLOAD_NEW_VERSION__</h3>
             </div>
             <form id="uploadnewversion-form" role="form">


### PR DESCRIPTION
The "close" buttons (), although they are marked up with `aria-hidden="true"`, are still navigated to by screen readers with no content read for them. This is because standard navigable elements (such as `<button>`) cannot be hidden with `aria-hidden`. Address this by removing `aria=hidden="true"` or by replacing the `<button>` elements with elements that will not receive keyboard focus (e.g., `<div onclick…>`) and maintaining `aria-hidden`.