### PR TITLE
(A11y severity 3) Add markup hierarchy to comment threads

### DIFF
--- a/node_modules/oae-core/comments/comments.html
+++ b/node_modules/oae-core/comments/comments.html
@@ -3,7 +3,7 @@
 
 <!-- CONTENT -->
 <div class="comments-widget">
-    <ul id="comments-container" class="media-list"><!-- --></ul>
+    <ul id="comments-container" class="media-list" role="list"><!-- --></ul>
 </div>
 
 <div id="comments-new-comment-template"><!--
@@ -30,7 +30,7 @@
 <div id="comments-comment-template"><!--
     {for comment in results}
         {var commentLevel = comment.level > 2 ? 2 : comment.level}
-        <li id="${comment.threadKey}" class="media comments-level-${commentLevel} {if !comment.body} deleted{/if}" data-id="${comment.created}">
+        <li id="${comment.threadKey}" class="media comments-level-${commentLevel} {if !comment.body} deleted{/if}" data-id="${comment.created}" role="listitem" aria-level="${commentLevel+1}">
             <div class="comments-thumbnail">
                 ${renderThumbnail(comment.createdBy || 'user')}
             </div>


### PR DESCRIPTION
While nested comments are apparent visually, there is no indication of these relationships available to screen readers.
 A nested relationship could be conveyed through the use of either unordered lists or by heading structure. Unordered lists may be the most appropriate in this situation since the first comment begins with a fourth-level heading which doesn’t leave much room for sub-headings. Using unordered lists would provide the nesting concept by ensuring that each sub-comment is a list item for each parent comment. No changes to the visual presentation would be necessary (styles can be used to suppress the list bullets, etc.). Present the nested relationship information to users in a way that conveys the same information available visually.