### PR TITLE
Add editor role to the UI

### DIFF
--- a/node_modules/oae-core/aboutcontent/tests/aboutcontent.js
+++ b/node_modules/oae-core/aboutcontent/tests/aboutcontent.js
@@ -120,7 +120,7 @@ casper.test.begin('Widget - About Content', function(test) {
                 // Create a link
                 contentUtil.createLink('Test link title', 'Test link description', null, 'http://www.oaeproject.org', null, [user2.id], null, function(err, linkProfile) {
                     // Create a collaborative document
-                    contentUtil.createCollabDoc('Test collabdoc title', 'Test collabdoc description', null, null, [user2.id], null, function(err, collabdocProfile) {
+                    contentUtil.createCollabDoc('Test collabdoc title', 'Test collabdoc description', null, null, [user2.id], null, null, function(err, collabdocProfile) {
                         // Log out from user 1
                         userUtil.doLogOut();
 

--- a/node_modules/oae-core/createcollabdoc/js/createcollabdoc.js
+++ b/node_modules/oae-core/createcollabdoc/js/createcollabdoc.js
@@ -21,7 +21,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
         var $rootel = $('#' + uid);
 
         // Variable that keeps track of the people and groups to share this document with
-        var managers = [];
+        var editors = [];
         // Variable that keeps track of the folders to add this document to
         var folders = [];
 
@@ -110,10 +110,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
                 // Update visibility for document
                 visibility = data.visibility;
 
-                // TODO: Make the users/groups this is being shared with editors instead
-                // of managers. As currently only managers can edit the document, we make
-                // them managers
-                managers = data.shared;
+                editors = data.shared;
                 folders = data.folders;
 
                 // Add the permissions summary
@@ -158,7 +155,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
 
             var displayName = $.trim($('#createcollabdoc-name', $rootel).val());
 
-            oae.api.content.createCollabDoc(displayName, '', visibility, managers, [], folders, function (err, data) {
+            oae.api.content.createCollabDoc(displayName, '', visibility, [], editors, [], folders, function (err, data) {
                 // If the creation succeeded, redirect to the document
                 if (!err) {
                     window.location = data.profilePath;

--- a/node_modules/oae-core/createcollabdoc/js/createcollabdoc.js
+++ b/node_modules/oae-core/createcollabdoc/js/createcollabdoc.js
@@ -21,7 +21,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
         var $rootel = $('#' + uid);
 
         // Variable that keeps track of the people and groups to share this document with
-        var editors = [];
+        var managers = [];
         // Variable that keeps track of the folders to add this document to
         var folders = [];
 
@@ -110,7 +110,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
                 // Update visibility for document
                 visibility = data.visibility;
 
-                editors = data.shared;
+                managers = data.shared;
                 folders = data.folders;
 
                 // Add the permissions summary
@@ -155,7 +155,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
 
             var displayName = $.trim($('#createcollabdoc-name', $rootel).val());
 
-            oae.api.content.createCollabDoc(displayName, '', visibility, [], editors, [], folders, function (err, data) {
+            oae.api.content.createCollabDoc(displayName, '', visibility, managers, [], [], folders, function (err, data) {
                 // If the creation succeeded, redirect to the document
                 if (!err) {
                     window.location = data.profilePath;

--- a/node_modules/oae-core/deleteresource/tests/deleteresource.js
+++ b/node_modules/oae-core/deleteresource/tests/deleteresource.js
@@ -92,7 +92,7 @@ casper.test.begin('Widget - Delete resource', function(test) {
                         // Create a discussion
                         discussionUtil.createDiscussion(null, null, null, null, null, function(err, discussionProfile) {
                             // Create a collaborative document
-                            contentUtil.createCollabDoc(null, null, null, null, null, null, function(err, collabdocProfile) {
+                            contentUtil.createCollabDoc(null, null, null, null, null, null, null, function(err, collabdocProfile) {
                                 // Verify that the delete resource modal opens
                                 uiUtil.openContentProfile(contentProfile);
                                 casper.then(function() {

--- a/node_modules/oae-core/etherpad/js/etherpad.js
+++ b/node_modules/oae-core/etherpad/js/etherpad.js
@@ -70,7 +70,7 @@ define(['jquery', 'oae.core'], function($, oae) {
          * viewers of the document will be shown the document's content in view mode.
          */
         var setUpEtherpad = function() {
-            if (contentObj.isManager) {
+            if (contentObj.isManager || contentObj.isEditor) {
                 showEditMode();
 
                 // The Etherpad iFrame is removed to avoid the 'Reconnecting Pad' message showing up.

--- a/node_modules/oae-core/filepreview/tests/filepreview.js
+++ b/node_modules/oae-core/filepreview/tests/filepreview.js
@@ -65,7 +65,7 @@ casper.test.begin('Widget - File preview', function(test) {
 
             contentUtil.createFile(null, null, null, null, null, null, function(err, content1Profile) {
                 contentUtil.createFile(null, null, null, 'tests/casperjs/data/sample-video.mp4', null, null, function(err, content2Profile) {
-                    contentUtil.createCollabDoc(null, null, null, null, null, null, function(err, collabdocProfile) {
+                    contentUtil.createCollabDoc(null, null, null, null, null, null, null, function(err, collabdocProfile) {
                         // Verify image previews
                         uiUtil.openContentProfile(content1Profile);
                         casper.then(function() {

--- a/node_modules/oae-core/manageaccess/js/manageaccess.js
+++ b/node_modules/oae-core/manageaccess/js/manageaccess.js
@@ -354,7 +354,7 @@ define(['jquery', 'oae.core', 'jquery.autosuggest'], function($, oae) {
          * @param  {String}     data.messages.privateDescription        Translated description for the `private` visibility option in the visibility panel
          * @param  {String}     data.messages.loggedinDescription       Translated description for the `loggedin` visibility option in the visibility panel
          * @param  {String}     data.messages.publicDescription         Translated description for the `public` visibility option in the visibility panel
-         * @param  {Object}     data.roles                              The available roles for members keyed by the role id where the values represent the translated role name
+         * @param  {Object[]}   data.roles                              The available roles for members has 2 properties: `id` and `name`
          */
         var initManageAccess = function(ev, data) {
             // Initialize the widget variables that cache context data

--- a/node_modules/oae-core/manageaccess/manageaccess.html
+++ b/node_modules/oae-core/manageaccess/manageaccess.html
@@ -68,7 +68,7 @@
             <label for="manageaccess-${member.id}-role" class="sr-only">__MSG__SELECT_ROLE_FOR_USER__</label>
             <select id="manageaccess-${member.id}-role" class="form-control" data-id="${member.id}">
                 {for role in roles}
-                    <option value="${role_index}" {if member.role === role_index}selected="true"{/if}>${role}</option>
+                    <option value="${role.id}" {if member.role === role.id}selected="true"{/if}>${role.name}</option>
                 {/for}
             </select>
         </div>
@@ -131,7 +131,7 @@
     <div class="form-group clearfix">
         <select id="manageaccess-share-role" class="pull-right form-control">
             {for role in roles}
-                <option value="${role_index}" {if defaultRole === role_index} selected="true"{/if}>${role}</option>
+                <option value="${role.id}" {if defaultRole === role.id} selected="true"{/if}>${role.name}</option>
             {/for}
         </select>
         <h4>

--- a/node_modules/oae-core/revisions/tests/revisions.js
+++ b/node_modules/oae-core/revisions/tests/revisions.js
@@ -102,7 +102,7 @@ casper.test.begin('Widget - Revisions', function(test) {
             userUtil.doLogIn(user1.username, user1.password);
 
             contentUtil.createFile(null, null, null, null, null, null, function(err, contentProfile) {
-                contentUtil.createCollabDoc(null, null, null, null, null, null, function(err, collabdocProfile) {
+                contentUtil.createCollabDoc(null, null, null, null, null, null, null, function(err, collabdocProfile) {
 
                     uiUtil.openContentProfile(contentProfile);
 

--- a/shared/oae/api/oae.api.content.js
+++ b/shared/oae/api/oae.api.content.js
@@ -237,6 +237,7 @@ define(['exports', 'jquery', 'underscore', 'oae.api.i18n', 'mimetypes'], functio
      * @param  {String}       [description]       The collaborative document's description
      * @param  {String}       [visibility]        The collaborative document's visibility. This can be public, loggedin or private
      * @param  {String[]}     [managers]          Array of user/group ids that should be added as managers to the collaborative document
+     * @param  {String[]}     [editors]           Array of user/group ids that should be added as editors to the collaborative document
      * @param  {String[]}     [viewers]           Array of user/group ids that should be added as viewers to the collaborative document
      * @param  {String[]}     [folders]           Array of folder ids to which the collaborative document should be added
      * @param  {Function}     [callback]          Standard callback function
@@ -244,7 +245,7 @@ define(['exports', 'jquery', 'underscore', 'oae.api.i18n', 'mimetypes'], functio
      * @param  {Content}      [callback.content]  Content object representing the created collaborative document
      * @throws {Error}                            Error thrown when not all of the required parameters have been provided
      */
-    var createCollabDoc = exports.createCollabDoc = function(displayName, description, visibility, managers, viewers, folders, callback) {
+    var createCollabDoc = exports.createCollabDoc = function(displayName, description, visibility, managers, editors, viewers, folders, callback) {
         if (!displayName) {
             throw new Error('A valid document name should be provided');
         }
@@ -258,6 +259,7 @@ define(['exports', 'jquery', 'underscore', 'oae.api.i18n', 'mimetypes'], functio
             'description': description,
             'visibility': visibility,
             'managers': managers,
+            'editors': editors,
             'viewers': viewers,
             'folders': folders
         };

--- a/shared/oae/bundles/ui/default.properties
+++ b/shared/oae/bundles/ui/default.properties
@@ -210,6 +210,7 @@ AUTHORING_EXPERIENCE = Authoring Experiences
 A_POWERFULL_NEW_WAY_FOR_STUDENTS_AND_FACULTY_TO_CREATE_KNOWLEDGE_COLLABORATE_AND_CONNECT_WITH_THE_WORLD = A powerful new way for students and faculty to create knowledge, collaborate and connect with the world
 BROWSE = Browse
 CANCEL = Cancel
+CAN_EDIT = Can edit
 CAN_MANAGE = Can manage
 CAN_VIEW = Can view
 CAUTION_THIS_ACTION_CANNOT_BE_UNDONE = <strong>Caution:</strong> this action cannot be undone!

--- a/shared/oae/macros/tests/metadata.js
+++ b/shared/oae/macros/tests/metadata.js
@@ -74,7 +74,7 @@ casper.test.begin('Macro - List Metadata', function(test) {
                             // Create a link
                             contentUtil.createLink(null, null, null, 'http://www.oaeproject.org', null, null, null, function(err, linkProfile) {
                                 // Create a collaborative document
-                                contentUtil.createCollabDoc(null, null, null, null, null, null, function(err, collabdocProfile) {
+                                contentUtil.createCollabDoc(null, null, null, null, null, null, null, function(err, collabdocProfile) {
                                     // Create a discussion
                                     discussionUtil.createDiscussion(null, null, null, null, null, function(err, discussionProfile) {
                                         // Create a group

--- a/tests/casperjs/util/include/content.js
+++ b/tests/casperjs/util/include/content.js
@@ -222,13 +222,14 @@ var contentUtil = (function() {
      * @param  {String}       [description]         The collabdoc's description
      * @param  {String}       [visibility]          The collabdoc's visibility. This can be public, loggedin or private
      * @param  {String[]}     [managers]            Array of user/group ids that should be added as managers to the collabdoc
+     * @param  {String[]}     [editors]             Array of user/group ids that should be added as editors to the collabdoc
      * @param  {String[]}     [viewers]             Array of user/group ids that should be added as viewers to the collabdoc
      * @param  {String[]}     [folders]             Array of folder ids to which the collaborative document should be added
      * @param  {Function}     callback              Standard callback method
      * @param  {Object}       [callback.err]        Error object containing error code and error message
      * @param  {Content}      [callback.content]    Content object representing the created collabdoc
      */
-    var createCollabDoc = function(displayName, description, visibility, managers, viewers, folders, callback) {
+    var createCollabDoc = function(displayName, description, visibility, managers, editors, viewers, folders, callback) {
         casper.then(function() {
             var collabdocProfile = null;
             var err = null;
@@ -236,10 +237,11 @@ var contentUtil = (function() {
             description = description || '';
             visibility = visibility || 'public';
             managers = managers || [];
+            editors = editors || [];
             viewers = viewers || [];
             folders = folders || [];
 
-            mainUtil.callInternalAPI('content', 'createCollabDoc', [displayName, description, visibility, managers, viewers, folders], function(_err, _collabdocProfile) {
+            mainUtil.callInternalAPI('content', 'createCollabDoc', [displayName, description, visibility, managers, editors, viewers, folders], function(_err, _collabdocProfile) {
                 if (_err) {
                     casper.echo('Could not create ' + displayName + '. Error ' + _err.code + ': ' + _err.msg, 'ERROR');
                     err = _err;

--- a/ui/js/content.js
+++ b/ui/js/content.js
@@ -307,7 +307,7 @@ require(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
         // collabdocs have a special editor role
         if (contentProfile.resourceSubType === 'collabdoc') {
             widgetData.roles.editor = oae.api.i18n.translate('__MSG__CAN_EDIT__');
-            widgetData.defaultRole = 'editor';
+            widgetData.defaultRole = 'manager';
         }
         return widgetData;
     };

--- a/ui/js/content.js
+++ b/ui/js/content.js
@@ -294,19 +294,19 @@ require(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
             'contextProfile': contentProfile,
             'messages': getManageAccessMessages(),
             'defaultRole': 'viewer',
-            'roles': {
-                'viewer': oae.api.i18n.translate('__MSG__CAN_VIEW__'),
-                'manager': oae.api.i18n.translate('__MSG__CAN_MANAGE__')
-            },
+            'roles': [
+                {'id': 'viewer', 'name': oae.api.i18n.translate('__MSG__CAN_VIEW__')},
+                {'id': 'manager', 'name': oae.api.i18n.translate('__MSG__CAN_MANAGE__')}
+            ],
             'api': {
                 'getMembersURL': '/api/content/'+ contentProfile.id + '/members',
                 'setMembers': oae.api.content.updateMembers,
                 'setVisibility': oae.api.content.updateContent
             }
         };
-        // collabdocs have a special editor role
+        // Collabdocs have a special editor role
         if (contentProfile.resourceSubType === 'collabdoc') {
-            widgetData.roles.editor = oae.api.i18n.translate('__MSG__CAN_EDIT__');
+            widgetData.roles.splice(1, 0, {'id': 'editor', 'name': oae.api.i18n.translate('__MSG__CAN_EDIT__')});
             widgetData.defaultRole = 'manager';
         }
         return widgetData;

--- a/ui/js/content.js
+++ b/ui/js/content.js
@@ -290,10 +290,10 @@ require(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
      * @see manageaccess#initManageAccess
      */
     var getManageAccessData = function() {
-        return {
+        var widgetData = {
             'contextProfile': contentProfile,
             'messages': getManageAccessMessages(),
-            'defaultRole': contentProfile.resourceSubType === 'collabdoc' ? 'manager' : 'viewer',
+            'defaultRole': 'viewer',
             'roles': {
                 'viewer': oae.api.i18n.translate('__MSG__CAN_VIEW__'),
                 'manager': oae.api.i18n.translate('__MSG__CAN_MANAGE__')
@@ -304,6 +304,12 @@ require(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
                 'setVisibility': oae.api.content.updateContent
             }
         };
+        // collabdocs have a special editor role
+        if (contentProfile.resourceSubType === 'collabdoc') {
+            widgetData.roles.editor = oae.api.i18n.translate('__MSG__CAN_EDIT__');
+            widgetData.defaultRole = 'editor';
+        }
+        return widgetData;
     };
 
     /**

--- a/ui/tests/content.js
+++ b/ui/tests/content.js
@@ -167,7 +167,7 @@ casper.test.begin('Page - Content', function(test) {
 
             contentUtil.createFile(null, null, null, null, null, [user2.id], function(err, contentProfile) {
                 contentUtil.createLink(null, null, null, null, null, [user2.id], null, function(err, linkProfile) {
-                    contentUtil.createCollabDoc(null, null, null, null, [user2.id], null, function(err, collabdocProfile) {
+                    contentUtil.createCollabDoc(null, null, null, null, [user2.id], null, null, function(err, collabdocProfile) {
                         ///////////
                         // FILES //
                         ///////////


### PR DESCRIPTION
- When managing the members of a collaborative document, the "Can edit" role should be available as one of the roles
- When sharing a collaborative document as a manager, the editor role should be available as one of the roles in the dropdown
- When sharing a collaborative document as an editor, the editor role should be available as one of the roles in the dropdown
- When creating a new collaborative document, all groups and users the item is shared with should become editors