### PR TITLE
Weird blue border around folder selection

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -50,10 +50,16 @@ a.oae-plain-link:hover {
  * Style that can be used to fake focus on an element. This can for example
  * be used when a hidden element needs to provide visual feedback on a different element.
  */
+
 .oae-focus {
     outline: thin dotted #333;
-    outline: 5px auto -webkit-focus-ring-color;
     outline-offset: -2px;
+}
+
+a.oae-focus,
+.btn.oae-focus,
+input.oae-focus {
+    outline: 5px auto -webkit-focus-ring-color;
 }
 
 

--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -57,8 +57,8 @@ a.oae-plain-link:hover {
 }
 
 a.oae-focus,
-.btn.oae-focus,
-input.oae-focus {
+input.oae-focus,
+.btn.oae-focus {
     outline: 5px auto -webkit-focus-ring-color;
 }
 


### PR DESCRIPTION
I have 1 folder shared with me.

I went into a collaborative document and selected to "Add to Folder". When I select the folder to which I want to add it, it gets a weird asymmetric blue border. Notice that I have switched focus to the "My Library" tab, which indicates that the blue border is *not* the browser's focus border.

![screen shot 2015-02-26 at 11 27 50 am](https://butt.githubusercontent.com/assets/102265/6399993/f28dea28-bdaa-11e4-967b-402f4819031c.png)

Chrome 40.0.2214.111 Mac OSX