### PR TITLE
Wait for body to be visible before applying $.dotdotdot

### DIFF
--- a/shared/oae/api/oae.api.js
+++ b/shared/oae/api/oae.api.js
@@ -129,7 +129,7 @@ define(['oae.api.admin', 'oae.api.authentication', 'oae.api.config', 'oae.api.co
                                     oae.api.widget.loadWidgets(null, null, null, function() {
                                         // We can show the body as internationalization and
                                         // initial widget loading have finished
-                                        $('body').show();
+                                        $('body').css('visibility', 'visible');
 
                                         // Initialize websocket push API, unless we're on the
                                         // global admin tenant

--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -20,10 +20,10 @@
 /* FULL-WIDTH LAYOUT */
 
 body {
+    min-width: 400px;
     padding-left: 30px;
     padding-right: 30px;
-    min-width: 400px;
-    display: none;
+    visibility: hidden;
 }
 
 @media (max-width : 480px) {

--- a/shared/oae/js/jquery-plugins/jquery.infinitescroll.js
+++ b/shared/oae/js/jquery-plugins/jquery.infinitescroll.js
@@ -100,30 +100,39 @@ define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n', 'oae.api.l10n'],
         };
 
         /**
+         * Helper function that postpones doing something until the body is visible
+         */
+        var whenVisible = function(callback) {
+            if (!$('body').is(':visible')) {
+                setTimeout(whenVisible, 100, callback);
+            } else {
+                callback();
+            }
+        }
+
+        /**
          * Function that checks whether the current scroll position is within a certain distance
          * of the end of the page or the end of the scroll container. If it is, we load the next set of results.
          */
         var checkLoadNext = function() {
-            // If the body isn't visible yet, the page is still being loaded. Postpone
-            // checking whether or not the next set of results should be loaded
-            if (!$('body').is(':visible')) {
-                setTimeout(checkLoadNext, 100);
-            // We only check if a new set of results should be loaded if a search
-            // is not in progress and if the container has not been killed
-            } else if (canRequestMoreData && ($listContainer && $listContainer.is(':visible'))) {
-                // In case we use the body
-                var threshold = 500;
-                var pixelsRemainingUntilBottom = $(document).height() - $(window).height() - $(window).scrollTop();
-                // In case we use a scroll container
-                if (options.scrollContainer) {
-                    threshold = 200;
-                    pixelsRemainingUntilBottom = options.scrollContainer.prop('scrollHeight') - options.scrollContainer.height() - options.scrollContainer.scrollTop();
+            whenVisible(function() {
+                // We only check if a new set of results should be loaded if a search
+                // is not in progress and if the container has not been killed
+                if (canRequestMoreData && ($listContainer && $listContainer.is(':visible'))) {
+                    // In case we use the body
+                    var threshold = 500;
+                    var pixelsRemainingUntilBottom = $(document).height() - $(window).height() - $(window).scrollTop();
+                    // In case we use a scroll container
+                    if (options.scrollContainer) {
+                        threshold = 200;
+                        pixelsRemainingUntilBottom = options.scrollContainer.prop('scrollHeight') - options.scrollContainer.height() - options.scrollContainer.scrollTop();
+                    }
+                    // Check if this is close enough to the bottom to kick off a new item load
+                    if (pixelsRemainingUntilBottom <= threshold) {
+                        loadResultList();
+                    }
                 }
-                // Check if this is close enough to the bottom to kick off a new item load
-                if (pixelsRemainingUntilBottom <= threshold) {
-                    loadResultList();
-                }
-            }
+            });
         };
 
         ////////////////////
@@ -264,9 +273,9 @@ define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n', 'oae.api.l10n'],
                 // Apply timeago to the `oae-timeago` elements in the output container
                 oaeL10n.timeAgo($listContainer);
 
-                // Apply multi-line threedotting to the tile titles
-                $('.oae-tile h3').dotdotdot({
-                    watch: 'window'
+                // Apply multi-line threedotting to the tile titles when the body becomes visible
+                whenVisible(function() {
+                    $('.oae-tile h3').dotdotdot({'watch': 'window'});
                 });
             }
         };

--- a/shared/oae/js/jquery-plugins/jquery.infinitescroll.js
+++ b/shared/oae/js/jquery-plugins/jquery.infinitescroll.js
@@ -100,39 +100,26 @@ define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n', 'oae.api.l10n'],
         };
 
         /**
-         * Helper function that postpones doing something until the body is visible
-         */
-        var whenVisible = function(callback) {
-            if (!$('body').is(':visible')) {
-                setTimeout(whenVisible, 100, callback);
-            } else {
-                callback();
-            }
-        }
-
-        /**
          * Function that checks whether the current scroll position is within a certain distance
          * of the end of the page or the end of the scroll container. If it is, we load the next set of results.
          */
         var checkLoadNext = function() {
-            whenVisible(function() {
-                // We only check if a new set of results should be loaded if a search
-                // is not in progress and if the container has not been killed
-                if (canRequestMoreData && ($listContainer && $listContainer.is(':visible'))) {
-                    // In case we use the body
-                    var threshold = 500;
-                    var pixelsRemainingUntilBottom = $(document).height() - $(window).height() - $(window).scrollTop();
-                    // In case we use a scroll container
-                    if (options.scrollContainer) {
-                        threshold = 200;
-                        pixelsRemainingUntilBottom = options.scrollContainer.prop('scrollHeight') - options.scrollContainer.height() - options.scrollContainer.scrollTop();
-                    }
-                    // Check if this is close enough to the bottom to kick off a new item load
-                    if (pixelsRemainingUntilBottom <= threshold) {
-                        loadResultList();
-                    }
+            // We only check if a new set of results should be loaded if a search
+            // is not in progress and if the container has not been killed
+            if (canRequestMoreData && ($listContainer && $listContainer.is(':visible'))) {
+                // In case we use the body
+                var threshold = 500;
+                var pixelsRemainingUntilBottom = $(document).height() - $(window).height() - $(window).scrollTop();
+                // In case we use a scroll container
+                if (options.scrollContainer) {
+                    threshold = 200;
+                    pixelsRemainingUntilBottom = options.scrollContainer.prop('scrollHeight') - options.scrollContainer.height() - options.scrollContainer.scrollTop();
                 }
-            });
+                // Check if this is close enough to the bottom to kick off a new item load
+                if (pixelsRemainingUntilBottom <= threshold) {
+                    loadResultList();
+                }
+            }
         };
 
         ////////////////////
@@ -273,10 +260,8 @@ define(['jquery', 'underscore', 'oae.api.util', 'oae.api.i18n', 'oae.api.l10n'],
                 // Apply timeago to the `oae-timeago` elements in the output container
                 oaeL10n.timeAgo($listContainer);
 
-                // Apply multi-line threedotting to the tile titles when the body becomes visible
-                whenVisible(function() {
-                    $('.oae-tile h3').dotdotdot({'watch': 'window'});
-                });
+                // Apply multi-line threedotting to the tile titles
+                $('.oae-tile h3').dotdotdot({'watch': 'window'});
             }
         };
 


### PR DESCRIPTION
There was a race condition where the $.dotdotdot plugin gets invoked while the body is not made visible yet. This change re-uses another area of `search.js` that seems to be listening for the same quirk.

Since `$('body').show()` seems to be in nature asynchronous, so it would be good to take some kind of event-driven approach to better trigger when the widgets have loaded.