### PR TITLE
(Issue #3986) Don't disable the file upload input when the form is submit

### DIFF
--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -47,6 +47,17 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
         ///////////////
 
         /**
+         * Determine which elements should be disabled / enabled when the upload form has been
+         * submit or reset. The result is a jQuery object representing the elements that can be
+         * enabled or disabled
+         */
+        var $toDisable = function() {
+            // Do not disable the file input element, as that will cause IE9 to drop it from the
+            // DOM and not submit its file content to the server
+            return $('#upload-modal *').not('input[type="file"]');
+        };
+
+        /**
          * Reset the state of the widget when the modal dialog has been closed
          */
         var reset = function() {
@@ -71,7 +82,7 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
             $('#upload-modal > .modal-footer', $rootel).show();
 
             // Reset controls
-            $('#upload-modal *', $rootel).prop('disabled', false);
+            $toDisable().prop('disabled', false);
             $('#upload-upload', $rootel).hide();
             $('#upload-permissions', $rootel).hide();
 
@@ -406,6 +417,8 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
                 'url': '/api/content/create',
                 'dropZone': $('#upload-dropzone', $rootel),
                 'forceIframeTransport': useIframeTransport,
+                // This is mandatory for browsers that require the iframe transport (i.e., IE9)
+                'replaceFileInput': false,
                 // Drop is fired when a user drops files on the dropzone
                 'drop': function(ev, data) {
                     // Ensure at least one file is valid
@@ -471,7 +484,7 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
                 }
 
                 // Disable editing on upload
-                $('#upload-modal *', $rootel).prop('disabled', true);
+                $toDisable().prop('disabled', true);
                 $('.jeditable-field', $rootel).editable('destroy');
                 $('[rel="tooltip"]', $rootel).tooltip('destroy');
 


### PR DESCRIPTION
`replaceFileInput` was still necessary. Verified file upload still works on Firefox, as removing it had something to do w/ Firefox.