### PR TITLE
(Issue #3985) Fix uneven width on jeditable list items

### DIFF
--- a/node_modules/oae-core/createlink/css/createlink.css
+++ b/node_modules/oae-core/createlink/css/createlink.css
@@ -29,11 +29,15 @@
     margin: 12px 0 0;
 }
 
-#createlink-modal .jeditable-field form input {
-    width: 370px !important;
+/* Add an IE9 fallback for threedots */
+
+.ie-lt10 #createlink-modal .oae-list-compact-item > .oae-listitem > div.oae-listitem-metadata > h3 {
+    width: auto !important;
 }
 
-/* Add an IE9 fallback for threedots */
+.ie-lt10 #createlink-modal .jeditable-field form input {
+    width: 370px !important;
+}
 
 @media (min-width: 550px) {
     .ie-lt10 #createlink-modal .jeditable-field {

--- a/node_modules/oae-core/createlink/js/createlink.js
+++ b/node_modules/oae-core/createlink/js/createlink.js
@@ -230,7 +230,16 @@ define(['jquery', 'oae.core', 'jquery.jeditable'], function($, oae) {
             // Apply jEditable for inline editing of link names
             $('.jeditable-field', $rootel).editable(editableSubmitted, {
                 'onblur': 'submit',
-                'select' : true
+                'select' : true,
+                'onedit': function(settings, field) {
+                    $(field).parent('h3').width('100%');
+                },
+                'onsubmit': function(settings, field) {
+                    $(field).parent('h3').width('auto');
+                },
+                'onreset': function(settings, field) {
+                    $(field).parent('h3').width('auto');
+                }
             });
 
             // Apply jQuery Tooltip to the link title field to show that the fields are editable.

--- a/node_modules/oae-core/upload/css/upload.css
+++ b/node_modules/oae-core/upload/css/upload.css
@@ -46,6 +46,14 @@
 
 /* Add an IE9 fallback for threedots */
 
+.ie-lt10 #upload-modal .oae-list-compact-item > .oae-listitem > div.oae-listitem-metadata > h3 {
+    width: auto !important;
+}
+
+.ie-lt10 #upload-modal .jeditable-field form input {
+    width: 370px !important;
+}
+
 @media (min-width: 550px) {
     .ie-lt10 #upload-modal .jeditable-field {
         max-width: 375px !important;
@@ -56,10 +64,6 @@
     .ie-lt10 #upload-modal .jeditable-field {
         max-width: 220px !important;
     }
-}
-
-#upload-modal .jeditable-field form input {
-    width: 370px !important;
 }
 
 /* Permissions */

--- a/node_modules/oae-core/upload/js/upload.js
+++ b/node_modules/oae-core/upload/js/upload.js
@@ -271,7 +271,16 @@ define(['jquery', 'oae.core', 'jquery.fileupload', 'jquery.iframe-transport', 'j
             // Apply jEditable for inline editing of file names
             $('.jeditable-field', $rootel).editable(editableSubmitted, {
                 'onblur': 'submit',
-                'select' : true
+                'select' : true,
+                'onedit': function(settings, field) {
+                    $(field).parent('h3').width('100%');
+                },
+                'onsubmit': function(settings, field) {
+                    $(field).parent('h3').width('auto');
+                },
+                'onreset': function(settings, field) {
+                    $(field).parent('h3').width('auto');
+                }
             });
 
             // Apply jQuery Tooltip to the file title field to show that the fields are editable.

--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -264,6 +264,7 @@ input.search-query {
     margin-top: -4px;
     outline: none;
     padding: 0;
+    width: 100%;
 }
 
 .modal .jeditable-field form input::-ms-clear {


### PR DESCRIPTION
I've fixed the jeditable width issue for all non-ie9 browsers. For IE9 the fluid width of the text field was always an issue, which is why we wound up with the fixed widths in the first place. This change makes it so that all modern browsers can have fluid width text fields that are the full width of the list item.
