### PR TITLE
Group descriptions should wrap on their profile page

### DIFF
--- a/node_modules/oae-core/groupprofile/css/groupprofile.css
+++ b/node_modules/oae-core/groupprofile/css/groupprofile.css
@@ -15,6 +15,7 @@
 
 .groupprofile-widget .groupprofile-description {
     white-space: pre-wrap;
+    word-wrap: break-word;
 }
 
 .groupprofile-widget .groupprofile-description,


### PR DESCRIPTION
Given the text `ThisIsSomeReallyLongTextWithoutASpaceOrLinebreakToSeeHowItRespondsWithWrapping` I get the following in Chrome (OS X):

![](https://cldup.com/9LsfsJT5Ul-3000x3000.png)

Some word wrapping should be applied