### PR TITLE
When an error occurs during manageacces, removed members still stay cached for adding users

### DIFF
--- a/node_modules/oae-core/manageaccess/js/manageaccess.js
+++ b/node_modules/oae-core/manageaccess/js/manageaccess.js
@@ -27,10 +27,24 @@ define(['jquery', 'oae.core', 'jquery.autosuggest'], function($, oae) {
         // Caches the visibility of the context (e.g. group/content/discussion/...)
         var visibility = null;
 
-        // Caches the member updates that need to be applied
+        // Caches the member updates that need to be applied. Each key is a
+        // member (user or group) id and its value is the role for that member.
+        // A value of `false` deletes the member from the group entirely. This
+        // object is sent to the server via an API call, so all updates should
+        // be relative to the server state.
         var membersUpdates = {};
         
-        // Caches members pending addition
+        // Caches members pending addition. This is distinct from `membersUpdates`
+        // to handle deletion. If a member that the user decides to delete is
+        // already a full member of the group, then we have to use the API to
+        // delete that member on the server. If, on the other hand, a member
+        // that the user decides to delete is one that the user has just added
+        // (but not saved to the server), then we don't use the API. Each key
+        // is a member (user or group) id that the user has identified as a
+        // candidate for addition; however, the member has not beend added to
+        // the group (yet) on the server. The value is normally `true` but can
+        // be set to `false` if the user changes his mind and removes the member
+        // before the server is updated.
         var pendingMembers = {};
 
         // Variable that will be used to keep track of the current infinite scroll instance

--- a/node_modules/oae-core/manageaccess/js/manageaccess.js
+++ b/node_modules/oae-core/manageaccess/js/manageaccess.js
@@ -220,7 +220,8 @@ define(['jquery', 'oae.core', 'jquery.autosuggest'], function($, oae) {
          */
         var setUpAutoSuggest = function() {
             oae.api.util.autoSuggest().setup($('#manageaccess-share-autosuggest', $rootel), {
-                'selectionChanged': autoSuggestChanged
+                'selectionChanged': autoSuggestChanged,
+                'exclude': widgetData.contextProfile.id
             }, null, function() {
                 // Focus on the autosuggest field once it has been set up
                 focusAutoSuggest();

--- a/node_modules/oae-core/manageaccess/js/manageaccess.js
+++ b/node_modules/oae-core/manageaccess/js/manageaccess.js
@@ -29,6 +29,9 @@ define(['jquery', 'oae.core', 'jquery.autosuggest'], function($, oae) {
 
         // Caches the member updates that need to be applied
         var membersUpdates = {};
+        
+        // Caches members pending addition
+        var pendingMembers = {};
 
         // Variable that will be used to keep track of the current infinite scroll instance
         var infinityScroll = null;
@@ -157,6 +160,7 @@ define(['jquery', 'oae.core', 'jquery.autosuggest'], function($, oae) {
         var addNewMembers = function(autoSuggestMembers) {
             $.each(autoSuggestMembers, function(i, newMember) {
                 membersUpdates[newMember.profile.id] = newMember.role;
+                pendingMembers[newMember.profile.id] = true;
             });
 
             infinityScroll.prependItems({'results': autoSuggestMembers});
@@ -175,7 +179,12 @@ define(['jquery', 'oae.core', 'jquery.autosuggest'], function($, oae) {
             infinityScroll.removeItems(principalId);
 
             // Mark the member as deleted
-            membersUpdates[principalId] = false;
+            if (pendingMembers[principalId]) {
+                delete membersUpdates[principalId];
+                pendingMembers[principalId] = false;
+            } else {
+                membersUpdates[principalId] = false;
+            }
 
             // Enable or disable the save button
             enableDisableSave();

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -973,7 +973,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
                     var toExclude = [];
 
                     $.each(data.results, function(index, result) {
-                        if (_.indexOf(options.exclude, result.id) !== -1) {
+                        if (_.contains(options.exclude, result.id)) {
                             toExclude.push(index);
                         } else {
                             result.displayName = security().encodeForHTML(result.displayName);
@@ -982,9 +982,9 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
                     });
                     
                     // Remove excluded items
-                    while (toExclude.length > 0) {
-                        data.results.splice(_.last(toExclude), 1);
-                        toExclude.pop();
+                    while (_.isEmpty(toExclude)) {
+                        // Remove from end of array to preserve indices
+                        data.results.splice(toExclude.pop(), 1);
                     }
 
                     if (retrieveComplete) {

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -881,6 +881,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
          * @param  {Boolean}            [options.preFill[i].fixed]      Whether or not the pre-filled item should be undeleteable from the selection list
          * @param  {Object[]}           [options.ghost]                 Ghost items that should be added to the autosuggest field upon initialization. This has the same format as `options.preFill`
          * @param  {Boolean}            [options.ghost[i].selected]     Whether or not the ghost item should be selected by default
+         * @param  {Object[]}           [options.exclude]               Specific items that should be excluded from suggestions
          * @param  {String}             [options.url]                   URL for the REST endpoint that should be used to fetch the suggested results
          * @param  {Function}           [options.selectionChanged]      Function that will be executed when the selection in the autosuggest field has changed
          * @param  {String[]}           [resourceTypes]                 Array of resourceTypes that should be used for the search. By default, `user` and `group` will be used
@@ -947,6 +948,13 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
                         ghostItem[options.selectedItemProp] = security().encodeForHTML(ghostItem[options.selectedItemProp]);
                     });
                 }
+                
+                // Coerce the set of excluded items to an array
+                if (!options.exclude) {
+                    options.exclude = [];
+                } else if (!_.isArray(options.exclude)) {
+                    options.exclude = [options.exclude];
+                }
 
                 // XSS escape the incoming data from the REST endpoints. We also add the current query
                 // onto each result object to make sure that the matching succeeds and all items are
@@ -960,10 +968,24 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
                     // Get the query from the request URL on the Ajax object, as that is the only provided clue
                     // for finding out the search query
                     var query = $.url(this.url).param('q');
+                    
+                    // Track any results that need to be excluded
+                    var toExclude = [];
+
                     $.each(data.results, function(index, result) {
-                        result.displayName = security().encodeForHTML(result.displayName);
-                        result.query = query;
+                        if (_.indexOf(options.exclude, result.id) !== -1) {
+                            toExclude.push(index);
+                        } else {
+                            result.displayName = security().encodeForHTML(result.displayName);
+                            result.query = query;
+                        }
                     });
+                    
+                    // Remove excluded items
+                    while (toExclude.length > 0) {
+                        data.results.splice(_.last(toExclude), 1);
+                        toExclude.pop();
+                    }
 
                     if (retrieveComplete) {
                         return retrieveComplete(data);


### PR DESCRIPTION
1. Create a group
2. Click manage access
3. Add several users, including the group itself
    * Note that another issue we should resolve is that the group itself doesn't show up in auto-suggest
    * This serves as a way to trigger a 400 error when you save the membership changes
4. Save the membership changes, there is an error because the group was being added to itself
5. Remove the group from the list
6. Click save. Still an error because it's still trying to add the group
7. Remove all the other users you tried to add and click save, all the members you removed are still part of the POST request