### PR TITLE
Extend userdetails to catch display names with @

### DIFF
--- a/node_modules/oae-core/userdetails/bundles/default.properties
+++ b/node_modules/oae-core/userdetails/bundles/default.properties
@@ -1,3 +1,4 @@
 ADDING_YOUR_FULL_NAME = Adding your full name will inform the people who you decide to work with that they are collaborating with the right person.
 CONTINUE = Continue
+PLEASE_ENTER_A_VALID_NAME = Please enter a valid name
 PLEASE_ENTER_YOUR_DETAILS = Please enter your details

--- a/node_modules/oae-core/userdetails/js/userdetails.js
+++ b/node_modules/oae-core/userdetails/js/userdetails.js
@@ -152,6 +152,12 @@ define(['jquery', 'oae.core'], function($, oae) {
                         'required': oae.api.i18n.translate('__MSG__PLEASE_ACCEPT_THE_TERMS_AND_CONDITIONS__')
                     }
                 },
+                'methods': {
+                    'displayname': {
+                        'method': oae.api.util.validation().isValidDisplayName,
+                        'text': oae.api.i18n.translate('__MSG__PLEASE_ENTER_A_VALID_NAME__', 'userdetails')
+                    }
+                },
                 'submitHandler': editUserDetails
             };
             oae.api.util.validation().validate($('#userdetails-form', $rootel), validateOpts);

--- a/node_modules/oae-core/userdetails/userdetails.html
+++ b/node_modules/oae-core/userdetails/userdetails.html
@@ -14,7 +14,7 @@
                     <div>
                         <div class="form-group">
                             <label class="control-label" for="userdetails-name"><h4>__MSG__NAME__</h4></label>
-                            <input type="text" id="userdetails-name" class="form-control required maxlength-short" name="userdetails-name" placeholder="Hiroyuki Sakai" />
+                            <input type="text" id="userdetails-name" class="form-control required displayname maxlength-short" name="userdetails-name" placeholder="Hiroyuki Sakai" />
                         </div>
                         <div class="form-group">
                             <label class="control-label" for="userdetails-email"><h4>__MSG__EMAIL__</h4></label>

--- a/node_modules/oae-core/userdetails/userdetails.html
+++ b/node_modules/oae-core/userdetails/userdetails.html
@@ -14,7 +14,7 @@
                     <div>
                         <div class="form-group">
                             <label class="control-label" for="userdetails-name"><h4>__MSG__NAME__</h4></label>
-                            <input type="text" id="userdetails-name" class="form-control required maxlength-short displayname" name="userdetails-name" placeholder="Hiroyuki Sakai" />
+                            <input type="text" id="userdetails-name" class="form-control required maxlength-short" name="userdetails-name" placeholder="Hiroyuki Sakai" />
                         </div>
                         <div class="form-group">
                             <label class="control-label" for="userdetails-email"><h4>__MSG__EMAIL__</h4></label>

--- a/node_modules/oae-core/userdetails/userdetails.html
+++ b/node_modules/oae-core/userdetails/userdetails.html
@@ -14,7 +14,7 @@
                     <div>
                         <div class="form-group">
                             <label class="control-label" for="userdetails-name"><h4>__MSG__NAME__</h4></label>
-                            <input type="text" id="userdetails-name" class="form-control required maxlength-short" name="userdetails-name" placeholder="Hiroyuki Sakai" />
+                            <input type="text" id="userdetails-name" class="form-control required maxlength-short displayname" name="userdetails-name" placeholder="Hiroyuki Sakai" />
                         </div>
                         <div class="form-group">
                             <label class="control-label" for="userdetails-email"><h4>__MSG__EMAIL__</h4></label>

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -589,8 +589,11 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
             if (options.submitHandler && $.isFunction(options.submitHandler)) {
                 submitCallback = options.submitHandler;
             }
+            
+            // Register common custom validation methods
+            $.validator.addMethod('displayname', isValidDisplayName, require('oae.api.i18n').translate('__MSG__NAMES_CANNOT_INCLUDE_URLS_OR_AT_SIGNS__'));
 
-            // Register the custom validation methods
+            // Register additional custom validation methods
             if (options.methods) {
                 $.each(options.methods, function(key, value) {
                     $.validator.addMethod(key, value.method, value.text);

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -701,6 +701,11 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
             if (/https?:\/\//i.test(displayName)) {
                 return false;
             }
+            
+            // Display names that contain `@` are also considered invalid
+            if (/@/.test(displayName)) {
+                return false;
+            }
 
             return true;
         };

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -695,15 +695,12 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
                 return false;
             }
 
-            // Display names that contain `http://` or `https://` are indicative of Shibboleth
+            // Display names that contain `http://`, `https://`, or `@` are indicative of Shibboleth
             // not releasing an attribute that could be used as the display name. This is not
             // considered to be valid
             if (/https?:\/\//i.test(displayName)) {
                 return false;
-            }
-            
-            // Display names that contain `@` are also considered invalid
-            if (/@/.test(displayName)) {
+            } else if (/@/.test(displayName)) {
                 return false;
             }
 

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -589,11 +589,8 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
             if (options.submitHandler && $.isFunction(options.submitHandler)) {
                 submitCallback = options.submitHandler;
             }
-            
-            // Register common custom validation methods
-            $.validator.addMethod('displayname', isValidDisplayName, require('oae.api.i18n').translate('__MSG__NAMES_CANNOT_INCLUDE_URLS_OR_AT_SIGNS__'));
 
-            // Register additional custom validation methods
+            // Register the custom validation methods
             if (options.methods) {
                 $.each(options.methods, function(key, value) {
                     $.validator.addMethod(key, value.method, value.text);

--- a/shared/oae/bundles/ui/default.properties
+++ b/shared/oae/bundles/ui/default.properties
@@ -398,6 +398,7 @@ MY_PICTURE = My picture
 MY_PREFERENCES = My preferences
 MY_PROFILE = My profile
 NAME = Name
+NAMES_CANNOT_INCLUDE_URLS_OR_AT_SIGNS = Names cannot include URLs or the '@' character
 NAME_COLON = Name:
 NARROW_BY_KEYWORD = Narrow by keyword
 NETWORK = Network

--- a/shared/oae/bundles/ui/default.properties
+++ b/shared/oae/bundles/ui/default.properties
@@ -398,7 +398,6 @@ MY_PICTURE = My picture
 MY_PREFERENCES = My preferences
 MY_PROFILE = My profile
 NAME = Name
-NAMES_CANNOT_INCLUDE_URLS_OR_AT_SIGNS = Names cannot include URLs or the '@' character
 NAME_COLON = Name:
 NARROW_BY_KEYWORD = Narrow by keyword
 NETWORK = Network


### PR DESCRIPTION
The userdetails widget should be extended to also consider display names with an `@` to be invalid. When going through the Shibboleth responses that we've received so far, I noticed quite a few that only release a targeted-id in the form of `...=@surrey.ac.uk`.