### PR TITLE
List item improvements

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -387,9 +387,7 @@ div.oae-thumbnail {
 
 div.oae-thumbnail:before {
     display: inline-block;
-    font-size: 18px;
-    margin-top: -9px;
-    padding-top: 50%;
+    position: relative;
 }
 
 div.oae-thumbnail a,
@@ -418,14 +416,19 @@ div.oae-thumbnail.fa-oae-user div {
     background-position: center;
 }
 
+div.oae-thumbnail.oae-thumbnail-small:before {
+    font-size: 18px;
+    top: 0;
+}
+
 div.oae-thumbnail.oae-thumbnail-medium:before {
     font-size: 30px;
-    margin-top: -15px;
+    top: 8px;
 }
 
 div.oae-thumbnail.oae-thumbnail-large:before {
     font-size: 50px;
-    margin-top: -25px;
+    top: 32px;
 }
 
 /* Default entity thumbnails */
@@ -1005,15 +1008,6 @@ div.oae-thumbnail i.fa {
 .oae-tile .oae-thumbnail a,
 .oae-tile .oae-thumbnail img {
     border-radius: 0;
-}
-
-.oae-tile .oae-thumbnail:before {
-    margin-top: -30px;
-}
-
-.oae-tile .oae-thumbnail.oae-thumbnail-large:before {
-    margin-top: -48px;
-    padding-top: 80px;
 }
 
 .oae-tile .oae-thumbnail img {

--- a/shared/oae/macros/list.html
+++ b/shared/oae/macros/list.html
@@ -161,7 +161,7 @@
                     ${renderCheckbox(entityData, 'details', displayOptions.showCheckbox)}
                     <div class="oae-listitem-primary-thumbnail">
                         ${displayOptions.addVisibilityIcon = true|eat}
-                        ${displayOptions.size = "small"|eat}
+                        ${displayOptions.size = "medium"|eat}
                         ${displayOptions.threedotTitle = true|eat}
                         ${renderThumbnail(entityData, displayOptions)}
                     </div>
@@ -181,6 +181,9 @@
                 <div class="oae-listitem">
                     ${renderCheckbox(entityData, 'compact', displayOptions.showCheckbox)}
                     <div class="oae-listitem-primary-thumbnail">
+                        ${displayOptions.addVisibilityIcon = true|eat}
+                        ${displayOptions.size = "small"|eat}
+                        ${displayOptions.threedotTitle = true|eat}
                         ${renderThumbnail(entityData, displayOptions)}
                     </div>
                     {if displayOptions.listItemActions}


### PR DESCRIPTION
- Rather than only wrapping a link around the thumbnail and the title of the item, we should wrap the entire tile in a link (this should not be he case for the other list types though)
- In the User Management page in the admin UI, clicking the bottom of a tile will actually cause you to click the list item below. This for example makes it difficult to click the `Import CSV` button

![screen shot 2015-06-11 at 07 15 55](https://cloud.githubusercontent.com/assets/109850/8109269/981bae88-100a-11e5-8901-31294cc1adc8.png)
