### PR TITLE
Manageuser widget should provide list of all associated LoginIds for a user

### DIFF
--- a/node_modules/oae-admin/manageuser/bundles/default.properties
+++ b/node_modules/oae-admin/manageuser/bundles/default.properties
@@ -6,6 +6,7 @@ ACTIONS = Actions
 ADMINISTRATION = Administration
 ADMINISTRATOR = Administrator
 ARE_YOU_SURE_YOU_WANT_TO_DELETE_THIS_ACCOUNT = Are you sure you want to delete this account?
+AUTHENTICATION = Authentication
 BECOME_USER = Become user
 BECOME_USER_NAME = Become ${displayName}
 CAUTION_IT_WILL_NO_LONGER_BE_POSSIBLE_TO_INVITE_THIS_ACCOUNT_INTO_ANY_COLLABORATIONS = <strong>Caution:</strong> it will no longer be possible to invite this account into any collaborations!

--- a/node_modules/oae-admin/manageuser/css/manageuser.css
+++ b/node_modules/oae-admin/manageuser/css/manageuser.css
@@ -25,6 +25,12 @@
     margin: 0;
 }
 
+/* AUTHENTICATION */
+
+#manageuser-modal #manageuser-authentication-container label {
+    text-transform: capitalize;
+}
+
 /* EDIT PROFILE */
 
 #manageuser-modal #manageuser-basic-profile-container {

--- a/node_modules/oae-admin/manageuser/js/manageuser.js
+++ b/node_modules/oae-admin/manageuser/js/manageuser.js
@@ -227,6 +227,23 @@ define(['jquery', 'oae.core'], function($, oae) {
             $('#manageuser-panel-' + panel).show();
         };
 
+
+        ////////////////////
+        // AUTHENTICATION //
+        ////////////////////
+
+        /**
+         * Set up the authentication form
+         */
+        var setUpAuthenticationForm = function() {
+            setUpChangePasswordValidation();
+
+            oae.api.util.template().render($('#manageuser-authentication-template', $rootel), {
+                'loginIds': widgetData.userProfile.loginIds
+            }, $('#manageuser-authentication-container', $rootel));
+        };
+
+
         /////////////////////
         // CHANGE PASSWORD //
         /////////////////////
@@ -281,7 +298,7 @@ define(['jquery', 'oae.core'], function($, oae) {
          * Set up the validation for the change password form
          */
         var setUpChangePasswordValidation = function() {
-            oae.api.util.validation().validate($('#manageuser-password-form', $rootel), {
+            oae.api.util.validation().validate($('#manageuser-authentication-form', $rootel), {
                 'rules': {
                     'manageuser-new-password': {
                         'minlength': 6
@@ -424,20 +441,25 @@ define(['jquery', 'oae.core'], function($, oae) {
                 oae.api.user.getUser(widgetData.userId, function(err, userProfile) {
                     widgetData.userProfile = userProfile;
 
-                    // Render the modal dialog header
-                    oae.api.util.template().render($('#manageuser-editprofile-header-template', $rootel), {
-                        'userProfile': userProfile
-                    }, $('#manageuser-editprofile-header-container', $rootel));
+                    // Retrieve the user login ids
+                    oae.api.authentication.getAuthLoginIds(widgetData.userProfile.id, function(err, loginIds) {
+                        widgetData.userProfile.loginIds = loginIds;
 
-                    // Don't show the actions tab for the global admin tenant
-                    if (widgetData.context.isGlobalAdminServer) {
-                        $('#manageuser-actions-tab', $rootel).hide();
-                    }
+                        // Render the modal dialog header
+                        oae.api.util.template().render($('#manageuser-editprofile-header-template', $rootel), {
+                            'userProfile': userProfile
+                        }, $('#manageuser-editprofile-header-container', $rootel));
 
-                    setUpChangePasswordValidation();
-                    setUpEditProfileForm();
-                    setUpActionsForm();
-                    setUpEmailForm();
+                        // Don't show the actions tab for the global admin tenant
+                        if (widgetData.context.isGlobalAdminServer) {
+                            $('#manageuser-actions-tab', $rootel).hide();
+                        }
+
+                        setUpAuthenticationForm();
+                        setUpEditProfileForm();
+                        setUpActionsForm();
+                        setUpEmailForm();
+                    });
                 });
             });
 

--- a/node_modules/oae-admin/manageuser/manageuser.html
+++ b/node_modules/oae-admin/manageuser/manageuser.html
@@ -25,7 +25,7 @@
                             <a href="#manageuser-actions-form" data-toggle="tab">__MSG__ACTIONS__</a>
                         </li>
                         <li>
-                            <a href="#manageuser-password-form" data-toggle="tab">__MSG__PASSWORD__</a>
+                            <a href="#manageuser-authentication-form" data-toggle="tab">__MSG__AUTHENTICATION__</a>
                         </li>
                     </ul>
                 </div>
@@ -55,23 +55,8 @@
                         </div>
                     </form>
 
-                    <form id="manageuser-password-form" class="tab-pane form-horizontal" role="form">
-                        <div class="modal-body">
-                            <div class="well">
-                                <div class="form-group">
-                                    <label class="control-label col-lg-5" for="manageuser-new-password">__MSG__NEW_PASSWORD_COLON__</label>
-                                    <div class="col-lg-7">
-                                        <input type="password" id="manageuser-new-password" name="manageuser-new-password" placeholder="&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;" class="form-control required maxlength-short">
-                                    </div>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label col-lg-5" for="manageuser-retype-password">__MSG__RETYPE_NEW_PASSWORD_COLON__</label>
-                                    <div class="col-lg-7">
-                                        <input type="password" id="manageuser-retype-password" name="manageuser-retype-password" placeholder="&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;" class="form-control required maxlength-short">
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                    <form id="manageuser-authentication-form" class="tab-pane form-horizontal" role="form">
+                        <div id="manageuser-authentication-container" class="modal-body"><!-- --></div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-link" data-dismiss="modal">__MSG__CANCEL__</button>
                             <button type="submit" class="btn btn-primary">__MSG__SAVE__</button>
@@ -97,6 +82,43 @@
         </div>
     </div>
 </div>
+
+<div id="manageuser-authentication-template"><!--
+    {if loginIds}
+        <div class="well">
+            {for loginId in loginIds}
+                {if loginId_index !== 'local'}
+                    <div class="form-group">
+                        <label class="control-label col-lg-5" for="manageuser-loginid-${loginId_index}">${loginId_index}:</label>
+                        <div class="col-lg-7">
+                            <input type="text" id="manageuser-loginid-${loginId_index}" name="manageuser-loginid-${loginId_index}" class="form-control" value="${loginId}" disabled>
+                        </div>
+                    </div>
+                {/if}
+            {/for}
+            {if loginIds.local}
+                <div class="form-group">
+                    <label class="control-label col-lg-5" for="manageuser-loginid-${loginId_index}">${loginId_index}:</label>
+                    <div class="col-lg-7">
+                        <input type="text" id="manageuser-loginid-${loginId_index}" name="manageuser-loginid-${loginId_index}" class="form-control" value="${loginId}" disabled>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="control-label col-lg-5" for="manageuser-new-password">__MSG__NEW_PASSWORD_COLON__</label>
+                    <div class="col-lg-7">
+                        <input type="password" id="manageuser-new-password" name="manageuser-new-password" placeholder="&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;" class="form-control required maxlength-short">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label class="control-label col-lg-5" for="manageuser-retype-password">__MSG__RETYPE_NEW_PASSWORD_COLON__</label>
+                    <div class="col-lg-7">
+                        <input type="password" id="manageuser-retype-password" name="manageuser-retype-password" placeholder="&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;" class="form-control required maxlength-short">
+                    </div>
+                </div>
+            {/if}
+        </div>
+    {/if}
+--></div>
 
 <div id="manageuser-editprofile-header-template"><!--
     ${userProfile.displayName|encodeForHTML}

--- a/shared/oae/api/oae.api.authentication.js
+++ b/shared/oae/api/oae.api.authentication.js
@@ -16,6 +16,32 @@
 define(['exports', 'jquery', 'oae.api.config'], function(exports, $, configAPI) {
 
     /**
+     * Get a user's login ids
+     *
+     * @param  {String}     userId              The id of the user to return the login ids for
+     * @param  {Function}   callback            Standard callback function
+     * @param  {Object}     callback.err        Error object containing error code and error message
+     * @param  {Object}     callback.loginIds   Hash object containing the user's login ids
+     * @throws {Error}                          Error thrown when not all of the required parameters have been provided
+     */
+    var getAuthLoginIds = exports.getAuthLoginIds = function(userId, callback) {
+        if (!userId) {
+            throw new Error('A valid user id should be provided');
+        }
+
+        $.ajax({
+            'url': '/api/auth/loginIds/' + userId,
+            'type': 'GET',
+            'success': function(data) {
+                callback(null, data);
+            },
+            'error': function(jqXHR, textStatus) {
+                callback({'code': jqXHR.status, 'msg': jqXHR.responseText});
+            }
+        });
+    };
+
+    /**
      * Get the list of all enabled authentication strategies for the current tenant
      *
      * @return {Object}                List of all enabled authentication strategies for the current tenant keyed by authentication strategy id. Each enabled authentication strategy will contain a `url` property with the URL to which to POST to initiate the authentication process for that strategy and a `name` property with the custom configured name for that strategy


### PR DESCRIPTION
The manageuser widget is an admin UI widget that allows a tenant administrator to view and change details of a particular user. The last tab in that widget is currently the "Password" tab, allowing for the local password of that user to be changed.

This tab needs to be changed to an `Authentication` tab. The content of this tab should be a list of all of the associated LoginIds for that user. For each LoginId, we should show the type (cas, shibboleth, facebook, local) and the external id for that type. If the user has a local LoginId, this should be shown at the bottom of the list accompanied by the "change password" form. If the user does not have a local LoginId, the "change password" form should not be shown.

![screen shot 2015-06-11 at 23 21 32](https://cloud.githubusercontent.com/assets/109850/8124468/9c05d1f0-1090-11e5-9d32-3c4e6f190227.png)
