### PR TITLE
(A11y severity 3) Remove hidden heading from pages

### DIFF
--- a/node_modules/oae-core/lhnavigation/lhnavigation.html
+++ b/node_modules/oae-core/lhnavigation/lhnavigation.html
@@ -5,7 +5,7 @@
     <div class="oae-lhnavigation">
         <ul class="nav nav-list"><!-- --></ul>
     </div>
-    <div class="oae-page"><!-- --></div>
+    <div id="oae-page-content" class="oae-page"><!-- --></div>
 </div>
 
 <div id="lhnavigation-navigation-template"><!--

--- a/node_modules/oae-core/topnavigation/bundles/default.properties
+++ b/node_modules/oae-core/topnavigation/bundles/default.properties
@@ -1,5 +1,3 @@
-SKIP_TOP_MENU = Skip to content [c]
-SKIP_TOP_MENU_KEY = c
-SKIP_MENU_TARGET = Content begins here
+SKIP_TO_CONTENT = Skip to content
 TOPNAV_ARIA_LABEL = Global navigation bar
 TOPNAV_SEARCH_ARIA_LABEL = Search everything

--- a/node_modules/oae-core/topnavigation/js/topnavigation.js
+++ b/node_modules/oae-core/topnavigation/js/topnavigation.js
@@ -112,6 +112,11 @@ define(['jquery', 'oae.core', 'activityadapter'], function($, oae, ActivityAdapt
          * to jump past the top navigation
          */
         var setUpSkipLinks = function() {
+            // Index page has a unique structure.
+            if ($('#index-page-container').length > 0) {
+                $('.oae-skip-link',$rootel).attr('href', '#index-page-container');
+            }
+
             // Focus on the target element when clicking
             // a skip link
             $rootel.on('click', '.oae-skip-link', function() {

--- a/node_modules/oae-core/topnavigation/topnavigation.html
+++ b/node_modules/oae-core/topnavigation/topnavigation.html
@@ -25,7 +25,6 @@
         </div>
     </div>
 </div>
-<h1 id="topnavigation-target" class="sr-only">__MSG__SKIP_MENU_TARGET__</h1>
 
 <div id="topnavigation-institutional-logo-template"><!--
     <a href="/" class="oae-institutional-logo hidden-xs visible-sm" title="${oae.data.me.tenant.displayName|encodeForHTMLAttribute}">

--- a/node_modules/oae-core/topnavigation/topnavigation.html
+++ b/node_modules/oae-core/topnavigation/topnavigation.html
@@ -3,7 +3,7 @@
 
 <div id="topnavigation-container" role="navigation" aria-label="__MSG__TOPNAV_ARIA_LABEL__">
     <!-- ACCESSIBILITY HELPERS -->
-    <a id="topnavigation-skip" class="sr-only oae-skip-link hide" href="#topnavigation-target" accesskey="__MSG__SKIP_TOP_MENU_KEY__">__MSG__SKIP_TOP_MENU__</a>
+    <a id="topnavigation-skip" class="sr-only oae-skip-link hide" href="#oae-page-content">__MSG__SKIP_TO_CONTENT__</a>
     <!-- NAVIGATION -->
     <div class="row">
         <!-- LEFT MENU -->


### PR DESCRIPTION
Several pages within the site have a hidden first- level heading titled "Content begins here". Since the pages already have a <main> element with an ARIA role of main, the hidden first-level heading is unnecessary and should be removed.