### PR TITLE
(A11y severity 3) Reorganize headings for accessibility

### DIFF
--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -498,7 +498,7 @@ div.oae-thumbnail i.fa {
  *                      </div>
  *                      <div>
  *                          <div>
- *                              <h1 class="oae-threedots">John Doe</h1>
+ *                              <span class="oae-clip-text oae-threedots">John Doe</span>
  *                              <i class="fa fa-caret-down"></i>
  *                              <small>Job Title</small>
  *                          </div>
@@ -532,7 +532,7 @@ div.oae-thumbnail i.fa {
  *   main button. This can also show a default entity picture (in case no image is provided) as well as a
  *   visibility icon (See the `Thumbnail` section for details on how to create a thumbnail).
  *   The thumbnail image is optional and can be left out as well.
- * - An optional `oae-threedots` class can be added to the `h1` elements in case a maximum width needs to be
+ * - An optional `oae-threedots` class can be added to the `.oae-clip-text` elements in case a maximum width needs to be
  *   enforced.
  * - The `fa-caret-down` element is optional. If it is not provided, the clip will be shown in view
  *   only mode. If it is provided, the clip will be toggleable and the action menu will be shown when clicked.
@@ -661,7 +661,7 @@ div.oae-thumbnail i.fa {
     width: 35px;
 }
 
-.oae-clip .oae-clip-content h1 {
+.oae-clip .oae-clip-content .oae-clip-text {
     display: inline-block;
     font-size: 16px;
     line-height: 1.3;
@@ -672,7 +672,7 @@ div.oae-thumbnail i.fa {
     word-wrap: nowrap;
 }
 
-.oae-clip .oae-clip-content h1.oae-threedots {
+.oae-clip .oae-clip-content .oae-clip-text.oae-threedots {
     float: left;
 }
 
@@ -684,8 +684,8 @@ div.oae-thumbnail i.fa {
     top: 3px;
 }
 
-.oae-clip .oae-clip-content > button h1.oae-threedots + i.fa-caret-down,
-.oae-clip .oae-clip-content > button h1.oae-threedots + i.fa-caret-up {
+.oae-clip .oae-clip-content > button .oae-clip-text.oae-threedots + i.fa-caret-down,
+.oae-clip .oae-clip-content > button .oae-clip-text.oae-threedots + i.fa-caret-up {
     margin-left: 10px;
 }
 
@@ -703,7 +703,7 @@ div.oae-thumbnail i.fa {
 }
 
 @media (max-width: 510px) {
-    .oae-clip .oae-clip-content > button h1,
+    .oae-clip .oae-clip-content > button .oae-clip-text,
     .oae-clip .oae-clip-content > button small {
         max-width: 185px;
     }

--- a/ui/content.html
+++ b/ui/content.html
@@ -38,7 +38,7 @@
                                 ${renderThumbnail(content, displayOptions)}
                                 <div>
                                     <div>
-                                        <h1 class="oae-threedots">${content.displayName|encodeForHTML}</h1>
+                                        <span class="oae-clip-text oae-threedots">${content.displayName|encodeForHTML}</span>
                                         <i class="fa fa-caret-down"></i>
                                         <small class="oae-threedots">${oae.api.content.getMimeTypeDescription(content)}</small>
                                     </div>

--- a/ui/discussion.html
+++ b/ui/discussion.html
@@ -39,7 +39,7 @@
                                 ${renderThumbnail(discussion, displayOptions)}
                                 <div>
                                     <div>
-                                        <h1 class="oae-threedots">${discussion.displayName|encodeForHTML}</h1>
+                                        <span class="oae-clip-text oae-threedots">${discussion.displayName|encodeForHTML}</span>
                                         <i class="fa fa-caret-down"></i>
                                         <small class="oae-threedots">__MSG__DISCUSSION__</small>
                                     </div>

--- a/ui/folder.html
+++ b/ui/folder.html
@@ -38,7 +38,7 @@
                                 ${renderThumbnail(folder, displayOptions)}
                                 <div>
                                     <div>
-                                        <h1 class="oae-threedots">${folder.displayName|encodeForHTML}</h1>
+                                        <span class="oae-clip-text oae-threedots">${folder.displayName|encodeForHTML}</span>
                                         <i class="fa fa-caret-down"></i>
                                         <small class="oae-threedots">__MSG__FOLDER__</small>
                                     </div>
@@ -75,7 +75,7 @@
                                 <button type="button" class="oae-trigger-upload">
                                     <div>
                                         <i class="fa fa-cloud-upload pull-left"></i>
-                                        <h1>__MSG__UPLOAD__</h1>
+                                        <span class="oae-clip-text">__MSG__UPLOAD__</span>
                                     </div>
                                 </button>
                             </div>
@@ -90,7 +90,7 @@
                                 <button type="button" aria-expanded="false" aria-controls="folder-secondary-clip-detail">
                                     <div>
                                         <i class="fa fa-plus-circle pull-left"></i>
-                                        <h1>__MSG__CREATE__</h1>
+                                        <span class="oae-clip-text">__MSG__CREATE__</span>
                                         <i class="fa fa-caret-down"></i>
                                     </div>
                                 </button>

--- a/ui/group.html
+++ b/ui/group.html
@@ -38,7 +38,7 @@
                                 ${renderThumbnail(group, displayOptions)}
                                 <div>
                                     <div>
-                                        <h1 class="oae-threedots">${group.displayName|encodeForHTML}</h1>
+                                        <span class="oae-clip-text oae-threedots">${group.displayName|encodeForHTML}</span>
                                         <i class="fa fa-caret-down"></i>
                                         <small class="oae-threedots">__MSG__GROUP__</small>
                                     </div>
@@ -71,7 +71,7 @@
                                 <button type="button" class="group-join">
                                     <div>
                                         <i class="fa fa-thumb-tack pull-left"></i>
-                                        <h1>__MSG__JOIN_GROUP__</h1>
+                                        <span class="oae-clip-text">__MSG__JOIN_GROUP__</span>
                                     </div>
                                 </button>
                             </div>
@@ -88,7 +88,7 @@
                                 <button type="button" class="oae-trigger-upload">
                                     <div>
                                         <i class="fa fa-cloud-upload pull-left"></i>
-                                        <h1>__MSG__UPLOAD__</h1>
+                                        <span class="oae-clip-text">__MSG__UPLOAD__</span>
                                     </div>
                                 </button>
                             </div>
@@ -103,7 +103,7 @@
                                 <button type="button" aria-expanded="false" aria-controls="group-secondary-clip-detail">
                                     <div>
                                         <i class="fa fa-plus-circle pull-left"></i>
-                                        <h1>__MSG__CREATE__</h1>
+                                        <span class="oae-clip-text">__MSG__CREATE__</span>
                                         <i class="fa fa-caret-down"></i>
                                     </div>
                                 </button>

--- a/ui/me.html
+++ b/ui/me.html
@@ -36,7 +36,7 @@
                                 ${renderThumbnail(oae.data.me, displayOptions)}
                                 <div>
                                     <div>
-                                        <h1 class="oae-threedots">${oae.data.me.displayName|encodeForHTML}</h1>
+                                        <span class="oae-clip-text oae-threedots">${oae.data.me.displayName|encodeForHTML}</span>
                                         <i class="fa fa-caret-down"></i>
                                         <small class="oae-threedots">${oae.data.me.tenant.displayName|encodeForHTML}</small>
                                     </div>
@@ -63,7 +63,7 @@
                             <button type="button" class="oae-trigger-upload">
                                 <div>
                                     <i class="fa fa-cloud-upload pull-left"></i>
-                                    <h1>__MSG__UPLOAD__</h1>
+                                    <span class="oae-clip-text">__MSG__UPLOAD__</span>
                                 </div>
                             </button>
                         </div>
@@ -78,7 +78,7 @@
                             <button type="button" aria-expanded="false" aria-controls="me-secondary-clip-detail">
                                 <div>
                                     <i class="fa fa-plus-circle pull-left"></i>
-                                    <h1>__MSG__CREATE__</h1>
+                                    <span class="oae-clip-text">__MSG__CREATE__</span>
                                     <i class="fa fa-caret-down"></i>
                                 </div>
                             </button>

--- a/ui/user.html
+++ b/ui/user.html
@@ -36,7 +36,7 @@
                                 ${renderThumbnail(user, displayOptions)}
                                 <div>
                                     <div>
-                                        <h1 class="oae-threedots">${user.displayName|encodeForHTML}</h1>
+                                        <span class="oae-clip-text oae-threedots">${user.displayName|encodeForHTML}</span>
                                         <small class="oae-threedots">${user.tenant.displayName|encodeForHTML}</small>
                                     </div>
                                 </div>
@@ -57,7 +57,7 @@
                                 <button type="button" class="user-follow">
                                     <div>
                                         <i class="fa fa-bookmark pull-left"></i>
-                                        <h1>__MSG__FOLLOW__</h1>
+                                        <span class="oae-clip-text">__MSG__FOLLOW__</span>
                                     </div>
                                 </button>
                             </div>


### PR DESCRIPTION
The majority of the pages in this site have multiple first-level headings (`<h1>`). While the presence of headings is good, pages should generally have a single `h1` for the document title/main heading. This facilitates quick navigation directly to the main content of the page.