### PR TITLE
["Manage access" popup] "Add" button is not clickable on Internet Explorer 11

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -1053,9 +1053,9 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
                 options.selectionAdded = function(elem) {
                     var $elem = $(elem);
                     // Wrap the element text in a 'oae-threedots' span element to prevent overflowing
-                    var text = $elem[0].lastChild.nodeValue;
-                    $elem[0].lastChild.remove();
-                    $elem.append($('<span>' + text + '</span>').addClass('pull-left oae-threedots'));
+                    $elem.contents().filter(function() {
+                        return this.nodeType === 3;
+                    }).wrapAll('<span class="pull-left oae-threedots" />');
 
                     var originalData = $elem.data('originalData');
                     if (originalData.resourceType) {


### PR DESCRIPTION
When using Internet Explorer 11, the "Add" button is disabled on the *popup* when trying to share a document with other users/groups.
![oae-error_ui](https://cloud.githubusercontent.com/assets/1647058/8375461/9db401f2-1bfd-11e5-8228-464b63b74fec.png)


The issue may be related to the use of the remove() method which is apparently not supported in IE:  
![error-oae](https://cloud.githubusercontent.com/assets/1647058/8375210/9bec9f66-1bfb-11e5-9b1c-bd4dedcbcfac.png)
