### PR TITLE
Sign Up modal doesn't allow email address as username

### DIFF
--- a/node_modules/oae-admin/createuser/js/createuser.js
+++ b/node_modules/oae-admin/createuser/js/createuser.js
@@ -99,7 +99,7 @@ define(['jquery', 'oae.core'], function($, oae) {
                 'methods': {
                     'validchars': {
                         'method': function(value, element) {
-                            return this.optional(element) || !(/[<>\\\/{}\[\]!@#\$%\^&\*,:]+/i.test(value));
+                            return this.optional(element) || !(/[<>\\\/{}\[\]!#\$%\^&\*,:]+/i.test(value));
                         },
                         'text': oae.api.i18n.translate('__MSG__ACCOUNT_INVALIDCHAR__')
                     },

--- a/node_modules/oae-core/register/js/register.js
+++ b/node_modules/oae-core/register/js/register.js
@@ -143,7 +143,7 @@ define(['jquery', 'underscore', 'oae.core'], function($, _, oae) {
                 'methods': {
                     'validchars': {
                         'method': function(value, element) {
-                            return this.optional(element) || !(/[<>\\\/{}\[\]!@#\$%\^&\*,:]+/i.test(value));
+                            return this.optional(element) || !(/[<>\\\/{}\[\]!#\$%\^&\*,:]+/i.test(value));
                         },
                         'text': oae.api.i18n.translate('__MSG__ACCOUNT_INVALIDCHAR__')
                     },


### PR DESCRIPTION
The Sign Up modal doesn't allow an email address as the username because the `@` is considered to be an invalid character. However, we want to allow email addresses as usernames and the REST API already supports this.