### PR TITLE
Allow email notifications for user to be turned off in admin UI

### DIFF
--- a/node_modules/oae-admin/manageuser/js/manageuser.js
+++ b/node_modules/oae-admin/manageuser/js/manageuser.js
@@ -404,9 +404,7 @@ define(['jquery', 'oae.core'], function($, oae) {
             $rootel.on('change', '.oae-large-options-container input[type="radio"]', function() {
                 var $optionsContainer = $(this).closest('.oae-large-options-container');
                 $optionsContainer.find('label').removeClass('checked');
-                $('.oae-large-options i', $optionsContainer).removeClass('selected');
                 $(this).closest('label').addClass('checked');
-                $(this).closest('label').find('.oae-large-options i').addClass('selected');
             });
         };
 

--- a/node_modules/oae-admin/manageuser/manageuser.html
+++ b/node_modules/oae-admin/manageuser/manageuser.html
@@ -162,7 +162,7 @@
     <div id="manageuser-email-options-container">
         <div id="manageuser-email-options" class="clearfix">
             <div class="oae-large-options-container row">
-                <div class="col-sm-4 text-center">
+                <div class="col-sm-3 text-center">
                     <label for="manageuser-email-immediate" {if userProfile.emailPreference === 'immediate'} class="checked"{/if}>
                         <i class="fa fa-check hide"></i>
                         <div class="well oae-large-options">
@@ -172,7 +172,7 @@
                         </div>
                     </label>
                 </div>
-                <div class="col-sm-4 text-center">
+                <div class="col-sm-3 text-center">
                     <label for="manageuser-email-daily" {if userProfile.emailPreference === 'daily'} class="checked"{/if}>
                         <i class="fa fa-check hide"></i>
                         <div class="oae-large-options well">
@@ -182,13 +182,23 @@
                         </div>
                     </label>
                 </div>
-                <div class="col-sm-4 text-center">
+                <div class="col-sm-3 text-center">
                     <label for="manageuser-email-weekly" {if userProfile.emailPreference === 'weekly'} class="checked"{/if}>
                         <i class="fa fa-check hide"></i>
                         <div class="oae-large-options well">
                             <input type="radio" id="manageuser-email-weekly" value="weekly" name="manageuser-email-group" class="pull-left" tabindex="0" {if userProfile.emailPreference === 'weekly'} checked{/if}/>
                             <i class="fa fa-calendar large text-center {if userProfile.emailPreference === 'weekly'} selected{/if}"></i>
                             <span class="oae-threedots">__MSG__WEEKLY__</span>
+                        </div>
+                    </label>
+                </div>
+                <div class="col-sm-3 text-center">
+                    <label for="manageuser-email-never" {if userProfile.emailPreference === 'never'} class="checked"{/if}>
+                        <i class="fa fa-check hide"></i>
+                        <div class="oae-large-options well">
+                            <input type="radio" id="manageuser-email-never" value="never" name="manageuser-email-group" class="pull-left" tabindex="0" {if userProfile.emailPreference === 'never'} checked{/if}/>
+                            <i class="fa fa-ban large text-center {if userProfile.emailPreference === 'weekly'} selected{/if}"></i>
+                            <span class="oae-threedots">__MSG__NEVER__</span>
                         </div>
                     </label>
                 </div>

--- a/node_modules/oae-admin/manageuser/manageuser.html
+++ b/node_modules/oae-admin/manageuser/manageuser.html
@@ -167,7 +167,7 @@
                         <i class="fa fa-check hide"></i>
                         <div class="well oae-large-options">
                             <input type="radio" id="manageuser-email-immediate" value="immediate" name="manageuser-email-group" class="pull-left" tabindex="0" {if userProfile.emailPreference === 'immediate'} checked{/if}/>
-                            <i class="fa fa-bolt large text-center {if userProfile.emailPreference === 'immediate'} selected{/if}"></i>
+                            <i class="fa fa-bolt large text-center"></i>
                             <span class="oae-threedots">__MSG__IMMEDIATE__</span>
                         </div>
                     </label>
@@ -177,7 +177,7 @@
                         <i class="fa fa-check hide"></i>
                         <div class="oae-large-options well">
                             <input type="radio" id="manageuser-email-daily" value="daily" name="manageuser-email-group" class="pull-left" tabindex="0" {if userProfile.emailPreference === 'daily'} checked{/if}/>
-                            <i class="fa fa-clock-o large text-center {if userProfile.emailPreference === 'daily'} selected{/if}"></i>
+                            <i class="fa fa-clock-o large text-center"></i>
                             <span class="oae-threedots">__MSG__DAILY__</span>
                         </div>
                     </label>
@@ -187,7 +187,7 @@
                         <i class="fa fa-check hide"></i>
                         <div class="oae-large-options well">
                             <input type="radio" id="manageuser-email-weekly" value="weekly" name="manageuser-email-group" class="pull-left" tabindex="0" {if userProfile.emailPreference === 'weekly'} checked{/if}/>
-                            <i class="fa fa-calendar large text-center {if userProfile.emailPreference === 'weekly'} selected{/if}"></i>
+                            <i class="fa fa-calendar large text-center"></i>
                             <span class="oae-threedots">__MSG__WEEKLY__</span>
                         </div>
                     </label>
@@ -197,7 +197,7 @@
                         <i class="fa fa-check hide"></i>
                         <div class="oae-large-options well">
                             <input type="radio" id="manageuser-email-never" value="never" name="manageuser-email-group" class="pull-left" tabindex="0" {if userProfile.emailPreference === 'never'} checked{/if}/>
-                            <i class="fa fa-ban large text-center {if userProfile.emailPreference === 'weekly'} selected{/if}"></i>
+                            <i class="fa fa-ban large text-center"></i>
                             <span class="oae-threedots">__MSG__NEVER__</span>
                         </div>
                     </label>

--- a/node_modules/oae-core/preferences/js/preferences.js
+++ b/node_modules/oae-core/preferences/js/preferences.js
@@ -198,9 +198,7 @@ define(['jquery', 'oae.core'], function($, oae) {
 
             $rootel.on('change', '.oae-large-options-container input[type="radio"]', function() {
                 $('.oae-large-options-container label', $rootel).removeClass('checked');
-                $('.oae-large-options i', $rootel).removeClass('selected');
                 $(this).parents('label').addClass('checked');
-                $(this).parents('label').find('.oae-large-options i').addClass('selected');
             });
 
             $rootel.on('submit', '#preferences-account', updatePreferences);

--- a/node_modules/oae-core/preferences/preferences.html
+++ b/node_modules/oae-core/preferences/preferences.html
@@ -111,7 +111,7 @@
                             <i class="fa fa-check hide"></i>
                             <div class="well oae-large-options">
                                 <input type="radio" id="preferences-email-immediate" value="immediate" name="preferences-email-group" class="pull-left" tabindex="0" {if oae.data.me.emailPreference === 'immediate'} checked{/if}/>
-                                <i class="fa fa-bolt large text-center {if oae.data.me.emailPreference === 'immediate'} selected{/if}"></i>
+                                <i class="fa fa-bolt large text-center"></i>
                                 <span class="oae-threedots">__MSG__IMMEDIATE__</span>
                             </div>
                             <small>__MSG__IMMEDIATE_EMAIL_DESCRIPTION__</small>
@@ -122,7 +122,7 @@
                             <i class="fa fa-check hide"></i>
                             <div class="oae-large-options well">
                                 <input type="radio" id="preferences-email-daily" value="daily" name="preferences-email-group" class="pull-left" tabindex="0" {if oae.data.me.emailPreference === 'daily'} checked{/if}/>
-                                <i class="fa fa-clock-o large text-center {if oae.data.me.emailPreference === 'daily'} selected{/if}"></i>
+                                <i class="fa fa-clock-o large text-center"></i>
                                 <span class="oae-threedots">__MSG__DAILY__</span>
                             </div>
                             <small>__MSG__DAILY_EMAIL_DESCRIPTION__</small>
@@ -133,7 +133,7 @@
                             <i class="fa fa-check hide"></i>
                             <div class="oae-large-options well">
                                 <input type="radio" id="preferences-email-weekly" value="weekly" name="preferences-email-group" class="pull-left" tabindex="0" {if oae.data.me.emailPreference === 'weekly'} checked{/if}/>
-                                <i class="fa fa-calendar large text-center {if oae.data.me.emailPreference === 'weekly'} selected{/if}"></i>
+                                <i class="fa fa-calendar large text-center"></i>
                                 <span class="oae-threedots">__MSG__WEEKLY__</span>
                             </div>
                             <small>__MSG__WEEKLY_EMAIL_DESCRIPTION__</small>

--- a/shared/oae/bundles/ui/default.properties
+++ b/shared/oae/bundles/ui/default.properties
@@ -401,6 +401,7 @@ NAME = Name
 NAME_COLON = Name:
 NARROW_BY_KEYWORD = Narrow by keyword
 NETWORK = Network
+NEVER = Never
 NEW_DOCUMENT= New document
 NEW_PASSWORD_COLON = New password:
 NEXT = Next

--- a/shared/oae/css/oae.skin.less
+++ b/shared/oae/css/oae.skin.less
@@ -324,7 +324,7 @@ a:hover, .btn-link:hover {
    color: @button-icon-color;
 }
 
-.fa.active, .fa:hover, .fa:focus, .fa.selected,
+.fa.active, .fa:hover, .fa:focus,
 .btn-link .fa.active, .btn-link:hover .fa, .btn-link:focus .fa,
 input[type="radio"]:checked+.fa {
     color: @button-icon-hover-color;


### PR DESCRIPTION
The OAE back-end has an option to turn off email notifications for a user, but it’s currently not exposed in the UI to discourage users from turning them off. You can currently turn off email notifications through the REST API and the Swagger documentation page, but we should also expose this as a fourth email notification option in the manageuser widget.

The fa-ban icon can be used for the new option.