### PR TITLE
Two modals display if accepting invitation, don't have email (signin with twitter) and need to accept T&C

### DIFF
--- a/node_modules/oae-core/editprofile/js/editprofile.js
+++ b/node_modules/oae-core/editprofile/js/editprofile.js
@@ -179,7 +179,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
                     if (!isEmailChange) {
                         // If the update succeeded and didn't have an email change, close the modal
                         // while showing a notification
-                        $('#editprofile-modal', $rootel).modal('hide');
+                        closeModal();
                         oae.api.util.notification(
                             oae.api.i18n.translate('__MSG__PROFILE_EDITED__'),
                             oae.api.i18n.translate('__MSG__PROFILE_DETAILS_EDIT_SUCCESS__', 'editprofile'));
@@ -245,6 +245,21 @@ define(['jquery', 'oae.core'], function ($, oae) {
             });
 
             showDefaultPanel();
+        };
+
+        /**
+         * Close the edit profile modal
+         */
+        var closeModal = function() {
+            $('#editprofile-modal', $rootel).modal('hide');
+            if (oae.data.me.needsToAcceptTC) {
+                // It is possible that we entered the edit profile modal to
+                // clean up our user profile before accepting the terms and
+                // conditions (see `oae.api.js` function `setupPreUseActions`).
+                // Therefore we need to ensure we segue to the terms and
+                // conditions widget after we close the editprofile modal
+                oae.api.widget.insertWidget('termsandconditions', null, null, true);
+           }
         };
 
         /**
@@ -322,7 +337,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
         var bindEditProfileEmailPanelListeners = function() {
             // When "Done" is clicked, close the modal
             $rootel.on('click', '#editprofile-panel-email-container .modal-footer button.btn-primary', function() {
-                $('#editprofile-modal', $rootel).modal('hide');
+                closeModal();
             });
 
             // When the user chooses to go back, re-render and enable the main panel

--- a/node_modules/oae-core/termsandconditions/js/termsandconditions.js
+++ b/node_modules/oae-core/termsandconditions/js/termsandconditions.js
@@ -21,6 +21,27 @@ define(['jquery', 'oae.core'], function($, oae) {
         var $rootel = $('#' + uid);
 
         /**
+         * Accept the invitation in the URL state, if any
+         */
+        var acceptInvitation = function() {
+            var invitationToken = oae.api.util.url().param('invitationToken');
+            if (!invitationToken) {
+                // Do not continue if there is no invitation info
+                return;
+            }
+
+            // Accept the invitation
+            oae.api.user.acceptInvitation(invitationToken, function(err, result) {
+                if (err && err.code !== 404) {
+                    oae.api.util.notification(
+                        oae.api.i18n.translate('__MSG__EMAIL_INVITATION_FAILED__'),
+                        oae.api.i18n.translate('__MSG__AN_ERROR_OCCURRED_WHILE_ACCEPTING_YOUR_INVITATION__'),
+                        'error');
+                }
+            });
+        };
+
+        /**
          * Fetch the Terms and Conditions and render the parsed markdown into the widget.
          */
         var renderTermsAndConditions = function() {
@@ -47,6 +68,10 @@ define(['jquery', 'oae.core'], function($, oae) {
                     $('#termsandconditions-modal', $rootel).modal('unlock');
                     // Hide the modal when the Terms and Conditions have been accepted
                     $('#termsandconditions-modal', $rootel).modal('hide');
+
+                    // Accept any resource invitations that we have delayed to
+                    // show the T&C
+                    acceptInvitation();
                 } else {
                     oae.api.util.notification(
                         oae.api.i18n.translate('__MSG__TERMS_AND_CONDITIONS_NOT_ACCEPTED__', 'termsandconditions'),

--- a/shared/oae/api/oae.api.js
+++ b/shared/oae/api/oae.api.js
@@ -185,8 +185,9 @@ define(['underscore', 'oae.api.admin', 'oae.api.authentication', 'oae.api.config
                 return;
             }
 
-            // Perform any invitation accepting if instructed
-            acceptInvitation(function(resources) {
+            // Perform any invitation accepting if instructed and if possible
+            acceptInvitation(function() {
+
                 // Perform any email verification if instructed before we try and determine if the
                 // user's profile info is valid
                 verifyEmail(function() {
@@ -209,11 +210,14 @@ define(['underscore', 'oae.api.admin', 'oae.api.authentication', 'oae.api.config
          * Accept the invitation if the query string indicates there is an invitation to be accepted
          *
          * @param  {Function}       callback            Invoked when the accept invitation request is complete
-         * @param  {Resource[]}     callback.resources  Indicates the resources that were accepted. If the request failed, this will be unspecified
          */
         var acceptInvitation = function(callback) {
             var invitationToken = oae.api.util.url().param('invitationToken');
             if (!invitationToken) {
+                return callback();
+            } else if (oae.data.me.needsToAcceptTC) {
+                // Do not attempt to accept an invitation when we still need to
+                // accept the T&C
                 return callback();
             }
 
@@ -233,11 +237,7 @@ define(['underscore', 'oae.api.admin', 'oae.api.authentication', 'oae.api.config
                         return callback();
                     }
 
-                    // Accepting an invitation will set a verified email if there wasn't one already,
-                    // so do that here to avoid giving the user a pop-up
-                    oae.data.me.email = oae.data.me.email || result.email;
-
-                    return callback(result.resources);
+                    return callback();
                 });
             });
         };

--- a/shared/oae/api/oae.api.user.js
+++ b/shared/oae/api/oae.api.user.js
@@ -259,6 +259,10 @@ define(['exports', 'jquery', 'underscore', 'oae.api.config'], function(exports, 
                 'token': token
             },
             'success': function(data) {
+                // Accepting an invitation will set a verified email if there wasn't one already,
+                // so do that here to avoid giving the user a pop-up
+                require('oae.core').data.me.email = require('oae.core').data.me.email || data.email;
+
                 callback(null, data);
             },
             'error': function(jqXHR, textStatus) {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/102265/10089085/d6f1b770-62ed-11e5-9e3e-ea86c85c6aa0.png)

I think the POST to accept invitations triggers a T&C modal while the email modal is showing.

Additionally, I'm not sure if the accept invitation request is going to work anyway with external login when T&C is needed as T&C needs to be accepted before the invitation.