### PR TITLE
Cannot confirm email unless you are already signed in

### DIFF
--- a/shared/oae/api/oae.api.js
+++ b/shared/oae/api/oae.api.js
@@ -180,18 +180,16 @@ define(['underscore', 'oae.api.admin', 'oae.api.authentication', 'oae.api.config
                 return;
             }
 
-            // Perform any invitation accepting if instructed and if possible
-            acceptInvitation(function() {
+            // Perform any email verification if instructed before we try and determine if the
+            // user's profile info is valid
+            verifyEmail(function() {
+                // No other pre-use actions are applicable to anonymous users
+                if (oae.data.me.anon) {
+                    return;
+                }
 
-                // Perform any email verification if instructed before we try and determine if the
-                // user's profile info is valid
-                verifyEmail(function() {
-                    // Do not make an anonymous user clean up their profile or
-                    // accept T&C
-                    if (oae.data.me.anon) {
-                        return;
-                    }
-
+                // Perform any invitation accepting if instructed and if possible
+                acceptInvitation(function() {
                     var needsToProvideDisplayName = !oae.api.util.validation().isValidDisplayName(oae.data.me.displayName);
                     var needsToProvideEmail = !oae.data.me.email;
 
@@ -213,12 +211,6 @@ define(['underscore', 'oae.api.admin', 'oae.api.authentication', 'oae.api.config
          * @param  {Function}       callback            Invoked when the accept invitation request is complete
          */
         var acceptInvitation = function(callback) {
-            // We cannot accept an invitation as the anonymous user. Let the
-            // signup page handle it
-            if (oae.data.me.anon) {
-                return callback();
-            }
-
             var invitationToken = oae.api.util.url().param('invitationToken');
             if (!invitationToken) {
                 return callback();


### PR DESCRIPTION
When the user is not already signed in to the OAE and they click on the "Verify my email" button in the email verification email, they are not presented the signin option when they arrive at the OAE, and there is no longer any redirect url to accept the verification.

Previously, redirecting to `/me` would cause a redirect to `/` with a `?url=` parameter for redirect. We should try and do something similar on the `/` page, however it will be a bit trickier because we need to reliably determine when to redirect. If we just send directly to `/?url=...`, then that might not have the desired effect when the user is already signed in.