### PR TITLE
Show email address field if invitation email domain is not valid for the current tenant

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -742,6 +742,45 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
         };
 
         /**
+         * Check whether the domain of the given email matches the current
+         * tenant. If this results in `true`, it means one of the following:
+         *
+         *  * The current tenant has no email domain configured for it
+         *  * The domain of the given email address is equal to or is a sub-
+         *    domain of the current tenant's configured email domain
+         *
+         * This does not validate that the given string is a valid email
+         * address, that should first be done with `isValidEmail`
+         *
+         * @param  {String}     email   The email to check
+         * @return {Boolean}            `true` when the current tenant has an email domain of which the given email address is a sub-domain
+         */
+        var isValidEmailDomainForTenant = function(email) {
+            // If the tenant has not been configured with an email domain, any email address
+            // can be used to sign up
+            var configuredEmailDomain = require('oae.core').data.me.tenant.emailDomain;
+            if (!configuredEmailDomain) {
+                return true;
+            }
+
+            configuredEmailDomain = configuredEmailDomain.toLowerCase();
+
+            // If the email domain is an exact match, it's a success
+            var givenEmailDomain = email.split('@').pop().toLowerCase();
+            if (givenEmailDomain === configuredEmailDomain) {
+                return true;
+            }
+
+            var emailDomainSuffix = '.' + configuredEmailDomain;
+            var suffixPosition = givenEmailDomain.indexOf(emailDomainSuffix);
+            var suffixMatch = (suffixPosition > 0 && suffixPosition === (givenEmailDomain.length - emailDomainSuffix.length));
+
+            // If the configured email domain is a suffix of the email domain,
+            // it's a success
+            return suffixMatch;
+        };
+
+        /**
          * Check whether a provided string is a valid host
          *
          * @param  {String}             host        The host to check
@@ -762,6 +801,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
             'init': init,
             'isValidDisplayName': isValidDisplayName,
             'isValidEmail': isValidEmail,
+            'isValidEmailDomainForTenant': isValidEmailDomainForTenant,
             'isValidHost': isValidHost,
             'validate': validate
         };

--- a/ui/signup.html
+++ b/ui/signup.html
@@ -84,8 +84,8 @@
                         <div id="signup-options-local">
                             <h4>__MSG__CREATE_A_NEW_ACCOUNT_COLON__</h4>
                             <form id="signup-createaccount-form" class="form-horizontal" role="form">
-                                {if invitationInfo.email}
-                                    <input type="hidden" id="signup-createaccount-email" name="email" class="form-control required email maxlength-short" value="${invitationInfo.email|encodeForHTMLAttribute}" />
+                                {if useEmail}
+                                    <input type="hidden" id="signup-createaccount-email" name="email" class="form-control required email maxlength-short" value="${useEmail|encodeForHTMLAttribute}" />
                                 {/if}
                                 {if invitationInfo.token}
                                     <input type="hidden" id="signup-createaccount-invitationtoken" name="invitationToken" class="form-control" value="${invitationInfo.invitationToken|encodeForHTMLAttribute}" />
@@ -103,7 +103,7 @@
                                         <input type="text" id="signup-createaccount-lastname" name="lastName" class="form-control required maxlength-short" placeholder="__MSG__YOUR_LAST_NAME__" />
                                     </div>
                                 </div>
-                                {if !invitationInfo.email}
+                                {if !useEmail}
                                     <div class="form-group">
                                         <label class="col-md-4 control-label" for="signup-createaccount-email">__MSG__EMAIL_COLON__</label>
                                         <div class="col-md-8">


### PR DESCRIPTION
Now that WAYF is merged, it is possible to transfer your invitation from the network tenant to another, and accept it there.

This also means that a user may want to accept an invitation from the gmail account, which takes them to the network tenant, then head over to their unadopted umichigan tenant to create an account with email address umich.edu. However since the invitation has a gmail.com email address, the email address field on the signup form is not present.