### PR TITLE
Deleted resource not redirecting user away

### DIFF
--- a/node_modules/oae-core/deletefolder/js/deletefolder.js
+++ b/node_modules/oae-core/deletefolder/js/deletefolder.js
@@ -78,7 +78,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
             oae.api.util.notification(
                 oae.api.i18n.translate('__MSG__FOLDER_DELETED__', 'deletefolder'),
                 oae.api.i18n.translate('__MSG__FOLDER_DELETE_SUCCESS__', 'deletefolder'));
-            setTimeout(oae.api.util.redirect().me, 2000);
+            setTimeout(oae.api.util.redirect().home, 2000);
         };
 
         /**

--- a/node_modules/oae-core/deleteresource/js/deleteresource.js
+++ b/node_modules/oae-core/deleteresource/js/deleteresource.js
@@ -57,7 +57,7 @@ define(['jquery', 'oae.core'], function ($, oae) {
                 // back to the me page after 2 seconds
                 if (!err) {
                     $('#deleteresource-modal', $rootel).modal('hide');
-                    setTimeout(oae.api.util.redirect().me, 2000);
+                    setTimeout(oae.api.util.redirect().home, 2000);
                 }
 
                 // Enable the delete button


### PR DESCRIPTION
Report:

> Today I created a document, pasted in some text, disliked the formatting and so clicked the Delete button. I got the message saying the document had been deleted, but it remained on screen and I could continue to work with the text; I got error messages if I tried to share or delete it (again). When I clicked away and tried to come back it had gone.

I can't remember if we ever did redirect them away. Where would we send them? Should the back-end provide some feedback to determine which group (if any) to redirect the user to? Should we always redirect them to their activity page?