### PR TITLE
Tile margin issue

### DIFF
--- a/node_modules/oae-core/activity/css/activity.css
+++ b/node_modules/oae-core/activity/css/activity.css
@@ -84,11 +84,6 @@
     height: 225px;
 }
 
-/* Re-position the standard resourceType icon because of the changed tile height */
-.activity-widget .activity-preview-container ul.oae-list > li .oae-thumbnail.oae-thumbnail-large:before {
-    margin-top: -43px;
-}
-
 .activity-widget .activity-show-all-toggle-container {
     margin-bottom: -15px;
     margin-top: 20px;

--- a/shared/oae/css/oae.components.css
+++ b/shared/oae/css/oae.components.css
@@ -1071,8 +1071,8 @@ div.oae-thumbnail i.fa {
 }
 
 .oae-tile .oae-thumbnail.oae-thumbnail-large:before {
-    margin-top: -48px;
-    padding-top: 80px;
+    margin-top: 0;
+    padding-top: 32px;
 }
 
 .oae-tile .oae-thumbnail img {


### PR DESCRIPTION
Reported by @D7Torres:

As you can see, the padding of the icon of the tile is overflowing the tile, because the margin is negative. My problem was, if you try to click in the button you could click the tile instead. You could even click a tile of the first road and actually being clicking the tile below, in the second row.

They only thing I had to do to solve it was changing this styles in `oae.components.css`

```
.oae-tile .oae-thumbnail.oae-thumbnail-large:before {
    margin-top: -48px;
    padding-top: 80px;
}
```

to 

```
.oae-tile .oae-thumbnail.oae-thumbnail-large:before {
    margin-top: -0px;
    padding-top: 32px;
 }
```

![image1](https://cloud.githubusercontent.com/assets/109850/15037484/7b47339c-1250-11e6-8296-e29e51ebb77a.png)
![image2](https://cloud.githubusercontent.com/assets/109850/15037487/7d0d5a3a-1250-11e6-95b0-4fe19313058f.png)
