### PR TITLE
Group description (About) and discussion description should both support markdown

### DIFF
--- a/node_modules/oae-core/discussion/js/discussion.js
+++ b/node_modules/oae-core/discussion/js/discussion.js
@@ -24,7 +24,7 @@ define(['jquery', 'oae.core'], function($, oae) {
          * Render the discussion topic
          */
         var renderDiscussionTopic = function(topic) {
-            $('#discussion-topic', $rootel).html(oae.api.util.security().encodeForHTMLWithLinks(topic));
+            $('#discussion-topic', $rootel).html(oae.api.util.security().encodeMarkdownForHTMLWithLinks(topic));
             $('#discussion-topic-container', $rootel).show();
         };
 

--- a/node_modules/oae-core/groupprofile/groupprofile.html
+++ b/node_modules/oae-core/groupprofile/groupprofile.html
@@ -13,7 +13,7 @@
 
 <div id="groupprofile-description-template"><!--
     {if contextProfile.description}
-        <div class="groupprofile-description">${oae.api.util.security().encodeForHTMLWithLinks(contextProfile.description)}</div>
+        <div class="groupprofile-description">${oae.api.util.security().encodeMarkdownForHTMLWithLinks(contextProfile.description)}</div>
     {elseif contextProfile.isManager}
         <div class="groupprofile-description-empty">
             <button class="btn btn-link group-trigger-editgroup" data-editgroup-focus="#editgroup-description">

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -1656,12 +1656,16 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
                 return '';
             } else {
 
+                // Escape asterisks instead of treating them as italics markers
+                input = input.replace(/\*/g, "\\*").replace(/\\\\/g, "\\");
+
                 // Convert the Markdown input string to HTML using marked.js. `gfm`
                 // automatically recognizes text beginning with http: or https: as a URL
                 // and converts it to a link. We also specify that the input should be sanitized.
                 // @see https://github.com/chjj/marked
                 input = markdown(input.toString(), {
                     'gfm': true,
+                    'tables': true,
                     'breaks': true,
                     'sanitize': true
                 });

--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -903,24 +903,23 @@ ul.as-list li.as-result-item.active {
  */
 
 .oae-markdown-embedded table {
-    margin: 20px 0;
     border-bottom: 1px solid #ECECEC;
-    color: #333;
     font-size: 14px;
+    margin: 20px 0;
 }
 
 .oae-markdown-embedded table th {
-    background-color: #FFF;
-    border-top: 1px solid #ECECEC;
+    background-color: transparent;
     border-bottom: 1px solid #999;
-    padding: 10px 0;
+    border-top: 1px solid #ECECEC;
     font-weight: bolder;
+    padding: 10px 0;
 }
 
 .oae-markdown-embedded table td {
-    padding: 5px 20px 6px 0;
     font-weight: normal;
     height: 22px;
+    padding: 6px 20px 6px 0;
 }
 
 .oae-markdown-embedded table tr:nth-child(odd) {

--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -909,11 +909,11 @@ ul.as-list li.as-result-item.active {
 }
 
 .oae-markdown-embedded table th {
-    background-color: transparent;
+    background-color: #FFF;
     border-bottom: 1px solid #999;
     border-top: 1px solid #ECECEC;
     font-weight: bolder;
-    padding: 10px 0;
+    padding: 10px;
 }
 
 .oae-markdown-embedded table td {
@@ -922,6 +922,6 @@ ul.as-list li.as-result-item.active {
     padding: 6px 20px 6px 0;
 }
 
-.oae-markdown-embedded table tr:nth-child(odd) {
+.oae-markdown-embedded table tr:nth-child(even) {
     background-color: #ECECEC;
 }

--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -904,7 +904,6 @@ ul.as-list li.as-result-item.active {
 
 .oae-markdown-embedded table {
     border-bottom: 1px solid #ECECEC;
-    font-size: 14px;
     margin: 20px 0;
 }
 
@@ -912,16 +911,20 @@ ul.as-list li.as-result-item.active {
     background-color: #FFF;
     border-bottom: 1px solid #999;
     border-top: 1px solid #ECECEC;
-    font-weight: bolder;
+    font-weight: 500;
     padding: 10px;
 }
 
 .oae-markdown-embedded table td {
     font-weight: normal;
     height: 22px;
-    padding: 6px 20px 6px 0;
+    padding: 6px 10px;
 }
 
 .oae-markdown-embedded table tr:nth-child(even) {
     background-color: #ECECEC;
+}
+
+.oae-markdown-embedded table tr:nth-child(odd) {
+    background-color: #FFF;
 }

--- a/shared/oae/css/oae.base.css
+++ b/shared/oae/css/oae.base.css
@@ -897,3 +897,32 @@ ul.as-list li.as-result-item.active {
 .oae-markdown-embedded p:first-child {
     margin-top: 0;
 }
+
+/**
+ * Markdown table styles
+ */
+
+.oae-markdown-embedded table {
+    margin: 20px 0;
+    border-bottom: 1px solid #ECECEC;
+    color: #333;
+    font-size: 14px;
+}
+
+.oae-markdown-embedded table th {
+    background-color: #FFF;
+    border-top: 1px solid #ECECEC;
+    border-bottom: 1px solid #999;
+    padding: 10px 0;
+    font-weight: bolder;
+}
+
+.oae-markdown-embedded table td {
+    padding: 5px 20px 6px 0;
+    font-weight: normal;
+    height: 22px;
+}
+
+.oae-markdown-embedded table tr:nth-child(odd) {
+    background-color: #ECECEC;
+}


### PR DESCRIPTION
We currently render markdown in comments (I think it's client-side), we should add that handling in these areas as well to make it more consistent.