### PR TITLE
Markdown tables should use alternative CSS in description

### DIFF
--- a/node_modules/oae-core/discussion/css/discussion.css
+++ b/node_modules/oae-core/discussion/css/discussion.css
@@ -17,3 +17,30 @@
     margin: 20px 0;
     white-space: pre-wrap;
 }
+
+#discussion-topic table {
+    border-bottom: 1px solid #999;
+    margin: 20px 0;
+}
+
+#discussion-topic table th {
+    background-color: #FFF;
+    border-bottom: 1px solid #999;
+    border-top: 1px solid #999;
+    font-weight: 500;
+    padding: 10px;
+}
+
+#discussion-topic table td {
+    font-weight: normal;
+    height: 22px;
+    padding: 6px 10px;
+}
+
+#discussion-topic table tr:nth-child(even) {
+    background-color: #FFF;
+}
+
+#discussion-topic table tr:nth-child(odd) {
+    background-color: #ECECEC;
+}

--- a/node_modules/oae-core/discussion/css/discussion.css
+++ b/node_modules/oae-core/discussion/css/discussion.css
@@ -44,3 +44,7 @@
 #discussion-topic table tr:nth-child(odd) {
     background-color: #ECECEC;
 }
+
+#discussion-topic ul {
+    white-space: normal;
+}

--- a/node_modules/oae-core/groupprofile/css/groupprofile.css
+++ b/node_modules/oae-core/groupprofile/css/groupprofile.css
@@ -51,3 +51,30 @@
 .groupprofile-widget .groupprofile-members div.oae-thumbnail div {
     border-radius: 0;
 }
+
+.groupprofile-description table {
+    border-bottom: 1px solid #ECECEC;
+    margin: 20px 0;
+}
+
+.groupprofile-description table th {
+    background-color: #FFF;
+    border-bottom: 1px solid #999;
+    border-top: 1px solid #ECECEC;
+    font-weight: 500;
+    padding: 10px;
+}
+
+.groupprofile-description table td {
+    font-weight: normal;
+    height: 22px;
+    padding: 6px 10px;
+}
+
+.groupprofile-description table tr:nth-child(even) {
+    background-color: #ECECEC;
+}
+
+.groupprofile-description table tr:nth-child(odd) {
+    background-color: #FFF;
+}


### PR DESCRIPTION
From bugbash: tables in comments display very different than in description. @SamPeck supplied alternative values for the main container (see below).

![tablecontentcontaineralt-v01_960](https://cloud.githubusercontent.com/assets/5364212/15863379/aa5d9b32-2cca-11e6-8388-8405dc6a5327.png)
