### PR TITLE
Omitting * from markdown

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -1657,7 +1657,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
             } else {
 
                 // Escape asterisks instead of treating them as italics markers
-                input = input.replace(/(\*)(?=[RU])/g, "\\*").replace(/(?:\s)(\*)(?=\s)/g, " \\*").replace(/\\\\/g, "\\");
+                input = input.replace(/(\*)(?=Research|Unity)/g, "\\*").replace(/(?:\s)(\*)(?=\s)/g, " \\*").replace(/\\\\/g, "\\");
 
                 // Convert the Markdown input string to HTML using marked.js. `gfm`
                 // automatically recognizes text beginning with http: or https: as a URL

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -1655,9 +1655,29 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
             if (!input) {
                 return '';
             } else {
-
+                var nonWord = /\W/;
                 // Escape asterisks instead of treating them as italics markers
-                input = input.replace(/(\*)(?=Research|Unity)/g, "\\*").replace(/(?:\s)(\*)(?=\s)/g, " \\*").replace(/\\\\/g, "\\");
+                input = input.replace(/\*/g, function(match, index) {
+                    var prevChar = input.charAt(index - 1);
+
+                    // Is this an asterisk used at the start of a line to indicate a bulleted list?
+                    if (prevChar.match(/./)) {
+                        var nextPosition = input.indexOf('*', index + 1);
+
+                        // Is this the starting asterisk followed by a letter and accompanied by a closing asterisk?
+                        if (nextPosition === -1 || input.charAt(index + 1).match(nonWord) || input.charAt(nextPosition - 1).match(nonWord) ) {
+                            var previousPosition = input.lastIndexOf('*', index - 1);
+
+                            // Is this the closing asterisk preceded by a letter and accompanied by a starting asterisk?
+                            if (previousPosition === -1 || prevChar.match(nonWord) || input.charAt(previousPosition + 1).match(nonWord) ) {
+                                // If not, escape it
+                                return '\\' + match;
+                            }
+                        }
+                    }
+
+                    return match;
+                }).replace(/\\{2,}/g, '\\');
 
                 // Convert the Markdown input string to HTML using marked.js. `gfm`
                 // automatically recognizes text beginning with http: or https: as a URL

--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -1657,7 +1657,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
             } else {
 
                 // Escape asterisks instead of treating them as italics markers
-                input = input.replace(/\*/g, "\\*").replace(/\\\\/g, "\\");
+                input = input.replace(/(\*)(?=[RU])/g, "\\*").replace(/(?:\s)(\*)(?=\s)/g, " \\*").replace(/\\\\/g, "\\");
 
                 // Convert the Markdown input string to HTML using marked.js. `gfm`
                 // automatically recognizes text beginning with http: or https: as a URL


### PR DESCRIPTION
I know this was a conscious decision, here's a bit of discussion in slack about the change during the bug bash:

```

mrvisser [10:35 AM] 
no it’s a good question, I posted above about it, what do you think?

[10:35] 
> Should we support an `*` followed by a space to be a bulleted list still?
> I personally use bulleted list a lot when I’m markdowning
> and it doesn’t affect *Research

cnicoletti [10:35 AM] 
I am one who doesnt use markdown often, but that is like THE one I use

mrvisser [10:35 AM] 
the bulleted list?

cnicoletti [10:36 AM] 
Ahh, I see now, yes, I would say so

mrvisser [10:36 AM] 
or the emphasis? or both?

cnicoletti [10:36 AM] 
both

[10:36] 
but definitely for bulleting

[10:36] 
but I see how I can just use - lists

mrvisser [10:37 AM] 
I didn’t know that
```

`*` I think is a pretty important character to have. Is there a less intrusive way we can have an exception for `*Research`?

At the least, maybe a little legend at the bottom of textareas that support markdown. For example, I've seen a simple list of supported syntax on a single line at the bottom of a text area like:

`*bold*, _italic_, * bulleted list, -strikethrough-`
