### PR TITLE
Use `window.location.replace` to eliminate need to manipulate history

### DIFF
--- a/shared/oae/api/oae.api.util.js
+++ b/shared/oae/api/oae.api.util.js
@@ -1773,8 +1773,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
          * the user can be redirected here when signing in.
          */
         var accessdenied = function() {
-            window.history.replaceState(null, null, document.referrer);
-            window.location = '/accessdenied?url=' + url().attr('path');
+            window.location.replace('/accessdenied?url=' + url().attr('path'));
         };
 
         /**
@@ -1782,8 +1781,7 @@ define(['exports', 'require', 'jquery', 'underscore', 'oae.api.config', 'markdow
          * that cannot be found.
          */
         var notfound = function() {
-            window.history.replaceState(null, null, document.referrer);
-            window.location = '/notfound';
+            window.location.replace('/notfound');
         };
 
         /**

--- a/shared/oae/errors/js/accessdenied.js
+++ b/shared/oae/errors/js/accessdenied.js
@@ -20,7 +20,7 @@ require(['jquery','oae.core'], function($, oae) {
 
     // Set up the back button
     $('#error-back-btn').click(function(){
-        parent.history.go(-2);
+        parent.history.go(-1);
         return false;
     });
 

--- a/shared/oae/errors/js/notfound.js
+++ b/shared/oae/errors/js/notfound.js
@@ -20,7 +20,7 @@ require(['jquery','oae.core'], function($, oae) {
 
     // Set up the back button
     $('#error-back-btn').click(function(){
-        parent.history.go(-2);
+        parent.history.go(-1);
         return false;
     });
 });


### PR DESCRIPTION
This fixes #4142.

EDIT: To clarify, it stops the browser back button from taking you to etherpad. The back button on the page itself will still do nothing (although I'm not sure if that's a problem - it's a new tab so there's no history for it to take you to).